### PR TITLE
fix(KAN-8): reconstruir sync PostgreSQL y gobierno tras cierre de PR #12

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+## Ticket Jira
+
+- KAN-__
+
+> Obligatorio. Todo PR debe referenciar al menos un ticket Jira `KAN-##` en titulo, rama o descripcion.
+
 ## Resumen
 
 Describe claramente que cambia y por que.
@@ -17,14 +23,21 @@ Modulos o rutas impactadas:
 
 - 
 
+## Base de datos
+
+- [ ] No aplica
+- [ ] Usa PostgreSQL canonico (`prisma/postgresql/schema.prisma`)
+- [ ] Incluye migracion PostgreSQL en `prisma/postgresql/migrations`
+- [ ] Verifique impacto de datos y rollback
+
 ## Checklist de calidad
 
 - [ ] Ejecute npm run lint
-- [ ] Ejecute npx tsc --noEmit
+- [ ] Ejecute npm run typecheck
 - [ ] Ejecute npm run build
-- [ ] Ejecute npx prisma validate
-- [ ] Revise impactos en migraciones o datos (si aplica)
-- [ ] Actualice documentacion (si aplica)
+- [ ] Ejecute npm run prisma:validate
+- [ ] Ejecute npm run test
+- [ ] Actualice documentacion afectada
 
 ## Evidencia de validacion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,41 +7,56 @@ Este repositorio usa un flujo basado en ramas cortas, Pull Request obligatoria y
 - Mantener main siempre desplegable.
 - Reducir ruido de historial con un commit por PR en main.
 - Estandarizar la limpieza manual de ramas sin perder trabajo activo.
+- Mantener trazabilidad obligatoria entre Jira, GitHub y cambios productivos.
+
+## Base tecnica obligatoria
+
+PostgreSQL es la base de datos canonica del proyecto.
+
+- Schema canonico: `prisma/postgresql/schema.prisma`.
+- Migraciones canonicas: `prisma/postgresql/migrations`.
+- Todo comando operativo debe usar `DATABASE_URL` PostgreSQL.
+- SQLite queda como legado/offline y no debe usarse como runtime, pruebas integradas ni fuente de verdad.
 
 ## Ramas
 
 - main: rama estable.
 - develop: integracion continua opcional.
-- feature/[ticket]-descripcion: trabajo funcional.
-- hotfix/[descripcion]: correcciones urgentes.
-- docs/[descripcion]: cambios de documentacion.
+- feature/KAN-##-descripcion: trabajo funcional.
+- fix/KAN-##-descripcion: correccion o estabilizacion.
+- hotfix/KAN-##-descripcion: correcciones urgentes.
+- docs/KAN-##-descripcion: cambios de documentacion.
 
 ## Politica para Pull Request a main
 
 1. Crear rama desde main actualizada.
-2. Implementar cambios y mantener commits pequenos y claros en la rama.
-3. Verificar localmente antes de abrir PR:
+2. Usar ticket Jira obligatorio en la rama, titulo o descripcion (`KAN-##`).
+3. Implementar cambios y mantener commits pequenos y claros en la rama.
+4. Verificar localmente antes de abrir PR:
    - npm run lint
-   - npx tsc --noEmit
+   - npm run typecheck
    - npm run build
-   - npx prisma validate
-4. Abrir PR hacia main usando la plantilla oficial.
-5. Esperar checks de CI en verde (Code Quality Checks y Security Audit).
-6. Resolver comentarios de revision cuando aplique.
-7. Hacer merge unicamente con Squash merge.
-8. Confirmar eliminacion automatica de la rama remota despues del merge.
+   - npm run prisma:validate
+   - npm run test
+5. Confirmar que `DATABASE_URL` apunta a PostgreSQL.
+6. Abrir PR hacia main usando la plantilla oficial.
+7. Esperar checks de CI en verde (Code Quality Checks y Security Audit).
+8. Resolver comentarios de revision cuando aplique.
+9. Hacer merge unicamente con Squash merge.
+10. Confirmar eliminacion automatica de la rama remota despues del merge.
+11. Actualizar el ticket Jira relacionado con evidencia, PR y estado real.
 
 ## Convencion de titulos
 
-Se recomienda este formato para mejorar el mensaje de squash commit:
+Formato recomendado:
 
