### PR TITLE
ci(KAN-53): ejecutar regresión WMS con PostgreSQL service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,49 +12,79 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://ci:ci@127.0.0.1:5432/wms?schema=public
-    
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: wms
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
-      - name: Run linter
-        run: npm run lint
-      
-      - name: TypeScript check
-        run: npx tsc --noEmit
-      
-      - name: Build application
-        run: npm run build
-      
-      - name: Prisma check
+
+      - name: Validate PostgreSQL connectivity
+        run: node scripts/db/assert-postgres-env.cjs --check-connection
+
+      - name: Prisma validate
         run: npm run prisma:validate
 
-      - name: Run automated tests
-        run: npm run test:rbac:unit && npm run test:customers:contracts
+      - name: Prisma generate
+        run: npm run prisma:generate
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: TypeScript check
+        run: npm run typecheck
+
+      - name: Run RBAC integration tests
+        run: npm run test:rbac:integration
+
+      - name: Run customer PostgreSQL integration tests
+        run: npm run test:customers:postgres
+
+      - name: Run sales service regression tests
+        run: npm run test:sales:service
+
+      - name: Run customer contract tests
+        run: npm run test:customers:contracts
+
+      - name: Build application
+        run: npm run build
 
   security:
     name: Security Audit
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
-      
+
       - name: Audit dependencies
         run: npm audit --audit-level=moderate
         continue-on-error: true

--- a/docs/jira/KAN-53-postgres-regression-ci.md
+++ b/docs/jira/KAN-53-postgres-regression-ci.md
@@ -1,0 +1,51 @@
+# KAN-53 — QA, RBAC y regresión PostgreSQL en CI
+
+Fecha de creación: 2026-04-30  
+Rama: `ci/KAN-53-postgres-regression`
+
+## Objetivo
+
+Cerrar la brecha de calidad donde CI declaraba `DATABASE_URL` PostgreSQL pero no levantaba un servicio PostgreSQL real para pruebas de integración.
+
+## Cambios aplicados
+
+- `.github/workflows/ci.yml` ahora agrega `services.postgres` con PostgreSQL 16.
+- El job `quality` valida conectividad con `node scripts/db/assert-postgres-env.cjs --check-connection`.
+- CI ejecuta Prisma validate y generate antes de pruebas.
+- CI ejecuta regresión mínima WMS:
+  - RBAC integration.
+  - Customer PostgreSQL integration.
+  - Sales service regression.
+  - Customer contract tests.
+- Build corre después de pruebas para evitar falso positivo de build sin validación funcional.
+
+## Quality gates esperados
+
+```bash
+npm ci
+node scripts/db/assert-postgres-env.cjs --check-connection
+npm run prisma:validate
+npm run prisma:generate
+npm run lint
+npm run typecheck
+npm run test:rbac:integration
+npm run test:customers:postgres
+npm run test:sales:service
+npm run test:customers:contracts
+npm run build
+```
+
+## Criterios de cierre Jira
+
+KAN-53 puede avanzar si:
+
+- El PR corre en GitHub Actions con PostgreSQL service.
+- Los checks de calidad pasan o se documentan fallos reales.
+- No requiere secretos para pruebas básicas.
+- No ejecuta migraciones destructivas fuera de entorno test.
+
+## Riesgos
+
+- Si las pruebas requieren seed adicional, el CI fallará correctamente y deberá ajustarse fixture/seed.
+- Si `next typegen` o `next build` depende de artefactos locales no versionados, CI expondrá esa deuda.
+- Este PR puede revelar fallos ocultos; no deben omitirse ni marcarse como no relacionados sin evidencia.


### PR DESCRIPTION
## Ticket Jira

- KAN-53

## Resumen

Endurece CI para ejecutar regresión WMS contra PostgreSQL real dentro de GitHub Actions.

## Cambios principales

- Agrega servicio PostgreSQL 16 al job `quality`.
- Valida conectividad con `node scripts/db/assert-postgres-env.cjs --check-connection`.
- Ejecuta `npm run prisma:validate` y `npm run prisma:generate` antes de pruebas.
- Reemplaza la regresión parcial por suites explícitas:
  - `npm run test:rbac:integration`
  - `npm run test:customers:postgres`
  - `npm run test:sales:service`
  - `npm run test:customers:contracts`
- Documenta el plan en `docs/jira/KAN-53-postgres-regression-ci.md`.

## Base de datos

- [x] Usa PostgreSQL canónico.
- [x] No requiere secretos para pruebas básicas.
- [x] Usa base efímera de CI.
- [x] No introduce SQLite como runtime operativo.

## Validación esperada en CI

```bash
npm ci
node scripts/db/assert-postgres-env.cjs --check-connection
npm run prisma:validate
npm run prisma:generate
npm run lint
npm run typecheck
npm run test:rbac:integration
npm run test:customers:postgres
npm run test:sales:service
npm run test:customers:contracts
npm run build
```

## Riesgo

Este PR puede revelar fallos reales que antes quedaban ocultos por falta de PostgreSQL en CI. Si falla, debe corregirse fixture/seed/test o deuda de build; no debe degradarse el gate sin evidencia.
