### PR TITLE
docs(KAN-8): unificar fuente de verdad GitHub Jira

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,22 @@
-## Contexto
+## Ticket Jira
 
-- Ticket Jira: KAN-xx
-- Objetivo de negocio:
-- Problema que resuelve:
+- KAN-____
+
+> Obligatorio. Todo PR debe referenciar al menos un ticket Jira `KAN-##` en rama, titulo y descripcion.
+
+## Resumen
+
+Describe claramente que cambia y por que.
+
+## Tipo de cambio
+
+- [ ] feat
+- [ ] fix
+- [ ] hotfix
+- [ ] docs
+- [ ] test
+- [ ] refactor
+- [ ] chore
 
 ## Alcance
 
@@ -10,16 +24,30 @@
 - Cambios explicitamente fuera de alcance:
 - Modulos/rutas impactadas:
 
+## Base de datos
+
+- [ ] No aplica
+- [ ] Usa PostgreSQL canonico (`prisma/postgresql/schema.prisma`)
+- [ ] Incluye migracion PostgreSQL en `prisma/postgresql/migrations`
+- [ ] Requiere `DATABASE_URL` PostgreSQL
+- [ ] No introduce dependencia SQLite ni `file:` como flujo operativo
+- [ ] Impacto de datos y rollback revisados
+
 ## Validaciones
 
+- [ ] `npm run prisma:validate`
+- [ ] `npm run prisma:generate`
 - [ ] `npm run lint`
 - [ ] `npm run typecheck`
 - [ ] `npm run test`
 - [ ] `npm run build`
-- [ ] `npm run prisma:validate`
-- [ ] Validacion funcional manual (describir abajo)
+- [ ] Validacion funcional manual documentada
 
 Resultados breves:
+
+```text
+Pegar aqui salida resumida o evidencia de validacion.
+```
 
 ## Riesgos
 
@@ -30,18 +58,19 @@ Resultados breves:
 ## Rollback
 
 - Estrategia de reversa:
-- Datos/migraciones afectadas (si aplica):
+- Datos/migraciones afectadas:
 - Comando(s) o pasos para rollback:
 
 ## Jira
 
-- Enlace ticket: https://rigentec.atlassian.net/browse/KAN-xx
+- Enlace ticket: `https://rigentec.atlassian.net/browse/KAN-____`
 - Estado Jira esperado al abrir PR: `En revision`
-- Evidencia a publicar al cerrar ticket: SHA merge + checks + validacion
+- Evidencia a publicar al cerrar ticket: PR + SHA merge + checks + validacion
 
 ## Checklist de gobernanza
 
-- [ ] Rama sigue formato `feature/KAN-<id>-<slug-corto>`
-- [ ] Commits incluyen prefijo `KAN-xx:`
-- [ ] Titulo PR sigue formato `KAN-xx | <resumen>`
-- [ ] Se documento desviacion de alcance en Jira (si hubo)
+- [ ] Rama sigue formato `feature|fix|hotfix|docs|test/KAN-##-slug-corto`
+- [ ] Titulo PR sigue formato `tipo(KAN-##): resumen corto`
+- [ ] Jira contiene alcance y criterios de aceptacion
+- [ ] Jira sera actualizado despues del merge
+- [ ] Se documento desviacion de alcance en Jira, si hubo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,59 +1,95 @@
 # Contribucion y flujo de Pull Request
 
-Este repositorio usa un flujo basado en ramas cortas, Pull Request obligatoria y merge por squash hacia main.
+Este repositorio usa ramas cortas, Pull Request obligatoria y merge por squash hacia `main`.
+
+## Fuente de verdad
+
+| Tema | Fuente oficial |
+|---|---|
+| Backlog, prioridad y alcance | Jira `KAN` |
+| Codigo, configuracion y migraciones | GitHub `main` |
+| Estado funcional consolidado | `docs/WMS_CAPABILITIES_STATUS.md` |
+| Proceso GitHub-Jira | `docs/process/atlassian-github-operating-guide.md` |
+| Cierre diario | `docs/runbooks/git-jira-sync-daily.md` |
 
 ## Objetivo
 
-- Mantener main siempre desplegable.
-- Reducir ruido de historial con un commit por PR en main.
-- Estandarizar la limpieza manual de ramas sin perder trabajo activo.
+- Mantener `main` siempre desplegable.
+- Mantener trazabilidad obligatoria Jira-GitHub.
+- Evitar trabajo funcional sin ticket.
+- Mantener PostgreSQL como unica base operativa.
+- Reducir ambiguedad entre backlog, codigo y documentacion.
+
+## Base tecnica obligatoria
+
+PostgreSQL es la base de datos canonica del WMS.
+
+- Schema canonico: `prisma/postgresql/schema.prisma`.
+- Migraciones canonicas: `prisma/postgresql/migrations`.
+- `DATABASE_URL` debe iniciar con `postgres://` o `postgresql://`.
+- SQLite queda como legado/offline y no debe usarse como runtime, pruebas integradas, CI, release ni fuente de verdad.
+- Todo script nuevo de Prisma debe usar el schema canonico o fallar si `DATABASE_URL` no es PostgreSQL.
 
 ## Ramas
 
-- main: rama estable.
-- develop: integracion continua opcional.
-- feature/KAN-[id]-descripcion-corta: trabajo funcional ligado a Jira.
-- hotfix/[descripcion]: correcciones urgentes.
-- docs/[descripcion]: cambios de documentacion.
+Formato obligatorio:
 
-## Politica para Pull Request a main
+- `feature/KAN-##-slug-corto`
+- `fix/KAN-##-slug-corto`
+- `hotfix/KAN-##-slug-corto`
+- `docs/KAN-##-slug-corto`
+- `test/KAN-##-slug-corto`
 
