### PR TITLE
test(KAN-49): validar administración de usuarios SYSTEM_ADMIN

### DIFF
--- a/docs/jira/KAN-49-user-admin-validation-plan.md
+++ b/docs/jira/KAN-49-user-admin-validation-plan.md
@@ -1,0 +1,76 @@
+# KAN-49 — Validación de administración de usuarios SYSTEM_ADMIN
+
+Fecha de creación: 2026-04-30  
+Rama: `test/KAN-49-user-admin-validation`
+
+## Objetivo
+
+Convertir el módulo existente de administración de usuarios en cierre auditable con pruebas de seguridad, RBAC, gestión de roles y auditoría.
+
+## Diagnóstico inicial
+
+El repositorio ya contiene base funcional para administración de usuarios:
+
+- Servicio principal: `lib/users/admin-service.ts`.
+- Rutas detectadas: `app/(shell)/users/new/page.tsx` y `app/(shell)/users/[id]/page.tsx`.
+- Permiso requerido: `users.manage`.
+- Auditoría sobre entidad `USER`.
+
+El ticket no debe cerrarse solo por existencia de código. Debe cerrarse únicamente con evidencia de pruebas y validación funcional.
+
+## Alcance obligatorio del PR
+
+1. Agregar pruebas específicas para `lib/users/admin-service.ts`.
+2. Verificar que solo usuarios autorizados puedan crear, editar, activar/desactivar y ejecutar acciones administrativas.
+3. Verificar que la información sensible no se exponga en respuestas ni auditoría.
+4. Verificar sincronización correcta de roles en `UserRole`.
+5. Verificar que no exista eliminación física de usuarios en el flujo administrativo.
+6. Verificar protección contra auto-desactivación y auto-remoción del rol crítico cuando aplique.
+7. Documentar comandos ejecutados y resultado.
+
+## Pruebas mínimas requeridas
+
+Archivo recomendado:
+
+```text
+tests/users/admin-service.integration.test.ts
+```
+
+Casos mínimos:
+
+- creación de usuario por SYSTEM_ADMIN autorizado.
+- rechazo por correo duplicado.
+- rechazo por roles inexistentes o inactivos.
+- actualización atómica de roles.
+- bloqueo de auto-desactivación.
+- bloqueo de auto-remoción del rol crítico propio.
+- acción administrativa sensible con auditoría.
+- consultas sin exposición de campos sensibles.
+- rechazo de sesión sin `users.manage`.
+
+## Quality gates esperados
+
+```bash
+npm run prisma:validate
+npm run prisma:generate
+npm run test:rbac:integration
+node scripts/db/run-vitest-postgres.cjs run tests/users/admin-service.integration.test.ts
+npm run typecheck
+npm run build
+```
+
+## Criterios de cierre Jira
+
+KAN-49 puede pasar a `Finalizada` solo si:
+
+- El PR queda mergeado a `main`.
+- Las pruebas anteriores pasan con `DATABASE_URL` PostgreSQL.
+- Se publica en Jira el SHA de merge y resumen de validación.
+- `docs/WMS_CAPABILITIES_STATUS.md` se actualiza de pendiente de validación a validado.
+
+## Fuera de alcance
+
+- Rediseño visual mayor de `/users`.
+- Nuevos permisos fuera de `users.manage`.
+- Cambio de modelo `User` salvo brecha demostrada.
+- Eliminación física de usuarios.