-- tipo(scope): resumen corto
+- tipo(KAN-##): resumen corto
 
 Ejemplos:
 
-- feat(inventory): agregar ajuste por lote
-- fix(catalog): corregir filtro por referencia
-- docs(runbook): actualizar pasos de recuperacion
+- feat(KAN-48): integrar clientes formales en pedidos
+- fix(KAN-29): consolidar PostgreSQL como runtime canonico
+- docs(KAN-8): sincronizar estado real WMS
 
 ## Reglas de proteccion recomendadas para main
 
@@ -64,10 +79,11 @@ Configurar en GitHub Branch Protection:
 
 1. git checkout main
 2. git pull
-3. git checkout -b feature/123-ajuste-kardex
+3. git checkout -b feature/KAN-48-clientes-pedidos
 4. Desarrollar y validar quality gates.
 5. Abrir PR a main.
 6. Merge por squash.
+7. Actualizar Jira con evidencia.
 
 ### Hotfix
 
@@ -76,12 +92,14 @@ Configurar en GitHub Branch Protection:
 3. Abrir PR con etiqueta hotfix.
 4. Merge por squash.
 5. Si se usa develop, sincronizar el cambio tambien hacia develop.
+6. Actualizar Jira con causa, impacto y rollback.
 
 ### Documentacion
 
-1. Usar docs/[descripcion].
+1. Usar docs/KAN-##-descripcion.
 2. Actualizar docs afectadas en el mismo PR del cambio funcional o en PR dedicado.
 3. Merge por squash.
+4. Actualizar Jira si la documentacion cierra deuda o cambia criterios operativos.
 
 ## Limpieza manual de ramas
 
@@ -95,3 +113,5 @@ La limpieza de ramas stale es manual. Procedimiento detallado:
 - Rebasar o actualizar la rama frecuentemente con main para reducir conflictos.
 - No mezclar refactors amplios con cambios funcionales no relacionados.
 - Incluir contexto de impacto tecnico y operativo en la descripcion del PR.
+- No abrir PR sin ticket Jira.
+- No introducir comandos nuevos que usen SQLite como default operativo.

--- a/docs/WMS_CAPABILITIES_STATUS.md
+++ b/docs/WMS_CAPABILITIES_STATUS.md
@@ -1,40 +1,77 @@
 # WMS Capabilities Status
 
-Fecha de corte: 2026-02-12
+Fecha de corte: 2026-04-28
+
+## Decision base
+
+PostgreSQL es la base de datos canonica y unica para runtime, pruebas integradas, migraciones y generacion de Prisma Client.
+
+- Schema canonico: `prisma/postgresql/schema.prisma`.
+- Migraciones canonicas: `prisma/postgresql/migrations`.
+- `DATABASE_URL` debe iniciar con `postgres://` o `postgresql://`.
+- SQLite queda como legado historico/offline y no debe usarse como fuente de verdad operativa.
 
 ## Implementado en codigo
 
-- Catalogo maestro de productos y categorias.
-- Almacenes y ubicaciones (creacion y detalle por almacen).
-- Inventario por ubicacion con campos `quantity`, `reserved` y `available`.
-- Recepcion (`IN`) con referencia documental y adjuntos.
-- Picking (`OUT`) validando inventario disponible.
-- Ajustes de inventario en servicio (`ADJUSTMENT`) por API interna.
-- Ordenes de produccion con reserva y consumo de inventario por estado.
-- Pruebas de integridad para `InventoryService`.
+- Catalogo maestro de productos, categorias, subcategorias, unidades y marcas por proveedor.
+- Proveedores con razon social, nombre comercial, marcas y relacion producto-proveedor.
+- Almacenes y ubicaciones por zona/bin/rack con tipos de uso.
+- Inventario por ubicacion con `quantity`, `reserved` y `available`.
+- Movimientos de inventario `IN`, `OUT`, `TRANSFER` y `ADJUSTMENT`.
+- Recepcion con referencia documental y adjuntos.
+- Picking validando inventario disponible.
+- Ajustes de inventario y transferencias internas.
+- Kardex por SKU/ubicacion con filtros.
+- Ordenes de produccion y ensamble 3 piezas con reservas, picklists, WIP y consumo.
+- Solicitudes/pedidos internos de venta con lineas de producto y ensamble configurado.
+- Picklists y tareas de picking para pedidos internos.
+- Compras: proveedores, ordenes de compra, lineas, recibos y lineas de recibo.
+- Auth/RBAC base: `User`, `Role`, `Permission`, `UserRole`, `RolePermission`.
+- Auditoria transversal base con `AuditLog`.
+- Trazabilidad, etiquetas, plantillas y trabajos de impresion.
+- Sync/outbox con `SyncEvent`.
+- Runtime AWS/local con PostgreSQL y scripts de despliegue AWS.
 
-## Implementado en esta iteracion (KAN)
+## Reconciliacion Jira vs repo
 
-- `KAN-10`: alta de producto no crea inventario invalido sin ubicacion.
-- `KAN-9`: validaciones server-side con Zod en `receive`, `pick` y `orders`.
-- `KAN-26`: bitacora de auditoria (`AuditLog`) para acciones criticas.
-- `KAN-11`: UI de ajustes de inventario (`/inventory/adjust`).
-- `KAN-12`: transferencias internas atomicas (`/inventory/transfer` + `transferStock`).
-- `KAN-13`: vista de kardex con filtros (`/inventory/kardex`).
-- `KAN-14`: reconciliacion automatica de reservas en ordenes de produccion.
+### Implementado o parcialmente implementado; requiere actualizar Jira
 
-## Pendiente
+- `KAN-10`: alta de producto sin inventario invalido.
+- `KAN-9`: validaciones server-side con Zod en flujos criticos.
+- `KAN-11`: UI/servicio de ajustes de inventario.
+- `KAN-12`: transferencias internas atomicas.
+- `KAN-13`: vista de kardex.
+- `KAN-14`: politica/reconciliacion de reservas.
+- `KAN-22`: modelo de compras y recibos ya existe en Prisma.
+- `KAN-25`: Auth/RBAC base ya existe; falta validar cobertura UI/operativa.
+- `KAN-26`: `AuditLog` ya existe; falta validar cobertura por accion critica.
+- `KAN-51`: campos de asignacion y entrega ya existen; falta validar flujo UI, permisos y auditoria.
 
-- Flujo completo de solicitudes internas (KAN-15 a KAN-18).
-- Reglas tecnicas de compatibilidad (KAN-19 a KAN-21).
-- Compras/reabasto (KAN-22 a KAN-24).
-- Auth/RBAC y KPI (KAN-25, KAN-27).
-- E2E y migracion productiva (KAN-28, KAN-29).
+### Mantener como prioridad abierta
+
+- `KAN-48`: registro formal de clientes e integracion en pedidos.
+- `KAN-49`: UI de administracion de usuarios para `SYSTEM_ADMIN`.
+- `KAN-50`: dashboard admin/manager centrado en pedidos por surtir.
+- `KAN-52`: UX de flujo de pedidos, `flowStage`, timeline y filtros.
+- `KAN-53`: QA, RBAC y regresion de flujos criticos.
+- `KAN-29`: cerrar migracion productiva PostgreSQL y retirar dependencias operativas SQLite.
+
+## Pendiente tecnico inmediato
+
+- Eliminar dependencias operativas restantes de SQLite en scripts legacy.
+- Confirmar que CI corre con `DATABASE_URL` PostgreSQL en secretos/variables.
+- Actualizar cualquier documentacion que aun mencione SQLite como flujo recomendado.
+- Ejecutar `npm run prisma:validate`, `npm run prisma:generate`, `npm run typecheck`, `npm run test` y `npm run build` con `DATABASE_URL` PostgreSQL.
 
 ## Nota operativa
 
-Para habilitar `AuditLog` en la base local, aplicar migraciones:
+Para trabajo diario y pruebas integradas:
 
 ```bash
+npm run prisma:validate
+npm run prisma:generate
 npm run db:migrate
+npm run test
 ```
+
+Todos los comandos anteriores requieren `DATABASE_URL` PostgreSQL. Si el valor apunta a SQLite, el proceso debe fallar.

--- a/docs/release/2026-04-28-sync-repo-atlassian.md
+++ b/docs/release/2026-04-28-sync-repo-atlassian.md
@@ -1,0 +1,71 @@
+# Reconciliacion Repo GitHub - Atlassian
+
+Fecha: 2026-04-28
+Proyecto Jira: KAN / WMS project
+Repositorio: raul2105/WMS-Mangueras-y-conexiones
+
+## Decision ejecutiva
+
+PostgreSQL queda definido como runtime canonico y unica base operativa del WMS.
+
+SQLite queda degradado a legado historico/offline y no debe usarse como fuente de verdad para desarrollo diario, pruebas integradas, migraciones ni despliegue.
+
+## Cambios aplicados en repo
+
+- `prisma.config.ts` apunta a `prisma/postgresql/schema.prisma` y `prisma/postgresql/migrations`.
+- `scripts/db/validate-prisma-schemas.cjs` valida solo PostgreSQL y falla si `DATABASE_URL` no es PostgreSQL.
+- `scripts/db/generate-default-prisma-client.cjs` genera Prisma Client contra PostgreSQL.
+- `scripts/db/run-vitest-postgresql.cjs` se agrega como runner canonico de pruebas.
+- `package.json` apunta scripts canonicos a PostgreSQL.
+- `.github/pull_request_template.md` exige ticket Jira y verificacion PostgreSQL.
+- `CONTRIBUTING.md` exige trazabilidad Jira y define PostgreSQL como base tecnica obligatoria.
+- `docs/WMS_CAPABILITIES_STATUS.md` queda actualizado con corte 2026-04-28.
+
+## Reconciliacion Jira
+
+### Tickets a marcar como implementado/parcial segun evidencia de repo
+
+- KAN-10: implementado.
+- KAN-9: implementado/parcial segun cobertura real.
+- KAN-11: implementado.
+- KAN-12: implementado.
+- KAN-13: implementado.
+- KAN-14: implementado/parcial.
+- KAN-22: implementado a nivel modelo base.
+- KAN-25: implementado a nivel modelo/RBAC base; falta validar UI y permisos completos.
+- KAN-26: implementado a nivel modelo; falta validar cobertura transversal.
+- KAN-51: parcialmente implementado a nivel schema; falta cierre UI/flujo/auditoria.
+
+### Tickets que siguen abiertos como prioridad
+
+- KAN-48: clientes formales en pedidos.
+- KAN-49: administracion de usuarios para SYSTEM_ADMIN.
+- KAN-50: dashboard operativo admin/manager.
+- KAN-52: UX flowStage, timeline y filtros.
+- KAN-53: QA, RBAC y regresion.
+- KAN-29: migracion productiva PostgreSQL y retiro total de SQLite operativo.
+
+## Quality gates requeridos
+
+Ejecutar con `DATABASE_URL` PostgreSQL:
+
+```bash
+npm run prisma:validate
+npm run prisma:generate
+npm run typecheck
+npm run test
+npm run build
+```
+
+## Riesgos
+
+1. CI puede fallar si no existe `DATABASE_URL` PostgreSQL en secretos/variables.
+2. Scripts legacy pueden seguir invocando SQLite si no se retiran en una segunda limpieza.
+3. Tests que dependian de SQLite pueden requerir fixtures/seed PostgreSQL.
+4. `package-lock.json` podria requerir actualizacion si `package.json` estaba desincronizado antes del PR.
+
+## Siguiente PR recomendado
+
+`feat(KAN-48): integrar clientes formales en pedidos`
+
+No avanzar a KAN-48 hasta que el PR de sincronizacion base este integrado y CI pase con PostgreSQL.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "db:push": "prisma db push --schema prisma/postgresql/schema.prisma --accept-data-loss",
     "db:setup": "npm run db:push && npm run db:seed",
     "db:seed": "prisma db seed",
-    "db:studio": "prisma studio --schema prisma/postgresql/schema.prisma",`r`n    "db:reset": "prisma migrate reset --schema prisma/postgresql/schema.prisma --force",
+    "db:studio": "prisma studio --schema prisma/postgresql/schema.prisma",
+    "db:reset": "prisma migrate reset --schema prisma/postgresql/schema.prisma --force",
     "import:products": "node scripts/data/import-products-from-csv.cjs",
     "link:product-images": "node scripts/data/link-product-images-from-folder.cjs",
     "populate:subcategories": "node scripts/data/populate-product-subcategories.cjs",
@@ -84,4 +85,5 @@
     "vitest": "^3.2.4"
   }
 }