-1. Crear rama desde main actualizada.
-2. Implementar cambios y mantener commits pequenos y claros en la rama.
-3. Verificar localmente antes de abrir PR:
-   - npm run lint
-   - npx tsc --noEmit
-   - npm run build
-   - npx prisma validate
-4. Abrir PR hacia main usando la plantilla oficial.
-5. Publicar en Jira el comentario de hito "revision" con URL del PR.
-6. Esperar checks de CI en verde (Code Quality Checks y Security Audit).
-7. Resolver comentarios de revision cuando aplique.
-8. Hacer merge unicamente con Squash merge.
-9. Publicar en Jira el comentario de cierre con SHA final y evidencia.
-10. Confirmar eliminacion automatica de la rama remota despues del merge.
+No abrir ramas funcionales sin ticket Jira.
 
-## Convencion Jira-GitHub obligatoria
+## Commits y PRs
 
-- Rama: `feature/KAN-<id>-<slug-corto>`.
-- Commit: `KAN-xx: <mensaje>`.
-- Titulo PR: `KAN-xx | <resumen>`.
-- Estado Jira esperado:
-  - `En curso` al iniciar rama.
-  - `En revision` al abrir PR.
-  - `Hecho` solo tras merge + checks verdes + evidencia publicada.
+Formato preferente para commits y titulos PR:
 
-## Convencion de titulos
-
-Se recomienda este formato para mejorar el mensaje de squash commit:
-
-- tipo(scope): resumen corto
+```text
+tipo(KAN-##): resumen corto
+```
 
 Ejemplos:
 
-- feat(inventory): agregar ajuste por lote
-- fix(catalog): corregir filtro por referencia
-- docs(runbook): actualizar pasos de recuperacion
+- `feat(KAN-48): integrar clientes formales en pedidos`
+- `fix(KAN-29): alinear release bootstrap con PostgreSQL`
+- `docs(KAN-8): unificar proceso GitHub Jira`
+- `test(KAN-53): cubrir regresion de clientes y pedidos`
+
+El formato `KAN-xx | resumen` queda permitido solo como legado temporal, no como estandar nuevo.
+
+## Politica para Pull Request a main
+
+1. Crear o seleccionar ticket Jira `KAN-##`.
+2. Crear rama desde `main` actualizado.
+3. Mover Jira a `En curso` cuando inicie trabajo real.
+4. Implementar solo el alcance del ticket.
+5. Verificar localmente antes de abrir PR:
+   - `npm run prisma:validate`
+   - `npm run prisma:generate`
+   - `npm run lint`
+   - `npm run typecheck`
+   - `npm run test`
+   - `npm run build`
+6. Confirmar que `DATABASE_URL` apunta a PostgreSQL cuando aplique.
+7. Abrir PR usando la plantilla oficial.
+8. Publicar URL del PR en Jira y mover el ticket a `En revision`.
+9. Esperar checks en verde.
+10. Resolver comentarios P0/P1 antes del merge.
+11. Hacer merge unicamente con Squash merge.
+12. Publicar en Jira evidencia de cierre: PR, SHA merge, checks y validacion.
+13. Mover Jira a `Finalizada` solo si no hay bloqueadores abiertos.
+
+## Estados Jira estandarizados
+
+| Estado Jira | Uso correcto |
+|---|---|
+| Idea | Backlog bruto o concepto no listo para ejecucion. |
+| Tareas por hacer | Ticket listo con alcance y criterios. |
+| En curso | Trabajo activo en rama o investigacion tecnica activa. |
+| En revision | PR abierto, QA pendiente o evidencia pendiente. |
+| Finalizada | PR mergeado, checks/evidencia registrados y sin bloqueadores. |
 
 ## Reglas de proteccion recomendadas para main
 
@@ -70,41 +106,25 @@ Configurar en GitHub Branch Protection:
 - Auto-delete head branches: activo.
 - Merge method permitido: Squash merge.
 
-## Flujo rapido por tipo de cambio
+## Cierre diario y sincronizacion
 
-### Feature
+Para cierre diario usar:
 