--- a/tests/auth/authorize-inactive-user.integration.test.ts
+++ b/tests/auth/authorize-inactive-user.integration.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import bcrypt from "bcryptjs";
+import { PrismaClient } from "@prisma/client";
+
+const shouldRunPostgresSuite = process.env.RUN_POSTGRES_TESTS === "1"
+  && /^postgres(ql)?:\/\//i.test(String(process.env.DATABASE_URL ?? ""));
+
+const describePostgres = shouldRunPostgresSuite ? describe : describe.skip;
+
+type CredentialsProviderLike = {
+  authorize: (credentials: { email?: string; password?: string }) => Promise<unknown>;
+};
+
+type NextAuthConfigLike = {
+  providers: CredentialsProviderLike[];
+};
+
+let capturedConfig: NextAuthConfigLike | undefined;
+
+vi.mock("next-auth", () => ({
+  default: (config: NextAuthConfigLike) => {
+    capturedConfig = config;
+    return { handlers: {}, auth: vi.fn(), signIn: vi.fn(), signOut: vi.fn() };
+  },
+}));
+
+vi.mock("next-auth/providers/credentials", () => ({
+  default: (config: CredentialsProviderLike) => config,
+}));
+
+describePostgres("auth authorize inactive user integration (postgres)", () => {
+  const prisma = new PrismaClient();
+  const runId = `KAN49-AUTH-${Date.now()}`;
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    await prisma.userRole.deleteMany({
+      where: {
+        user: {
+          email: {
+            startsWith: `${runId}-`,
+          },
+        },
+      },
+    });
+    await prisma.user.deleteMany({
+      where: {
+        email: {
+          startsWith: `${runId}-`,
+        },
+      },
+    });
+    await prisma.$disconnect();
+  });
+
+  it("blocks login when user is inactive even with valid password", async () => {
+    const password = "Admin123*";
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    const user = await prisma.user.create({
+      data: {
+        name: "Inactive Login",
+        email: `${runId}-inactive@scmayher.com`,
+        passwordHash,
+        isActive: false,
+      },
+      select: { id: true, email: true },
+    });
+
+    const role = await prisma.role.upsert({
+      where: { code: "MANAGER" },
+      update: { isActive: true, name: "MANAGER" },
+      create: { code: "MANAGER", name: "MANAGER", isActive: true },
+      select: { id: true },
+    });
+
+    await prisma.userRole.create({
+      data: {
+        userId: user.id,
+        roleId: role.id,
+      },
+    });
+
+    await import("@/lib/auth");
+
+    const provider = capturedConfig?.providers[0];
+    expect(provider).toBeTruthy();
+    if (!provider) {
+      throw new Error("No se pudo obtener provider de credenciales desde lib/auth");
+    }
+    const result = await provider.authorize({ email: user.email, password });
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/rbac/route-access.integration.test.ts
+++ b/tests/rbac/route-access.integration.test.ts
@@ -123,4 +123,15 @@ describe("rbac role-route access matrix", () => {
     expect(canAccess("WAREHOUSE_OPERATOR", "/users")).toBe(false);
     expect(canAccess("SALES_EXECUTIVE", "/users")).toBe(false);
   });
+
+  it("MANAGER, SALES_EXECUTIVE y WAREHOUSE_OPERATOR no acceden al modulo /users", () => {
+    const blockedRoles: RoleCode[] = ["MANAGER", "SALES_EXECUTIVE", "WAREHOUSE_OPERATOR"];
+    const userRoutes = ["/users", "/users/new", "/users/abc", "/users/abc/edit"] as const;
+
+    for (const role of blockedRoles) {
+      for (const route of userRoutes) {
+        expect(canAccess(role, route)).toBe(false);
+      }
+    }
+  });
 });