+
 

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "start": "next start -p 3002",
     "lint": "eslint",
     "typecheck": "next typegen && tsc --noEmit",
-    "test": "node scripts/db/run-vitest-sqlite.cjs run",
+    "test": "node scripts/db/run-vitest-postgresql.cjs run",
     "smoke:published": "node scripts/smoke/published-links.cjs",
     "smoke:mobile-auth": "node scripts/smoke/validate-mobile-auth.cjs",
-    "test:rbac": "vitest run tests/rbac",
-    "test:rbac:unit": "vitest run tests/rbac/permissions.test.ts tests/rbac/require-permission.test.ts",
-    "test:rbac:integration": "vitest run tests/rbac/route-access.integration.test.ts tests/rbac/server-actions-guards.integration.test.ts tests/rbac/fixtures.integration.test.ts",
+    "test:rbac": "node scripts/db/run-vitest-postgresql.cjs run tests/rbac",
+    "test:rbac:unit": "node scripts/db/run-vitest-postgresql.cjs run tests/rbac/permissions.test.ts tests/rbac/require-permission.test.ts",
+    "test:rbac:integration": "node scripts/db/run-vitest-postgresql.cjs run tests/rbac/route-access.integration.test.ts tests/rbac/server-actions-guards.integration.test.ts tests/rbac/fixtures.integration.test.ts",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
@@ -29,12 +29,11 @@
     "prisma:generate:aws": "node scripts/db/generate-aws-prisma-client.cjs",
     "verify:release": "npm run prisma:validate && npm run prisma:generate && npm run typecheck && npm run test && npm run build",
     "build:release": "powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\release\\build-release.ps1",