-1. git checkout main
-2. git pull
-3. git checkout -b feature/KAN-123-ajuste-kardex
-4. Desarrollar y validar quality gates.
-5. Abrir PR a main.
-6. Merge por squash.
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ops\sync-jira-views.ps1 -JiraProject KAN
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ops\daily-sync-report.ps1 -JiraProject KAN
+```
 
-### Hotfix
+Variables esperadas si se sincroniza con Jira API:
 
-1. Crear hotfix desde main.
-2. Priorizar fix minimo y validacion completa.
-3. Abrir PR con etiqueta hotfix.
-4. Merge por squash.
-5. Si se usa develop, sincronizar el cambio tambien hacia develop.
-
-### Documentacion
-
-1. Usar docs/[descripcion].
-2. Actualizar docs afectadas en el mismo PR del cambio funcional o en PR dedicado.
-3. Merge por squash.
-
-## Limpieza manual de ramas
-
-La limpieza de ramas stale es manual. Procedimiento detallado:
-
-- Ver docs/runbooks/git-branch-cleanup.md
-- Para cierre diario y trazabilidad operativa, ver docs/runbooks/git-jira-sync-daily.md
+- `JIRA_EMAIL`
+- `JIRA_API_TOKEN`
+- `JIRA_SHARE_GROUP` opcional
 
 ## Buenas practicas
 
 - Evitar ramas de larga vida.
-- Rebasar o actualizar la rama frecuentemente con main para reducir conflictos.
-- No mezclar refactors amplios con cambios funcionales no relacionados.
-- Incluir contexto de impacto tecnico y operativo en la descripcion del PR.
+- No mezclar refactors grandes con features.
+- No mezclar documentacion/proceso con cambios funcionales salvo que el ticket lo requiera.
+- No introducir SQLite como default operativo.
+- Si Jira contradice `main`, actualizar Jira o documentar estado parcial; no asumir Jira como verdad tecnica.

--- a/README.md
+++ b/README.md
@@ -1,212 +1,188 @@
 # WMS-SCMayher
 
-Sistema WMS para mangueras y conexiones industriales sobre Next.js, TypeScript y Prisma.
+Sistema WMS para mangueras y conexiones industriales sobre Next.js, TypeScript, Prisma y PostgreSQL.
 
 ## Estado operativo
 
 ### Prerrequisitos
-- Node.js 22+ y npm
-- Git
+
+- Node.js 22+ y npm.
+- Git.
+- PostgreSQL como base canonica del proyecto.
 - AWS web: runtime remoto activo para la experiencia web; infraestructura en `infra/cdk` y despliegue en `scripts/deploy/aws-web.ps1`.
-- Windows portable: runtime local soportado para operación en sitio; release en `scripts/release/build-release.ps1` y wrapper compatible en `build-release.cmd`.
+- Windows portable: runtime local soportado para operacion en sitio; release en `scripts/release/build-release.ps1` y wrapper compatible en `build-release.cmd`.
 - Mobile edge/PWA: artefactos en `mobile/` y `mobile-web/`; despliegue de staging en `scripts/deploy/mobile-staging.ps1`.
-- PM2 legacy: scripts históricos archivados en `archive/legacy/windows-pm2/`; no se usan para instalaciones nuevas.
+- PM2 legacy: scripts historicos archivados en `archive/legacy/windows-pm2/`; no se usan para instalaciones nuevas.
+
+## Decision tecnica base
+
+PostgreSQL es la base de datos canonica del WMS.
+
+- Schema canonico: `prisma/postgresql/schema.prisma`.
+- Migraciones canonicas: `prisma/postgresql/migrations`.
+- `DATABASE_URL` debe iniciar con `postgres://` o `postgresql://`.
+- SQLite queda como legado/offline y no debe usarse como runtime operativo, pruebas integradas, CI, release ni fuente de verdad.
+
+## Fuente de verdad
+
+| Tema | Fuente oficial |
+|---|---|
+| Backlog, prioridad y alcance | Jira `KAN` |
+| Codigo, configuracion y migraciones | GitHub `main` |
+| Estado funcional consolidado | `docs/WMS_CAPABILITIES_STATUS.md` |
+| Proceso GitHub-Jira | `docs/process/atlassian-github-operating-guide.md` |
+| Cierre diario | `docs/runbooks/git-jira-sync-daily.md` |
 
 ## Comandos principales
 
 ```bash
 npm install
 npm run prisma:validate
+npm run prisma:generate
 npm run lint
+npm run typecheck
+npm run test
 npm run build
 npm run dev
 ```
 
-Flujo local con base AWS en tiempo real:
+Todos los comandos de Prisma y pruebas integradas deben ejecutarse con `DATABASE_URL` PostgreSQL.
+
+## Flujo local con base AWS en tiempo real
 
 ```bash
 dev-local-launcher.cmd
 ```
 
 Notas del launcher AWS local:
+
 - Acepta `DATABASE_URL` en `.env` con o sin comillas.
-- Si la URL falta o es invalida, ejecuta automaticamente `maintenance\setup-aws.cmd`, reintenta `.env` y luego `DATABASE_URL` de entorno de maquina.
+- Si la URL falta o es invalida, ejecuta `maintenance\setup-aws.cmd`, reintenta `.env` y luego `DATABASE_URL` de entorno de maquina.
 
-Comandos operativos relevantes:
+## Estructura del Proyecto
 
-## 📁 Estructura del Proyecto
-
-```
-/app                    → Next.js App Router
-  /catalog              → Gestión de productos y categorías
-  /inventory            → Control de existencias y movimientos
-  /page.tsx             → Dashboard principal
-/components             → Componentes reutilizables
-/lib                    → Utilidades y cliente Prisma
+```text
+/app                    -> Next.js App Router
+/components             -> Componentes reutilizables
+/lib                    -> Servicios, RBAC, Prisma y dominio
 /prisma
-  /schema.prisma        → Modelo de datos
-  /migrations           → Historial de migraciones
-  /seed.cjs             → Datos iniciales
+  /postgresql/schema.prisma     -> Modelo canonico PostgreSQL
+  /postgresql/migrations        -> Migraciones canonicas PostgreSQL
+  /seed.cjs                     -> Datos iniciales
 /docs
-  /ADR                  → Architecture Decision Records
-/scripts                → Scripts de automatización
-/.github/workflows      → CI/CD con GitHub Actions
+  /ADR                  -> Architecture Decision Records
+  /process              -> Guias operativas de proceso
+  /runbooks             -> Operacion, cierre diario y soporte
+/scripts                -> Scripts de automatizacion
+/.github/workflows      -> CI/CD con GitHub Actions
 ```
 
-## 🛠️ Scripts Disponibles
+## Scripts disponibles
 
 ### Desarrollo
+
 ```bash
-npm run dev              # Servidor de desarrollo (puerto 3002)
-npm run dev:webpack      # Fallback para diagnóstico con webpack
-npm run build            # Build de producción
-npm run start            # Servidor de producción
-npm run lint             # Linter (ESLint)
-npm run mobile:infra:synth  # Sintetiza IaC móvil (sin deploy)
-npm run mobile:infra:diff   # Diff IaC móvil (sin deploy)
-npm run mobile:infra:deploy # Despliega IaC móvil en AWS
-npm run mobile:infra:destroy # Elimina stack móvil en AWS (usar con cuidado)
+npm run dev              # Servidor de desarrollo puerto 3002
+npm run dev:webpack      # Fallback de diagnostico con webpack
+npm run build            # Build de produccion
+npm run start            # Servidor de produccion
+npm run lint             # Linter ESLint
+npm run typecheck        # Next typegen + TypeScript check
+npm run test             # Pruebas con PostgreSQL obligatorio
 ```
 
-### Base de Datos
+### Base de datos y release
+
 ```bash
-npm run build:release
+npm run prisma:validate
+npm run prisma:generate
+npm run db:migrate
+npm run db:push
+npm run db:studio
 npm run verify:release