--- a/tests/users/admin-service.integration.test.ts
+++ b/tests/users/admin-service.integration.test.ts
@@ -1,0 +1,324 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import bcrypt from "bcryptjs";
+import { PrismaClient } from "@prisma/client";
+
+const shouldRunPostgresSuite = process.env.RUN_POSTGRES_TESTS === "1"
+  && /^postgres(ql)?:\/\//i.test(String(process.env.DATABASE_URL ?? ""));
+
+const describePostgres = shouldRunPostgresSuite ? describe : describe.skip;
+
+const { requirePermissionMock, getSessionContextMock } = vi.hoisted(() => ({
+  requirePermissionMock: vi.fn(async () => ({ user: { id: "session-admin" } })),
+  getSessionContextMock: vi.fn(async () => ({
+    session: { user: { id: "session-admin", email: "session-admin@scmayher.com", name: "Session Admin", roles: ["SYSTEM_ADMIN"] } },
+    user: { id: "session-admin", email: "session-admin@scmayher.com", name: "Session Admin", roles: ["SYSTEM_ADMIN"] },
+    roles: ["SYSTEM_ADMIN"],
+    permissions: ["users.manage"],
+    isAuthenticated: true,
+    isSystemAdmin: true,
+  })),
+}));
+
+vi.mock("@/lib/rbac", () => ({
+  requirePermission: requirePermissionMock,
+}));
+
+vi.mock("@/lib/auth/session-context", () => ({
+  getSessionContext: getSessionContextMock,
+}));
+
+import { createUser, resetUserPassword, updateUser, UserAdminError } from "@/lib/users/admin-service";
+
+describePostgres("users admin service integration (postgres)", () => {
+  const prisma = new PrismaClient();
+  const runId = `KAN49-${Date.now()}`;
+
+  let roleSystemAdminId = "";
+  let roleManagerId = "";
+  let roleWarehouseId = "";
+  let sessionAdminUserId = "";
+
+  beforeAll(async () => {
+    await prisma.$connect();
+
+    const systemAdminRole = await prisma.role.upsert({
+      where: { code: "SYSTEM_ADMIN" },
+      update: { isActive: true, name: "SYSTEM_ADMIN" },
+      create: { code: "SYSTEM_ADMIN", name: "SYSTEM_ADMIN", isActive: true },
+      select: { id: true },
+    });
+    roleSystemAdminId = systemAdminRole.id;
+
+    const managerRole = await prisma.role.upsert({
+      where: { code: "MANAGER" },
+      update: { isActive: true, name: "MANAGER" },
+      create: { code: "MANAGER", name: "MANAGER", isActive: true },
+      select: { id: true },
+    });
+    roleManagerId = managerRole.id;
+
+    const warehouseRole = await prisma.role.upsert({
+      where: { code: "WAREHOUSE_OPERATOR" },
+      update: { isActive: true, name: "WAREHOUSE_OPERATOR" },
+      create: { code: "WAREHOUSE_OPERATOR", name: "WAREHOUSE_OPERATOR", isActive: true },
+      select: { id: true },
+    });
+    roleWarehouseId = warehouseRole.id;
+
+    const sessionAdminEmail = `${runId}-session-admin@scmayher.com`;
+    const sessionAdmin = await prisma.user.upsert({
+      where: { email: sessionAdminEmail },
+      update: {
+        name: "Session Admin",
+        isActive: true,
+      },
+      create: {
+        name: "Session Admin",
+        email: sessionAdminEmail,
+        passwordHash: "session-admin-hash",
+        isActive: true,
+      },
+      select: { id: true },
+    });
+    sessionAdminUserId = sessionAdmin.id;
+
+    await prisma.userRole.deleteMany({ where: { userId: sessionAdminUserId } });
+    await prisma.userRole.create({
+      data: {
+        userId: sessionAdminUserId,
+        roleId: roleSystemAdminId,
+      },
+    });
+  });
+
+  beforeEach(async () => {
+    requirePermissionMock.mockClear();
+    getSessionContextMock.mockResolvedValue({
+      session: { user: { id: sessionAdminUserId, email: `${runId}-session-admin@scmayher.com`, name: "Session Admin", roles: ["SYSTEM_ADMIN"] } },
+      user: { id: sessionAdminUserId, email: `${runId}-session-admin@scmayher.com`, name: "Session Admin", roles: ["SYSTEM_ADMIN"] },
+      roles: ["SYSTEM_ADMIN"],
+      permissions: ["users.manage"],
+      isAuthenticated: true,
+      isSystemAdmin: true,
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.userRole.deleteMany({
+      where: {
+        user: {
+          email: {
+            startsWith: `${runId}-`,
+          },
+        },
+      },
+    });
+    await prisma.auditLog.deleteMany({
+      where: {
+        source: "users/admin-service",
+      },
+    });
+    await prisma.user.deleteMany({
+      where: {
+        email: {
+          startsWith: `${runId}-`,
+        },
+      },
+    });
+    await prisma.$disconnect();
+  });
+
+  it("createUser: crea usuario activo con rol válido y audit log", async () => {
+    const created = await createUser({
+      name: "Nuevo Admin",
+      email: `${runId}-create-ok@scmayher.com`,
+      password: "Admin123*",
+      roleIds: [roleSystemAdminId],
+      isActive: true,
+    });
+
+    const [persisted, audit] = await Promise.all([
+      prisma.user.findUnique({
+        where: { id: created.id },
+        select: {
+          id: true,
+          email: true,
+          isActive: true,
+          userRoles: { select: { roleId: true } },
+        },
+      }),
+      prisma.auditLog.findFirst({
+        where: {
+          entityType: "USER",
+          entityId: created.id,
+          action: "CREATE",
+          source: "users/admin-service",
+        },
+      }),
+    ]);
+
+    expect(requirePermissionMock).toHaveBeenCalledWith("users.manage");
+    expect(persisted?.email).toBe(`${runId}-create-ok@scmayher.com`.toLowerCase());
+    expect(persisted?.isActive).toBe(true);
+    expect(persisted?.userRoles.map((entry) => entry.roleId)).toContain(roleSystemAdminId);
+    expect(audit).toBeTruthy();
+  });
+
+  it("createUser: rechaza email duplicado", async () => {
+    const duplicateEmail = `${runId}-duplicate@scmayher.com`;
+
+    await createUser({
+      name: "Duplicado Uno",
+      email: duplicateEmail,
+      password: "Admin123*",
+      roleIds: [roleManagerId],
+      isActive: true,
+    });
+
+    await expect(
+      createUser({
+        name: "Duplicado Dos",
+        email: duplicateEmail,
+        password: "Admin123*",
+        roleIds: [roleManagerId],
+        isActive: true,
+      }),
+    ).rejects.toBeInstanceOf(UserAdminError);
+  });
+
+  it("updateUser: actualiza name/email/roles/isActive, sincroniza UserRole y crea audit log", async () => {
+    const target = await createUser({
+      name: "Target Update",
+      email: `${runId}-update-target@scmayher.com`,
+      password: "Admin123*",
+      roleIds: [roleSystemAdminId],
+      isActive: true,
+    });
+
+    await updateUser(target.id, {
+      name: "Target Updated Name",
+      email: `${runId}-updated@scmayher.com`,
+      roleIds: [roleManagerId, roleWarehouseId],
+      isActive: false,
+    });
+
+    const [persisted, audit] = await Promise.all([
+      prisma.user.findUnique({
+        where: { id: target.id },
+        select: {
+          name: true,
+          email: true,
+          isActive: true,
+          userRoles: {
+            select: { role: { select: { code: true } } },
+            orderBy: { role: { code: "asc" } },
+          },
+        },
+      }),
+      prisma.auditLog.findFirst({
+        where: {
+          entityType: "USER",
+          entityId: target.id,
+          action: "UPDATE",
+          source: "users/admin-service",
+        },
+      }),
+    ]);
+
+    expect(persisted?.name).toBe("Target Updated Name");
+    expect(persisted?.email).toBe(`${runId}-updated@scmayher.com`.toLowerCase());
+    expect(persisted?.isActive).toBe(false);
+    expect(persisted?.userRoles.map((entry) => entry.role.code)).toEqual(["MANAGER", "WAREHOUSE_OPERATOR"]);
+    expect(audit).toBeTruthy();
+  });
+
+  it("updateUser: permite desactivar y reactivar usuario (soft disable)", async () => {
+    const target = await createUser({
+      name: "Toggle Target",
+      email: `${runId}-toggle@scmayher.com`,
+      password: "Admin123*",
+      roleIds: [roleManagerId],
+      isActive: true,
+    });
+
+    await updateUser(target.id, {
+      name: "Toggle Target",
+      email: `${runId}-toggle@scmayher.com`,
+      roleIds: [roleManagerId],
+      isActive: false,
+    });
+
+    let persisted = await prisma.user.findUnique({
+      where: { id: target.id },
+      select: { isActive: true },
+    });
+    expect(persisted?.isActive).toBe(false);
+
+    await updateUser(target.id, {
+      name: "Toggle Target",
+      email: `${runId}-toggle@scmayher.com`,
+      roleIds: [roleManagerId],
+      isActive: true,
+    });
+
+    persisted = await prisma.user.findUnique({
+      where: { id: target.id },
+      select: { isActive: true },
+    });
+    expect(persisted?.isActive).toBe(true);
+  });
+
+  it("updateUser: bloquea auto-desactivación de SYSTEM_ADMIN", async () => {
+    await expect(
+      updateUser(sessionAdminUserId, {
+        name: "Session Admin",
+        email: `${runId}-session-admin@scmayher.com`,
+        roleIds: [roleSystemAdminId],
+        isActive: false,
+      }),
+    ).rejects.toThrow("No puedes desactivar tu propio usuario");
+  });
+
+  it("updateUser: bloquea quitarse rol SYSTEM_ADMIN", async () => {
+    await expect(
+      updateUser(sessionAdminUserId, {
+        name: "Session Admin",
+        email: `${runId}-session-admin@scmayher.com`,
+        roleIds: [roleManagerId],
+        isActive: true,
+      }),
+    ).rejects.toThrow("No puedes quitarte el rol SYSTEM_ADMIN");
+  });
+
+  it("resetUserPassword: actualiza hash de contraseña y deja audit log", async () => {
+    const target = await createUser({
+      name: "Reset Target",
+      email: `${runId}-reset@scmayher.com`,
+      password: "Admin123*",
+      roleIds: [roleManagerId],
+      isActive: true,
+    });
+
+    const newPassword = "Admin123*NEW";
+    await resetUserPassword(target.id, newPassword);
+
+    const [persisted, audit] = await Promise.all([
+      prisma.user.findUnique({
+        where: { id: target.id },
+        select: { passwordHash: true },
+      }),
+      prisma.auditLog.findFirst({
+        where: {
+          entityType: "USER",
+          entityId: target.id,
+          action: "RESET_PASSWORD",
+          source: "users/admin-service",
+        },
+      }),
+    ]);
+
+    expect(persisted?.passwordHash).toBeTruthy();
+    expect(await bcrypt.compare(newPassword, String(persisted?.passwordHash))).toBe(true);
+    expect(audit).toBeTruthy();
+  });
+});

--- a/tests/users/admin-service.no-hard-delete.contract.test.ts
+++ b/tests/users/admin-service.no-hard-delete.contract.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("users admin service no hard delete contract", () => {
+  it("does not call prisma.user.delete or prisma.user.deleteMany", () => {
+    const source = readFileSync(resolve(process.cwd(), "lib/users/admin-service.ts"), "utf8");
+
+    expect(source).not.toContain(".user.delete(");
+    expect(source).not.toContain(".user.deleteMany(");
+    expect(source).toContain("isActive");
+  });
+});


### PR DESCRIPTION
## Ticket Jira

- KAN-49

## Resumen

PR de arranque para cerrar KAN-49 con evidencia auditable. Documenta el plan de validación requerido para el módulo de administración de usuarios, incluyendo RBAC, gestión de roles, acciones administrativas, auditoría y no exposición de información sensible.

## Alcance inicial

- Agrega `docs/jira/KAN-49-user-admin-validation-plan.md`.
- Define pruebas mínimas requeridas para `lib/users/admin-service.ts`.
- Define quality gates esperados con PostgreSQL.
- Define criterio de cierre Jira.

## Siguiente implementación requerida

- Agregar `tests/users/admin-service.integration.test.ts`.
- Ejecutar validación PostgreSQL.
- Actualizar `docs/WMS_CAPABILITIES_STATUS.md` cuando las pruebas estén en verde.

## Validación

Este PR inicial es documental. No cambia código funcional ni migraciones.

## Riesgo

No cierra KAN-49 por sí solo. Sirve como PR operativo para que Codex implemente las pruebas y deje evidencia de cierre.