-    "db:migrate": "prisma migrate dev",
-    "db:push": "prisma db push --accept-data-loss",
+    "db:migrate": "prisma migrate dev --schema prisma/postgresql/schema.prisma",
+    "db:push": "prisma db push --schema prisma/postgresql/schema.prisma --accept-data-loss",
     "db:setup": "npm run db:push && npm run db:seed",
     "db:seed": "prisma db seed",
-    "db:studio": "prisma studio",
-    "db:reset": "prisma migrate reset --force",
+    "db:studio": "prisma studio --schema prisma/postgresql/schema.prisma",`r`n    "db:reset": "prisma migrate reset --schema prisma/postgresql/schema.prisma --force",
     "import:products": "node scripts/data/import-products-from-csv.cjs",
     "link:product-images": "node scripts/data/link-product-images-from-folder.cjs",
     "populate:subcategories": "node scripts/data/populate-product-subcategories.cjs",
@@ -85,3 +84,4 @@
     "vitest": "^3.2.4"
   }
 }
+

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from "prisma/config";
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
 
 export default defineConfig({
-  schema: "prisma/schema.prisma",
+  schema: "prisma/postgresql/schema.prisma",
   migrations: {
+    path: "prisma/postgresql/migrations",
     seed: "node prisma/seed.cjs",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
   },
 });