+npm run build:release
 npm run infra:synth
 npm run infra:diff
 npm run mobile:infra:synth
 npm run mobile:staging:deploy
 ```
 
-## Estructura
+### Sincronizacion GitHub-Jira
 
-- `app/`, `components/`, `lib/`: aplicación principal Next.js.
-- `prisma/`: modelo de datos, migraciones y seed.
-- `infra/cdk/`: stack AWS para la app web.
-- `mobile/` y `mobile-web/`: runtime edge/API y cliente PWA.
-- `scripts/release/`, `scripts/deploy/`, `scripts/data/`, `scripts/db/`, `scripts/smoke/`: scripts canónicos.
-- `scripts/*.ps1|*.cjs|*.py`: wrappers de compatibilidad para rutas antiguas.
-- `docs/`: documentación viva.
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ops\sync-jira-views.ps1 -JiraProject KAN
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ops\daily-sync-report.ps1 -JiraProject KAN
+```
 
-## Documentación
+Variables esperadas:
 
+- `JIRA_EMAIL`
+- `JIRA_API_TOKEN`
+- `JIRA_SHARE_GROUP` opcional
+
+## Documentacion
+
+- [Guia operativa Atlassian - GitHub](./docs/process/atlassian-github-operating-guide.md)
+- [Guia de contribucion y flujo PR](./CONTRIBUTING.md)
+- [Cierre diario GitHub-Jira](./docs/runbooks/git-jira-sync-daily.md)
 - [Matriz de soporte de runtimes](./docs/runbooks/runtime-support-matrix.md)
-- [Guía de contraste y tokens](./docs/reference/theme-contrast-guide.md)
-- [Operación Windows portable](./docs/runbooks/windows-portable-install.md)
-- [Operación local Windows](./docs/runbooks/windows-local-operations.md)
+- [Operacion Windows portable](./docs/runbooks/windows-portable-install.md)
+- [Operacion local Windows](./docs/runbooks/windows-local-operations.md)
 - [Deploy AWS web prod-ready](./docs/runbooks/aws-web-prod-deploy.md)
-- [Runbook de limpieza manual de ramas Git](./docs/runbooks/git-branch-cleanup.md)
 - [Base de datos y Prisma](./docs/reference/database-setup.md)
-- [Importación de productos CSV](./docs/reference/import-products-csv.md)
-- [Deploy AWS móvil](./docs/mobile/aws-deploy.md)
-- [Contratos mobile v1](./docs/mobile/v1-contracts.md)
+- [Importacion de productos CSV](./docs/reference/import-products-csv.md)
 - [Estado real de capacidades WMS](./docs/WMS_CAPABILITIES_STATUS.md)
 - [Architecture Decision Records](./docs/ADR/README.md)
-  - [ADR-001: Arquitectura Base](./docs/ADR/001-arquitectura-base.md)
-  - [ADR-002: Capa móvil AWS híbrida](./docs/ADR/002-mobile-aws-hibrido.md)
-- [Mobile API v1 Contracts](./docs/mobile/v1-contracts.md)
-- [AWS Mobile Deploy Guide](./docs/mobile/aws-deploy.md)
 
-## ☁️ Capa móvil AWS (Fase 0+1+2 parcial)
+## Capa movil AWS
 
-Implementada como extensión desacoplada, sin tocar la operación crítica local.
+Implementada como extension desacoplada, sin tocar la operacion critica local.
 
-- `mobile-web/`: PWA shell mínima (estática).
-- `mobile/functions/`: handlers Lambda (`health`, `version`, `me/permissions`, `inventory/search`, `assembly-requests`, `product-drafts`).
-- `mobile/infra/cdk/`: infraestructura AWS (S3, CloudFront, Cognito, HTTP API, Lambda, DynamoDB, SQS, CloudWatch).
-- `lib/mobile/`: contratos, feature flags y RBAC móvil.
+- `mobile-web/`: PWA shell minima.
+- `mobile/functions/`: handlers Lambda.
+- `mobile/infra/cdk/`: infraestructura AWS.
+- `lib/mobile/`: contratos, feature flags y RBAC movil.
 
-### Principio operativo
+## Quality Gates
 
-- El WMS local sigue siendo `source of truth`.
-- La nube soporta consulta de inventario, solicitudes de ensamble y borradores de productos nuevos.
-- El sistema local sigue siendo el `source of truth`; cloud publica eventos de intake por SQS para integración controlada.
-- Runtime objetivo del repositorio y de la capa móvil AWS: `Node 22.x`.
+Todo cambio debe pasar:
 
-### Evolución prevista
+1. `npm run prisma:validate`
+2. `npm run prisma:generate`
+3. `npm run lint`
+4. `npm run typecheck`
+5. `npm run test`
+6. `npm run build`
+7. Code review obligatorio en PRs
 
-- La PWA actual es una base mínima.
-- La dirección objetivo es llevar la experiencia AWS móvil hacia paridad visual y funcional con los flujos comerciales del WMS local.
-- La propuesta ideal de reestructura quedó documentada en [docs/mobile/mobile-edge-restructure.md](./docs/mobile/mobile-edge-restructure.md).
+CI/CD automatizado en `.github/workflows/ci.yml`.
 
-### Variables de entorno móviles (Lambda)
+## Contribuir
 
-- `MOBILE_ENABLED`
-- `INVENTORY_SEARCH_ENABLED`
-- `ASSEMBLY_REQUESTS_ENABLED`
-- `PRODUCT_DRAFTS_ENABLED`
-- `MOBILE_BUILD`
-- `MOBILE_RELEASE_DATE`
-- `MOBILE_SERVICE_NAME`
-- `MOBILE_AUTH_MODE` (`cognito` o `mock`)
-- `MOBILE_DDB_INVENTORY_TABLE`
-- `MOBILE_DDB_ASSEMBLY_REQUESTS_TABLE`
-- `MOBILE_DDB_PRODUCT_DRAFTS_TABLE`
-- `MOBILE_INTEGRATION_QUEUE_URL`
-- `MOBILE_CORS_ALLOWED_ORIGIN`
+1. Crea o selecciona un ticket Jira `KAN-##`.
+2. Crea branch desde `main`: `feature/KAN-##-descripcion`.
+3. Haz commits con alcance cerrado.
+4. Ejecuta los quality gates.
+5. Abre PR con titulo `tipo(KAN-##): resumen corto`.
+6. Actualiza Jira con PR, evidencia y estado real.
 
-## 🔒 Quality Gates
+Consulta la [Guia operativa Atlassian - GitHub](./docs/process/atlassian-github-operating-guide.md) antes de iniciar trabajo nuevo.
 
-Todo código debe pasar:
-1. ✅ Linter (ESLint)
-2. ✅ TypeScript check (`tsc --noEmit`)
-3. ✅ Build exitoso (`npm run build`)
-4. ✅ Prisma validate
-5. ✅ Code review obligatorio en PRs
+## Convenciones
 
-CI/CD automatizado en `.github/workflows/ci.yml`
+- Archivos: kebab-case (`product-list.tsx`).
+- Componentes: PascalCase (`ProductCard`).
+- Variables: camelCase (`productId`).
+- Constantes: UPPER_SNAKE_CASE (`MAX_ITEMS`).
+- Branches: `feature|fix|hotfix|docs|test/KAN-##-slug-corto`.
+- PR/commits: `tipo(KAN-##): resumen corto`.
 
-## 🤝 Contribuir
-
-1. Crea un branch desde `main`: `git checkout -b feature/mi-funcionalidad`
-2. Haz tus cambios y commits con mensajes descriptivos
-3. Ejecuta `npm run lint` y `npm run build` para validar
-4. Crea un Pull Request con descripción clara
-5. Espera code review y aprobación
-
-## 📝 Convenciones
-
-- **Archivos:** kebab-case (`product-list.tsx`)
-- **Componentes:** PascalCase (`ProductCard`)
-- **Variables:** camelCase (`productId`)
-- **Constantes:** UPPER_SNAKE_CASE (`MAX_ITEMS`)
-- **Commits:** Mensajes claros en español/inglés
-
-## 🐛 Troubleshooting
-
-### Build Error: "Cannot apply unknown utility class `glass`"
-✅ **Solucionado** en último commit. Si persiste, ejecuta:
-```bash
-npm install
-npm run build
-```
-
-### Error de Prisma Client
-```bash
-npx prisma generate
-```
-
-### Puerto 3002 ya en uso
-```bash
-# Windows
-npx kill-port 3002
-
-# Linux/Mac
-lsof -ti:3002 | xargs kill
-```
-
-## 📄 Licencia
-
-Privado - SCMayher © 2026
-
-## 🙋 Soporte
+## Soporte
 
 Para dudas o problemas, contactar al Tech Lead o abrir un issue en el repositorio.
-- [ADR](./docs/ADR/README.md)
-- [Guía de contribución y flujo PR](./CONTRIBUTING.md)
 
 ## Notas
 
-- `release/` y los respaldos locales se preservan fuera del flujo normal de limpieza del repo.
+- `release/` y respaldos locales se preservan fuera del flujo normal de limpieza del repo.
 - Los entrypoints operativos siguen siendo `launcher.cmd`, `stop.cmd`, `uninstall.cmd`, `maintenance/*.cmd` y `build-release.cmd`.
-- Si se reorganiza un script interno, se mantiene un wrapper temporal en la ruta anterior hasta cerrar la transición.
+- Si se reorganiza un script interno, se mantiene wrapper temporal en la ruta anterior hasta cerrar la transicion.

--- a/docs/WMS_CAPABILITIES_STATUS.md
+++ b/docs/WMS_CAPABILITIES_STATUS.md
@@ -1,6 +1,6 @@
 # WMS Capabilities Status
 
-Fecha de corte: 2026-04-28
+Fecha de corte: 2026-04-29
 
 ## Decision base
 
@@ -10,6 +10,16 @@ PostgreSQL es la base de datos canonica y unica para runtime, pruebas integradas
 - Migraciones canonicas: `prisma/postgresql/migrations`.
 - `DATABASE_URL` debe iniciar con `postgres://` o `postgresql://`.
 - SQLite queda como legado historico/offline y no debe usarse como fuente de verdad operativa.
+
+## Fuente de verdad operacional
+
+| Tema | Fuente oficial |
+|---|---|
+| Backlog, prioridad y alcance | Jira `KAN` |
+| Codigo, configuracion y migraciones | GitHub `main` |
+| Estado funcional consolidado | Este documento |
+| Proceso GitHub-Jira | `docs/process/atlassian-github-operating-guide.md` |
+| Cierre diario | `docs/runbooks/git-jira-sync-daily.md` |
 
 ## Implementado en codigo
 
@@ -31,11 +41,14 @@ PostgreSQL es la base de datos canonica y unica para runtime, pruebas integradas
 - Trazabilidad, etiquetas, plantillas y trabajos de impresion.
 - Sync/outbox con `SyncEvent`.
 - Runtime AWS/local con PostgreSQL y scripts de despliegue AWS.
+- Flujo operativo GitHub/Jira incorporado con `daily-sync-report` y `sync-jira-views`.
+- Registro formal de clientes integrado parcialmente en ventas/produccion por PR #16.
 
 ## Reconciliacion Jira vs repo
 
 ### Implementado o parcialmente implementado; requiere actualizar Jira
 
+- `KAN-8`: guia, proceso y fuente de verdad quedan unificados en el PR documental actual.
 - `KAN-10`: alta de producto sin inventario invalido.
 - `KAN-9`: validaciones server-side con Zod en flujos criticos.
 - `KAN-11`: UI/servicio de ajustes de inventario.
@@ -45,23 +58,24 @@ PostgreSQL es la base de datos canonica y unica para runtime, pruebas integradas
 - `KAN-22`: modelo de compras y recibos ya existe en Prisma.
 - `KAN-25`: Auth/RBAC base ya existe; falta validar cobertura UI/operativa.
 - `KAN-26`: `AuditLog` ya existe; falta validar cobertura por accion critica.
-- `KAN-51`: campos de asignacion y entrega ya existen; falta validar flujo UI, permisos y auditoria.
+- `KAN-48`: clientes formales avanzados por PR #16; requiere confirmar cierre funcional completo y QA.
+- `KAN-51`: campos y parte de flujo de asignacion/entrega existen; falta validar UI, permisos y auditoria completa.
 
 ### Mantener como prioridad abierta
 
-- `KAN-48`: registro formal de clientes e integracion en pedidos.
+- `KAN-29`: cerrar PostgreSQL-only en release, CI, scripts legacy y pruebas con `DATABASE_URL` PostgreSQL.
+- `KAN-53`: QA, RBAC y regresion de flujos criticos, especialmente tras PR #16.
 - `KAN-49`: UI de administracion de usuarios para `SYSTEM_ADMIN`.
 - `KAN-50`: dashboard admin/manager centrado en pedidos por surtir.
 - `KAN-52`: UX de flujo de pedidos, `flowStage`, timeline y filtros.
-- `KAN-53`: QA, RBAC y regresion de flujos criticos.
-- `KAN-29`: cerrar migracion productiva PostgreSQL y retirar dependencias operativas SQLite.
 
 ## Pendiente tecnico inmediato
 
 - Eliminar dependencias operativas restantes de SQLite en scripts legacy.
 - Confirmar que CI corre con `DATABASE_URL` PostgreSQL en secretos/variables.
-- Actualizar cualquier documentacion que aun mencione SQLite como flujo recomendado.
-- Ejecutar `npm run prisma:validate`, `npm run prisma:generate`, `npm run typecheck`, `npm run test` y `npm run build` con `DATABASE_URL` PostgreSQL.
+- Resolver `KAN-29` / GitHub issue #14.
+- Ejecutar regresion `KAN-53` para clientes, pedidos y RBAC tras PR #16.
+- Actualizar Jira al cerrar este PR documental con SHA merge y evidencia.
 
 ## Nota operativa
 
@@ -70,8 +84,10 @@ Para trabajo diario y pruebas integradas:
 ```bash
 npm run prisma:validate
 npm run prisma:generate
-npm run db:migrate
+npm run lint
+npm run typecheck
 npm run test
+npm run build
 ```
 
-Todos los comandos anteriores requieren `DATABASE_URL` PostgreSQL. Si el valor apunta a SQLite, el proceso debe fallar.
+Todos los comandos anteriores requieren `DATABASE_URL` PostgreSQL cuando toquen Prisma, pruebas integradas o DB. Si el valor apunta a SQLite, el proceso debe fallar.

--- a/docs/process/atlassian-github-operating-guide.md
+++ b/docs/process/atlassian-github-operating-guide.md
@@ -1,0 +1,174 @@
+# Guia operativa Atlassian - GitHub
+
+Fecha de corte: 2026-04-29
+Proyecto Jira: `KAN / WMS project`
+Repositorio: `raul2105/WMS-Mangueras-y-conexiones`
+
+## Objetivo
+
+Unificar el flujo de trabajo entre Atlassian y GitHub para que cada cambio tenga ticket, PR, validacion, evidencia y cierre operativo claro.
+
+## Fuente de verdad
+
+| Informacion | Fuente primaria | Regla |
+|---|---|---|
+| Backlog, prioridad y alcance funcional | Jira `KAN` | Todo trabajo debe tener ticket `KAN-##`. |
+| Codigo, configuracion y migraciones | GitHub `main` | `main` es la verdad tecnica desplegable. |
+| Estado funcional consolidado | `docs/WMS_CAPABILITIES_STATUS.md` | Se actualiza cuando cambian capacidades reales. |
+| Reconciliaciones repo-Jira | `docs/release/` | Se crea acta cuando haya cambio estructural. |
+| Politica de contribucion | `CONTRIBUTING.md` | Define ramas, PR, calidad y cierre. |
+| Cierre diario | `docs/runbooks/git-jira-sync-daily.md` | Define reporte y sincronizacion operativa. |
+
+## Decision tecnica base
+
+PostgreSQL es la base canonica del WMS.
+
+- Schema canonico: `prisma/postgresql/schema.prisma`.
+- Migraciones canonicas: `prisma/postgresql/migrations`.
+- `DATABASE_URL` debe iniciar con `postgres://` o `postgresql://`.
+- SQLite queda como legado/offline y no se acepta como runtime operativo, pruebas integradas, CI, release ni fuente de verdad.
+
+## Convencion oficial
+
+### Ramas
+
+```text
+feature/KAN-48-clientes-pedidos
+fix/KAN-29-postgresql-release-bootstrap
+docs/KAN-8-unificar-fuente-verdad
+test/KAN-53-regresion-clientes-pedidos
+hotfix/KAN-##-slug-corto
+```
+
+### PRs y commits
+
+Formato oficial:
+
+```text
+tipo(KAN-##): resumen corto
+```
+
+Ejemplos:
+
+```text
+feat(KAN-48): integrar clientes formales en pedidos
+fix(KAN-29): eliminar dependencia SQLite del build release
+docs(KAN-8): unificar proceso Atlassian GitHub
+test(KAN-53): cubrir regresion de clientes y pedidos
+```
+
+El formato `KAN-xx | resumen` queda permitido solo como legado temporal por el PR #16, pero no debe usarse para trabajo nuevo.
+
+## Flujo obligatorio
+
+### 1. Preparar ticket Jira
+
+Antes de programar debe existir un ticket `KAN-##` con:
+
+- objetivo de negocio,
+- alcance tecnico,
+- criterios de aceptacion,
+- prioridad real,
+- dependencias,
+- riesgos o impacto de datos si aplica.
+
+### 2. Crear rama desde `main`
+
+- Actualizar `main`.
+- Crear rama con prefijo por tipo y ticket.
+- Mover Jira a `En curso`.
+
+### 3. Implementar con alcance cerrado
+
+No mezclar:
+
+- refactors amplios con features,
+- migraciones de base de datos con UI no relacionada,
+- cambios de proceso con cambios funcionales,
+- limpieza de release con features de negocio.
+
+### 4. Validar antes de abrir PR
+
+```bash
+npm run prisma:validate
+npm run prisma:generate
+npm run lint
+npm run typecheck
+npm run test
+npm run build
+```
+
+Si toca Prisma, CI, release o migraciones, validar con `DATABASE_URL` PostgreSQL y documentar resultado en el PR.
+
+### 5. Abrir PR
+
+- Usar plantilla oficial.
+- Titulo `tipo(KAN-##): resumen corto`.
+- Publicar URL del PR en Jira.
+- Mover Jira a `En revision`.
+
+### 6. Review y CI
+
+No fusionar si:
+
+- falta ticket Jira,
+- no hay evidencia de validacion,
+- CI falla,
+- existe comentario P0/P1 abierto,
+- se introduce SQLite como default operativo,
+- el PR mezcla alcance no relacionado.
+
+### 7. Merge y cierre
+
+- Usar Squash merge hacia `main`.
+- Publicar en Jira:
+  - URL del PR,
+  - SHA merge,
+  - checks,
+  - validacion funcional,
+  - riesgos restantes.
+- Mover Jira a `Finalizada` solo si no hay bloqueadores.
+
+## Estados Jira estandarizados
+
+| Estado Jira | Uso correcto |
+|---|---|
+| Idea | Backlog bruto o concepto sin ejecucion inmediata. |
+| Tareas por hacer | Ticket listo para ejecutar. |
+| En curso | Trabajo activo en rama o investigacion tecnica. |
+| En revision | PR abierto, QA pendiente o evidencia pendiente. |
+| Finalizada | PR mergeado, evidencia registrada y sin bloqueadores. |
+
+## Reconciliacion periodica
+
+Ejecutar cuando haya cambios estructurales o antes de iniciar un bloque P0.
+
+Checklist:
+
+- Comparar `docs/WMS_CAPABILITIES_STATUS.md` contra Jira.
+- Revisar PRs mergeados recientes.
+- Revisar tickets `Idea` que ya tengan evidencia en codigo.
+- Marcar como parcial tickets con modelo implementado pero UI/QA pendiente.
+- Crear o actualizar deuda tecnica si hay bloqueante.
+- Documentar hallazgos en `docs/release/`.
+
+## Deuda tecnica
+
+Toda deuda tecnica debe tener:
+
+- ticket Jira,
+- impacto operativo,
+- riesgo si no se atiende,
+- condicion de cierre,
+- prioridad.
+
+Caso actual prioritario:
+
+`KAN-29`: cerrar PostgreSQL-only en release, CI, scripts legacy y pruebas con `DATABASE_URL` PostgreSQL.
+
+## Orden recomendado actual
+
+1. Cerrar `KAN-8` con esta guia y README estandarizados.
+2. Cerrar `KAN-29` para eliminar dependencias operativas SQLite restantes.
+3. Ejecutar `KAN-53` para cubrir regresion tras PR #16.
+4. Continuar con `KAN-49`, `KAN-51`, `KAN-50` y `KAN-52` segun prioridad operativa.

--- a/docs/runbooks/git-jira-sync-daily.md
+++ b/docs/runbooks/git-jira-sync-daily.md
@@ -1,87 +1,116 @@
 # Sincronizacion Local-GitHub-Jira (WMS)
 
 ## Objetivo
+
 Mantener trazabilidad completa entre trabajo local, PRs en GitHub y seguimiento en Jira para cada ticket.
 
 ## Convenciones obligatorias
-- Rama por ticket: `feature/KAN-<id>-<slug-corto>`
-- Commit message: `KAN-xx: <mensaje>`
-- PR title: `KAN-xx | <resumen>`
+
+- Rama por ticket: `feature|fix|hotfix|docs|test/KAN-##-slug-corto`
+- PR title: `tipo(KAN-##): resumen corto`
+- Commit recomendado: `tipo(KAN-##): resumen corto`
 - Jira: cada ticket debe tener evidencia de inicio, revision y cierre.
 
+El formato `KAN-xx | resumen` queda permitido solo como legado temporal, no como estandar nuevo.
+
 ## Flujo operativo por ticket
-1. Preparar base
-- `git fetch --all --prune`
-- Verificar que `main` local no este desalineado con `origin/main`.
+
+### 1. Preparar base
+
+- Verificar que `main` local este alineado con `origin/main`.
 - Crear rama desde `main` actualizado.
+- Mover Jira a `En curso`.
 
-2. Desarrollo
+### 2. Desarrollo
+
 - Implementar solo alcance del ticket.
-- Mantener commits pequenos y con prefijo del ticket.
+- Mantener commits pequenos y con referencia `KAN-##`.
+- Confirmar PostgreSQL cuando el cambio toque Prisma, DB, CI, pruebas o release.
 
-3. Abrir PR
+### 3. Abrir PR
+
 - Completar plantilla PR obligatoria.
-- Publicar enlace del PR en comentario Jira del ticket.
-- Mover Jira a estado de revision.
+- Publicar enlace del PR en Jira.
+- Mover Jira a `En revision`.
 
-4. Validacion y merge
+### 4. Validacion y merge
+
 - Confirmar checks requeridos en verde.
-- Resolver comentarios de revision.
-- Hacer merge a `main`.
+- Resolver comentarios P0/P1.
+- Hacer squash merge a `main`.
 
-5. Cierre Jira
-- Mover ticket a hecho.
-- Publicar evidencia minima:
-  - URL PR
-  - SHA merge
-  - Resultado de checks
-  - Nota de validacion funcional
+### 5. Cierre Jira
+
+Mover ticket a `Finalizada` solo con evidencia minima:
+
+- URL PR.
+- SHA merge.
+- Resultado de checks.
+- Nota de validacion funcional.
+- Riesgos abiertos si aplica.
 
 ## Plantillas de comentario Jira por hito
-### Inicio (al crear rama)
-```
+
+### Inicio
+
+```text
 Inicio de trabajo tecnico.
-- Rama: feature/KAN-xx-<slug>
-- Objetivo: <resumen corto>
-- Siguiente paso: <paso inmediato>
+- Rama: feature/KAN-##-slug
+- Objetivo: resumen corto
+- Siguiente paso: paso inmediato
 ```
 
-### Revision (al abrir PR)
-```
+### Revision
+
+```text
 Ticket en revision.
-- PR: <url_pr>
-- Riesgos abiertos: <si/no + detalle>
-- Estado de checks: <pendiente/en progreso/en verde>
+- PR: url_pr
+- Riesgos abiertos: no / si, detalle
+- Estado de checks: pendiente / en progreso / verde
 ```
 
-### Cierre (tras merge)
-```
+### Cierre
+
+```text
 Ticket completado y mergeado.
-- PR: <url_pr>
-- SHA merge: <sha>
-- Checks: <resultado>
-- Validacion funcional: <resultado breve>
+- PR: url_pr
+- SHA merge: sha
+- Checks: resultado
+- Validacion funcional: resultado breve
 ```
 
-## Cierre diario (Delta del dia)
-Ejecutar:
-`powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ops\daily-sync-report.ps1 -JiraProject KAN`
+## Cierre diario
 
-Antes del cierre, sincronizar vistas Jira:
-`powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ops\sync-jira-views.ps1 -JiraProject KAN`
+Ejecutar reporte diario:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ops\daily-sync-report.ps1 -JiraProject KAN
+```
+
+Sincronizar vistas Jira antes del cierre:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ops\sync-jira-views.ps1 -JiraProject KAN
+```
 
 Variables esperadas para sincronizacion via REST:
+
 - `JIRA_EMAIL`
 - `JIRA_API_TOKEN`
-- Opcional para compartir vistas por equipo: `JIRA_SHARE_GROUP`
+- `JIRA_SHARE_GROUP` opcional
 
-El reporte incluye:
+## Reporte esperado
+
+El reporte debe incluir:
+
 - Git local: rama activa, ahead/behind contra `origin/main`, ramas activas.
-- GitHub: PRs abiertos y estado de checks (requiere `gh` autenticado).
-- Jira: conteo de `Highest` vencidos, sin owner y tickets en curso/revision sin evidencia PR (via JQL URL y/o API si hay token).
+- GitHub: PRs abiertos, estado de checks y tickets relacionados.
+- Jira: tickets vencidos, sin owner y tickets en curso/revision sin evidencia PR.
 
 ## Reglas de gobierno
+
 - No trabajar directo en `main` salvo incidente critico aprobado y documentado.
-- Ningun ticket pasa a hecho sin evidencia tecnica enlazada.
+- Ningun ticket pasa a `Finalizada` sin evidencia tecnica enlazada.
 - Cualquier cambio de alcance debe registrarse en Jira antes del merge.
-- Ticket `Highest` vencido >24h debe tener owner, nueva fecha y plan de desbloqueo el mismo dia.
+- Ticket `Highest` vencido por mas de 24h debe tener owner, nueva fecha y plan de desbloqueo el mismo dia.
+- No introducir SQLite como default operativo.


### PR DESCRIPTION
## Ticket Jira

- KAN-8
- Relacionado: KAN-29, KAN-48, KAN-49, KAN-50, KAN-51, KAN-52, KAN-53

## Resumen

Reabre y reconstruye el PR documental sobre `main` actual despues del merge del PR #16. El objetivo es unificar una sola fuente de verdad entre Atlassian y GitHub, evitando reglas cruzadas de ramas, PRs, PostgreSQL, cierre diario y estado funcional.

## Cambios principales

- `CONTRIBUTING.md`: define fuente de verdad, PostgreSQL canonico, ramas oficiales, formato PR/commit y cierre Jira.
- `.github/pull_request_template.md`: exige ticket Jira, PostgreSQL, validaciones, rollback y checklist de gobernanza.
- `README.md`: actualiza comandos, estructura, PostgreSQL y documentos operativos.
- `docs/process/atlassian-github-operating-guide.md`: agrega guia formal de proceso Atlassian-GitHub.
- `docs/runbooks/git-jira-sync-daily.md`: alinea cierre diario con la convencion oficial.
- `docs/WMS_CAPABILITIES_STATUS.md`: actualiza corte tras PR #16 y registra clientes como avance parcial.

## Decisiones estandarizadas

- Jira `KAN`: backlog, prioridad y alcance.
- GitHub `main`: verdad tecnica desplegable.
- `docs/WMS_CAPABILITIES_STATUS.md`: estado funcional consolidado.
- PostgreSQL: unica base operativa canonica.
- Formato oficial PR/commit: `tipo(KAN-##): resumen corto`.
- Formato oficial rama: `feature|fix|hotfix|docs|test/KAN-##-slug-corto`.

## Base de datos

- [x] No introduce cambios de schema ni migraciones.
- [x] Refuerza PostgreSQL como base canonica.
- [x] No introduce dependencia SQLite.

## Validacion

Cambio documental. Validacion recomendada antes de merge:

```bash
npm run prisma:validate
npm run prisma:generate
npm run lint
npm run typecheck
npm run test
npm run build
```

## Riesgos

- Riesgo principal: que `README`/guias queden mas estrictos que scripts legacy aun pendientes.
- Mitigacion: `KAN-29` queda como siguiente bloque tecnico para limpiar release/CI/scripts legacy.

## Rollback

Revertir este PR restaura documentacion y plantilla anterior. No hay impacto en codigo funcional ni migraciones.