--- a/scripts/db/generate-default-prisma-client.cjs
+++ b/scripts/db/generate-default-prisma-client.cjs
@@ -5,12 +5,18 @@ const path = require("node:path");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const prismaCli = path.join(repoRoot, "node_modules", "prisma", "build", "index.js");
+const databaseUrl = process.env.DATABASE_URL || "postgresql://local:local@127.0.0.1:5432/wms?schema=public";
 
-const result = spawnSync(process.execPath, [prismaCli, "generate", "--schema", "prisma/schema.prisma"], {
+if (!/^postgres(?:ql)?:\/\//i.test(databaseUrl)) {
+  console.error("[prisma] DATABASE_URL debe apuntar a PostgreSQL. SQLite no es un runtime valido para este proyecto.");
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, [prismaCli, "generate", "--schema", "prisma/postgresql/schema.prisma"], {
   cwd: repoRoot,
   env: {
     ...process.env,
-    DATABASE_URL: "file:./dev.db",
+    DATABASE_URL: databaseUrl,
   },
   stdio: "inherit",
 });

--- a/scripts/db/run-vitest-postgresql.cjs
+++ b/scripts/db/run-vitest-postgresql.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const vitestCli = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
+const args = process.argv.slice(2);
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl || !/^postgres(?:ql)?:\/\//i.test(databaseUrl)) {
+  console.error("[test] DATABASE_URL debe apuntar a PostgreSQL. SQLite no es un runtime valido para pruebas del WMS.");
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, [vitestCli, ...args], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+  },
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 0);

--- a/scripts/db/validate-prisma-schemas.cjs
+++ b/scripts/db/validate-prisma-schemas.cjs
@@ -5,37 +5,26 @@ const path = require("node:path");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const prismaCli = path.join(repoRoot, "node_modules", "prisma", "build", "index.js");
+const databaseUrl = process.env.DATABASE_URL || "postgresql://local:local@127.0.0.1:5432/wms?schema=public";
 
-const schemas = [
-  {
-    schema: "prisma/schema.prisma",
-    databaseUrl: "file:./dev.db",
-    label: "sqlite-default",
-  },
-  {
-    schema: "prisma/postgresql/schema.prisma",
-    databaseUrl: "postgresql://local:local@127.0.0.1:5432/wms?schema=public",
-    label: "aws-postgresql",
-  },
-];
-
-for (const { schema, databaseUrl, label } of schemas) {
-  console.log(`[prisma] validating ${label}: ${schema}`);
-  const result = spawnSync(process.execPath, [prismaCli, "validate", "--schema", schema], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      DATABASE_URL: databaseUrl,
-    },
-    stdio: "inherit",
-  });
-
-  if (result.error) {
-    console.error(result.error);
-    process.exit(1);
-  }
-
-  if ((result.status ?? 0) !== 0) {
-    process.exit(result.status ?? 1);
-  }
+if (!/^postgres(?:ql)?:\/\//i.test(databaseUrl)) {
+  console.error("[prisma] DATABASE_URL debe apuntar a PostgreSQL. SQLite no es un runtime valido para este proyecto.");
+  process.exit(1);
 }
+
+console.log("[prisma] validating postgresql-canonical: prisma/postgresql/schema.prisma");
+const result = spawnSync(process.execPath, [prismaCli, "validate", "--schema", "prisma/postgresql/schema.prisma"], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+  },
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Ticket Jira

- KAN-8
- Reemplaza técnicamente al PR cerrado #12: https://github.com/raul2105/WMS-Mangueras-y-conexiones/pull/12

## Resumen

Reconstrucción del alcance original de KAN-8 sobre base actual de `main` usando cherry-pick controlado.
Se mantiene la decisión técnica: PostgreSQL canónico para Prisma/scripts y gobierno de contribución alineado.

## Cambios principales

- Runtime/DB tooling (PostgreSQL canónico):
  - `prisma.config.ts` apuntando a `prisma/postgresql/schema.prisma` y `prisma/postgresql/migrations`.
  - `scripts/db/validate-prisma-schemas.cjs` validando solo PostgreSQL.
  - `scripts/db/generate-default-prisma-client.cjs` contra PostgreSQL.
  - `scripts/db/run-vitest-postgresql.cjs` agregado para pruebas PostgreSQL.
  - `package.json` actualizado para scripts canónicos PostgreSQL.
- Gobierno:
  - `.github/pull_request_template.md` con trazabilidad Jira y checklist DB.
  - `CONTRIBUTING.md` con lineamientos PostgreSQL canónico.
- Estado/documentación:
  - `docs/WMS_CAPABILITIES_STATUS.md` actualizado.
  - `docs/release/2026-04-28-sync-repo-atlassian.md` agregado.

## Validación ejecutada

- ✅ `npm run prisma:validate`
- ✅ `npm run prisma:generate`
- ✅ `npm run typecheck`
- ⚠️ `npm run test` bloqueado por política del runner: requiere `DATABASE_URL` PostgreSQL (falló por variable no configurada)
- ✅ `npm run build` completó correctamente

## Notas

- Este PR evita tocar trabajo en curso de `main`; se trabajó en rama limpia desde `origin/main`.
- Si se habilita `DATABASE_URL` de CI/entorno, debería completarse la validación de tests PostgreSQL.