### PR TITLE
fix(KAN-9): align direct-pick server validation with zod schemas

### DIFF
--- a/app/(shell)/production/fulfillment/[id]/page.tsx
+++ b/app/(shell)/production/fulfillment/[id]/page.tsx
@@ -7,10 +7,23 @@ import { PageHeader } from "@/components/ui/page-header";
 import { InventoryServiceError } from "@/lib/inventory-service";
 import { confirmSalesRequestPickTasksBatch, releaseSalesRequestPickList } from "@/lib/sales/request-service";
 import { summarizePickListStatus } from "@/lib/sales/internal-orders";
+import { buildSalesOrderFlowSnapshot } from "@/lib/sales/flow-snapshot";
 import { startPerf } from "@/lib/perf";
 import { getRequestId } from "@/lib/request-meta";
+import {
+  firstErrorMessage,
+  salesOrderPickConfirmSchema,
+  salesOrderPickListTransitionSchema,
+} from "@/lib/schemas/wms";
+import { z } from "zod";
 
 export const dynamic = "force-dynamic";
+
+const directPickTaskConfirmSchema = z.object({
+  taskId: z.string().trim().min(1, "Tarea es obligatoria"),
+  pickedQty: z.number().finite().min(0, "Cantidad surtida invalida").nullable(),
+  shortReason: z.string().trim().nullable(),
+});
 
 function isNextRedirectError(error: unknown) {
   return Boolean(
@@ -28,8 +41,11 @@ async function releaseDirectPick(formData: FormData) {
   const requestId = await getRequestId();
   await (await import("@/lib/rbac")).requirePermission("production.execute");
 
-  const orderId = String(formData.get("orderId") ?? "").trim();
-  if (!orderId) redirect("/production");
+  const parsed = salesOrderPickListTransitionSchema.safeParse({
+    orderId: String(formData.get("orderId") ?? "").trim(),
+  });
+  if (!parsed.success) redirect("/production");
+  const { orderId } = parsed.data;
 
   try {
     const servicePerf = startPerf("action.production.fulfillment.release_direct_pick.service");
@@ -54,25 +70,38 @@ async function confirmDirectPick(formData: FormData) {
   const requestId = await getRequestId();
   await (await import("@/lib/rbac")).requirePermission("production.execute");
 
-  const orderId = String(formData.get("orderId") ?? "").trim();
-  const operatorName = String(formData.get("operatorName") ?? "").trim();
+  const orderIdRaw = String(formData.get("orderId") ?? "").trim();
+  const operatorNameRaw = String(formData.get("operatorName") ?? "").trim();
+  const parsedHeader = salesOrderPickConfirmSchema.safeParse({
+    orderId: orderIdRaw,
+    operatorName: operatorNameRaw,
+  });
+  if (!parsedHeader.success) {
+    if (!orderIdRaw) redirect("/production");
+    redirect(`/production/fulfillment/${orderIdRaw}?error=${encodeURIComponent(firstErrorMessage(parsedHeader.error))}`);
+  }
+  const { orderId, operatorName } = parsedHeader.data;
+
   const taskIds = formData
     .getAll("taskIds")
     .map((value) => String(value).trim())
     .filter(Boolean);
 
-  if (!orderId || !operatorName || taskIds.length === 0) {
+  if (taskIds.length === 0) {
     redirect(`/production/fulfillment/${orderId}?error=${encodeURIComponent("Datos de surtido invalidos")}`);
   }
 
   const tasks = taskIds.map((taskId) => {
     const pickedRaw = String(formData.get(`pickedQty__${taskId}`) ?? "").trim();
-    const shortReason = String(formData.get(`shortReason__${taskId}`) ?? "").trim() || null;
-    const pickedQty = pickedRaw === "" ? null : Number(pickedRaw);
-    if (pickedQty !== null && (!Number.isFinite(pickedQty) || pickedQty < 0)) {
-      redirect(`/production/fulfillment/${orderId}?error=${encodeURIComponent("Cantidad surtida invalida")}`);
+    const parsedTask = directPickTaskConfirmSchema.safeParse({
+      taskId,
+      pickedQty: pickedRaw === "" ? null : Number(pickedRaw),
+      shortReason: String(formData.get(`shortReason__${taskId}`) ?? "").trim() || null,
+    });
+    if (!parsedTask.success) {
+      redirect(`/production/fulfillment/${orderId}?error=${encodeURIComponent(firstErrorMessage(parsedTask.error))}`);
     }
-    return { taskId, pickedQty, shortReason };
+    return parsedTask.data;
   });
 
   try {
@@ -112,8 +141,12 @@ export default async function ProductionFulfillmentPage({
       id: true,
       code: true,
       status: true,
+      assignedToUserId: true,
+      deliveredToCustomerAt: true,
       customerName: true,
       dueDate: true,
+      updatedAt: true,
+      lines: { select: { lineKind: true } },
       warehouse: { select: { code: true, name: true } },
       pickLists: {
         orderBy: { createdAt: "desc" },
@@ -121,6 +154,7 @@ export default async function ProductionFulfillmentPage({
           id: true,
           code: true,
           status: true,
+          updatedAt: true,
           releasedAt: true,
           completedAt: true,
           targetLocation: { select: { code: true, name: true } },
@@ -161,8 +195,43 @@ export default async function ProductionFulfillmentPage({
     redirect("/production");
   }
 
+  const linkedAssemblyOrders = await prisma.productionOrder.findMany({
+    where: {
+      sourceDocumentType: "SalesInternalOrder",
+      sourceDocumentId: order.id,
+    },
+    select: {
+      status: true,
+      sourceDocumentLineId: true,
+      updatedAt: true,
+    },
+  });
+
   const activePickList = order.pickLists.find((pickList) => pickList.status !== "CANCELLED") ?? null;
   const actionableTasks = activePickList?.tasks.filter((task) => !["COMPLETED", "PARTIAL", "CANCELLED"].includes(task.status)) ?? [];
+  const hasProductLines = order.lines.some((line) => line.lineKind === "PRODUCT");
+  const hasAssemblyLines = order.lines.some((line) => line.lineKind === "CONFIGURED_ASSEMBLY");
+  const linkedAssemblyOpen = linkedAssemblyOrders.filter((row) => row.status !== "COMPLETADA" && row.status !== "CANCELADA").length;
+  const linkedAssemblyUpdatedAt = linkedAssemblyOrders
+    .map((row) => row.updatedAt)
+    .sort((a, b) => b.getTime() - a.getTime())[0] ?? null;
+  const snapshot = buildSalesOrderFlowSnapshot({
+    orderId: order.id,
+    status: order.status,
+    assignedToUserId: order.assignedToUserId,
+    deliveredToCustomerAt: order.deliveredToCustomerAt,
+    dueDate: order.dueDate,
+    orderUpdatedAt: order.updatedAt,
+    latestPickStatus: activePickList?.status ?? null,
+    latestPickUpdatedAt: activePickList?.updatedAt ?? null,
+    hasProductLines,
+    hasAssemblyLines,
+    linkedAssemblyTotal: linkedAssemblyOrders.length,
+    linkedAssemblyOpen,
+    linkedAssemblyUpdatedAt,
+    hasCompletedConfiguredAssembly: !hasAssemblyLines || (linkedAssemblyOrders.length > 0 && linkedAssemblyOpen === 0),
+    assemblyStatus: linkedAssemblyOrders[0]?.status ?? null,
+  });
 
   return (
     <div className="max-w-6xl mx-auto space-y-6">
@@ -195,6 +264,12 @@ export default async function ProductionFulfillmentPage({
           <p>Almacen: {order.warehouse ? `${order.warehouse.code} - ${order.warehouse.name}` : "--"}</p>
           <p>Fecha compromiso: {order.dueDate ? new Date(order.dueDate).toLocaleDateString("es-MX") : "--"}</p>
           <p>Estado del pedido: {order.status}</p>
+          <p className="flex flex-wrap gap-2">
+            <span className={`rounded px-2 py-1 text-xs ${snapshot.orderStatusBadgeModel.className}`}>{snapshot.orderStatusBadgeModel.label}</span>
+            <span className="rounded px-2 py-1 text-xs border border-white/10">{snapshot.pickStatusBadgeModel.label}</span>
+            <span className="rounded px-2 py-1 text-xs border border-white/10">{snapshot.riskLevel}</span>
+          </p>
+          <p className="text-xs text-slate-400">Bloqueo: {snapshot.blockingCauseLabel}</p>
         </div>
         <div className="space-y-3">
           {!activePickList ? (

--- a/app/(shell)/production/fulfillment/[id]/page.tsx
+++ b/app/(shell)/production/fulfillment/[id]/page.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from "@/components/ui/page-header";
 import { InventoryServiceError } from "@/lib/inventory-service";
 import { confirmSalesRequestPickTasksBatch, releaseSalesRequestPickList } from "@/lib/sales/request-service";
 import { summarizePickListStatus } from "@/lib/sales/internal-orders";
-import { buildSalesOrderFlowSnapshot } from "@/lib/sales/flow-snapshot";
 import { startPerf } from "@/lib/perf";
 import { getRequestId } from "@/lib/request-meta";
 import {
@@ -55,9 +54,10 @@ async function releaseDirectPick(formData: FormData) {
   } catch (error) {
     perf.end({ requestId, orderId, ok: false });
     if (isNextRedirectError(error)) throw error;
-    const message = error instanceof InventoryServiceError
-      ? error.message
-      : "Ocurrio un error inesperado al liberar el surtido directo";
+    const message =
+      error instanceof InventoryServiceError
+        ? error.message
+        : "Ocurrio un error inesperado al liberar el surtido directo";
     redirect(`/production/fulfillment/${orderId}?error=${encodeURIComponent(message)}`);
   }
 
@@ -117,9 +117,10 @@ async function confirmDirectPick(formData: FormData) {
   } catch (error) {
     perf.end({ requestId, orderId, ok: false });
     if (isNextRedirectError(error)) throw error;
-    const message = error instanceof InventoryServiceError
-      ? error.message
-      : "Ocurrio un error inesperado al confirmar el surtido";
+    const message =
+      error instanceof InventoryServiceError
+        ? error.message
+        : "Ocurrio un error inesperado al confirmar el surtido";
     redirect(`/production/fulfillment/${orderId}?error=${encodeURIComponent(message)}`);
   }
 }
@@ -141,12 +142,8 @@ export default async function ProductionFulfillmentPage({
       id: true,
       code: true,
       status: true,
-      assignedToUserId: true,
-      deliveredToCustomerAt: true,
       customerName: true,
       dueDate: true,
-      updatedAt: true,
-      lines: { select: { lineKind: true } },
       warehouse: { select: { code: true, name: true } },
       pickLists: {
         orderBy: { createdAt: "desc" },
@@ -154,7 +151,6 @@ export default async function ProductionFulfillmentPage({
           id: true,
           code: true,
           status: true,
-          updatedAt: true,
           releasedAt: true,
           completedAt: true,
           targetLocation: { select: { code: true, name: true } },
@@ -195,43 +191,9 @@ export default async function ProductionFulfillmentPage({
     redirect("/production");
   }
 
-  const linkedAssemblyOrders = await prisma.productionOrder.findMany({
-    where: {
-      sourceDocumentType: "SalesInternalOrder",
-      sourceDocumentId: order.id,
-    },
-    select: {
-      status: true,
-      sourceDocumentLineId: true,
-      updatedAt: true,
-    },
-  });
-
   const activePickList = order.pickLists.find((pickList) => pickList.status !== "CANCELLED") ?? null;
-  const actionableTasks = activePickList?.tasks.filter((task) => !["COMPLETED", "PARTIAL", "CANCELLED"].includes(task.status)) ?? [];
-  const hasProductLines = order.lines.some((line) => line.lineKind === "PRODUCT");
-  const hasAssemblyLines = order.lines.some((line) => line.lineKind === "CONFIGURED_ASSEMBLY");
-  const linkedAssemblyOpen = linkedAssemblyOrders.filter((row) => row.status !== "COMPLETADA" && row.status !== "CANCELADA").length;
-  const linkedAssemblyUpdatedAt = linkedAssemblyOrders
-    .map((row) => row.updatedAt)
-    .sort((a, b) => b.getTime() - a.getTime())[0] ?? null;
-  const snapshot = buildSalesOrderFlowSnapshot({
-    orderId: order.id,
-    status: order.status,
-    assignedToUserId: order.assignedToUserId,
-    deliveredToCustomerAt: order.deliveredToCustomerAt,
-    dueDate: order.dueDate,
-    orderUpdatedAt: order.updatedAt,
-    latestPickStatus: activePickList?.status ?? null,
-    latestPickUpdatedAt: activePickList?.updatedAt ?? null,
-    hasProductLines,
-    hasAssemblyLines,
-    linkedAssemblyTotal: linkedAssemblyOrders.length,
-    linkedAssemblyOpen,
-    linkedAssemblyUpdatedAt,
-    hasCompletedConfiguredAssembly: !hasAssemblyLines || (linkedAssemblyOrders.length > 0 && linkedAssemblyOpen === 0),
-    assemblyStatus: linkedAssemblyOrders[0]?.status ?? null,
-  });
+  const actionableTasks =
+    activePickList?.tasks.filter((task) => !["COMPLETED", "PARTIAL", "CANCELLED"].includes(task.status)) ?? [];
 
   return (
     <div className="max-w-6xl mx-auto space-y-6">
@@ -264,12 +226,6 @@ export default async function ProductionFulfillmentPage({
           <p>Almacen: {order.warehouse ? `${order.warehouse.code} - ${order.warehouse.name}` : "--"}</p>
           <p>Fecha compromiso: {order.dueDate ? new Date(order.dueDate).toLocaleDateString("es-MX") : "--"}</p>
           <p>Estado del pedido: {order.status}</p>
-          <p className="flex flex-wrap gap-2">
-            <span className={`rounded px-2 py-1 text-xs ${snapshot.orderStatusBadgeModel.className}`}>{snapshot.orderStatusBadgeModel.label}</span>
-            <span className="rounded px-2 py-1 text-xs border border-white/10">{snapshot.pickStatusBadgeModel.label}</span>
-            <span className="rounded px-2 py-1 text-xs border border-white/10">{snapshot.riskLevel}</span>
-          </p>
-          <p className="text-xs text-slate-400">Bloqueo: {snapshot.blockingCauseLabel}</p>
         </div>
         <div className="space-y-3">
           {!activePickList ? (
@@ -327,7 +283,9 @@ export default async function ProductionFulfillmentPage({
                     </div>
                     <div>
                       <p className="text-xs text-slate-400">Origen</p>
-                      <p>{task.sequence}. {task.sourceLocation.code}</p>
+                      <p>
+                        {task.sequence}. {task.sourceLocation.code}
+                      </p>
                       <p className="text-xs text-slate-500">{task.sourceLocation.name}</p>
                     </div>
                     <div>
@@ -385,7 +343,9 @@ export default async function ProductionFulfillmentPage({
               </label>
               <button
                 type="submit"
-                className={buttonStyles({ className: actionableTasks.length === 0 || activePickList.status === "DRAFT" ? "opacity-50" : "" })}
+                className={buttonStyles({
+                  className: actionableTasks.length === 0 || activePickList.status === "DRAFT" ? "opacity-50" : "",
+                })}
                 disabled={actionableTasks.length === 0 || activePickList.status === "DRAFT"}
               >
                 Confirmar surtido

--- a/docs/release/2026-05-12-direct-pick-validation-closeout.md
+++ b/docs/release/2026-05-12-direct-pick-validation-closeout.md
@@ -1,0 +1,41 @@
+# Cierre tecnico: validacion server-side de surtido directo
+
+Fecha: 2026-05-12  
+Repositorio: raul2105/WMS-Mangueras-y-conexiones
+
+## Resumen breve
+
+Se corrigio una inconsistencia de validacion server-side en el flujo de surtido directo para alinear acciones sensibles con el patron vigente del repositorio: `safeParse(...)` + `firstErrorMessage(...)` + `redirect` temprano.
+
+## Cambios realizados
+
+- Problema corregido:
+  - `app/(shell)/production/fulfillment/[id]/page.tsx` validaba `FormData` manualmente en acciones sensibles de surtido directo.
+- Archivo funcional ajustado:
+  - `app/(shell)/production/fulfillment/[id]/page.tsx`
+- Alineacion de patron de validacion:
+  - `releaseDirectPick(...)` ahora usa `salesOrderPickListTransitionSchema`.
+  - `confirmDirectPick(...)` ahora usa `salesOrderPickConfirmSchema` para cabecera (`orderId`, `operatorName`).
+  - La validacion por tarea se mantiene local en el mismo archivo mediante schema privado (`taskId`, `pickedQty`, `shortReason`) y error contract con `firstErrorMessage(...)`.
+- Cobertura de pruebas ampliada:
+  - `tests/schemas.test.ts` agrega casos para schemas de ventas y usuarios relacionados.
+
+## Validacion ejecutada
+
+1. `npm run test:postgres -- tests/schemas.test.ts`
+   - Resultado: PASS
+2. `npm run typecheck`
+   - Resultado: PASS
+
+## Alcance excluido
+
+- No se modifico logica de negocio en `lib/sales/request-service.ts`.
+- No se modificaron definiciones en `lib/schemas/wms.ts`.
+- No se cambiaron rutas ni flujo operativo fuera de validacion server-side.
+
+## Riesgo residual y seguimiento recomendado
+
+- Riesgo residual bajo: la correccion cubre el flujo puntual de surtido directo, pero puede existir brecha entre schemas declarados y cobertura operativa completa en otros flujos de ventas.
+- Seguimiento recomendado:
+  1. Cerrar la brecha restante entre schemas declarados y cobertura operativa completa en otros flujos de ventas donde aun haya parseo manual.
+  2. Mantener vigilancia de OCC/idempotencia en `SalesInternalOrder`, `PickList` y `PickTask` durante cambios de confirmacion/liberacion.

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -7,10 +7,22 @@ import {
   productionOrderCreateSchema,
   assemblyOrderHeaderSchema,
   assemblyConfigSchema,
+  assemblyOrderCancelSchema,
+  assemblyOrderConfirmHeaderSchema,
+  assemblyOrderConfirmTaskSchema,
+  assemblyOrderReleaseSchema,
   parsePriority,
   parseDueDate,
   firstErrorMessage,
+  productsLookupQuerySchema,
+  productsSearchQuerySchema,
+  salesInternalOrderAssemblyLineCreateSchema,
+  salesInternalOrderCreateSchema,
+  salesInternalOrderProductLineCreateSchema,
+  salesOrderPickConfirmSchema,
+  salesOrderPickListTransitionSchema,
 } from "../lib/schemas/wms";
+import { userCreateSchema, userResetPasswordSchema, userUpdateSchema } from "../lib/schemas/users";
 
 describe("receiveStockSchema", () => {
   const base = {
@@ -235,5 +247,198 @@ describe("firstErrorMessage", () => {
       expect(typeof msg).toBe("string");
       expect(msg.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("KAN-9 assembly order action schemas", () => {
+  it("validates release and cancel order id", () => {
+    expect(assemblyOrderReleaseSchema.safeParse({ orderId: "ord-1" }).success).toBe(true);
+    expect(assemblyOrderCancelSchema.safeParse({ orderId: "ord-1" }).success).toBe(true);
+    expect(assemblyOrderReleaseSchema.safeParse({ orderId: "" }).success).toBe(false);
+  });
+
+  it("requires operator and task ids for batch confirm", () => {
+    const ok = assemblyOrderConfirmHeaderSchema.safeParse({
+      orderId: "ord-1",
+      operatorName: "Operador",
+      taskIds: ["task-1"],
+    });
+    expect(ok.success).toBe(true);
+    expect(assemblyOrderConfirmHeaderSchema.safeParse({
+      orderId: "ord-1",
+      operatorName: "",
+      taskIds: ["task-1"],
+    }).success).toBe(false);
+  });
+
+  it("rejects negative picked quantity", () => {
+    expect(assemblyOrderConfirmTaskSchema.safeParse({
+      taskId: "task-1",
+      pickedQty: 0,
+      shortReason: null,
+    }).success).toBe(true);
+    expect(assemblyOrderConfirmTaskSchema.safeParse({
+      taskId: "task-1",
+      pickedQty: -1,
+      shortReason: null,
+    }).success).toBe(false);
+  });
+});
+
+describe("KAN-9 products query schemas", () => {
+  it("applies defaults for search query", () => {
+    const parsed = productsSearchQuerySchema.safeParse({});
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.take).toBe(6);
+      expect(parsed.data.cursor).toBe(0);
+      expect(parsed.data.q).toBe("");
+    }
+  });
+
+  it("rejects malformed numeric params", () => {
+    expect(productsSearchQuerySchema.safeParse({ take: "abc" }).success).toBe(false);
+    expect(productsSearchQuerySchema.safeParse({ cursor: "-2" }).success).toBe(false);
+    expect(productsSearchQuerySchema.safeParse({ requiredQty: "0" }).success).toBe(false);
+  });
+
+  it("normalizes lookup code", () => {
+    const parsed = productsLookupQuerySchema.safeParse({ code: "  abc  " });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.code).toBe("abc");
+  });
+});
+
+describe("sales internal order schemas", () => {
+  it("validates salesInternalOrderCreateSchema", () => {
+    expect(salesInternalOrderCreateSchema.safeParse({
+      warehouseId: "wh-1",
+      dueDateRaw: "2026-05-12",
+      customerName: "Cliente",
+    }).success).toBe(true);
+    expect(salesInternalOrderCreateSchema.safeParse({
+      warehouseId: "",
+      dueDateRaw: "2026-05-12",
+    }).success).toBe(false);
+    expect(salesInternalOrderCreateSchema.safeParse({
+      warehouseId: "wh-1",
+      dueDateRaw: "",
+    }).success).toBe(false);
+  });
+
+  it("validates salesInternalOrderProductLineCreateSchema", () => {
+    expect(salesInternalOrderProductLineCreateSchema.safeParse({
+      orderId: "ord-1",
+      productId: "prod-1",
+      requestedQtyRaw: "2",
+    }).success).toBe(true);
+    expect(salesInternalOrderProductLineCreateSchema.safeParse({
+      orderId: "ord-1",
+      productId: "prod-1",
+      requestedQtyRaw: "0",
+    }).success).toBe(false);
+    expect(salesInternalOrderProductLineCreateSchema.safeParse({
+      orderId: "ord-1",
+      productId: "",
+      requestedQtyRaw: "2",
+    }).success).toBe(false);
+  });
+
+  it("validates salesInternalOrderAssemblyLineCreateSchema", () => {
+    const base = {
+      orderId: "ord-1",
+      warehouseId: "wh-1",
+      entryFittingProductId: "entry-1",
+      hoseProductId: "hose-1",
+      exitFittingProductId: "exit-1",
+      hoseLengthRaw: "1",
+      assemblyQuantityRaw: "1",
+    };
+    expect(salesInternalOrderAssemblyLineCreateSchema.safeParse(base).success).toBe(true);
+    expect(salesInternalOrderAssemblyLineCreateSchema.safeParse({
+      ...base,
+      hoseLengthRaw: "0",
+    }).success).toBe(false);
+    expect(salesInternalOrderAssemblyLineCreateSchema.safeParse({
+      ...base,
+      assemblyQuantityRaw: "0",
+    }).success).toBe(false);
+  });
+});
+
+describe("sales pick schemas", () => {
+  it("validates salesOrderPickListTransitionSchema", () => {
+    expect(salesOrderPickListTransitionSchema.safeParse({ orderId: "ord-1" }).success).toBe(true);
+    expect(salesOrderPickListTransitionSchema.safeParse({ orderId: "" }).success).toBe(false);
+  });
+
+  it("validates salesOrderPickConfirmSchema", () => {
+    expect(salesOrderPickConfirmSchema.safeParse({
+      orderId: "ord-1",
+      operatorName: "Operador",
+    }).success).toBe(true);
+    expect(salesOrderPickConfirmSchema.safeParse({
+      orderId: "",
+      operatorName: "Operador",
+    }).success).toBe(false);
+    expect(salesOrderPickConfirmSchema.safeParse({
+      orderId: "ord-1",
+      operatorName: "",
+    }).success).toBe(false);
+  });
+});
+
+describe("user schemas", () => {
+  it("validates userCreateSchema", () => {
+    const base = {
+      name: "Usuario Demo",
+      email: "demo@wms.com",
+      password: "Segura123",
+      confirmPassword: "Segura123",
+      roleIds: ["role-1"],
+      isActive: true,
+    };
+    expect(userCreateSchema.safeParse(base).success).toBe(true);
+    expect(userCreateSchema.safeParse({
+      ...base,
+      confirmPassword: "Distinta123",
+    }).success).toBe(false);
+    expect(userCreateSchema.safeParse({
+      ...base,
+      roleIds: [],
+    }).success).toBe(false);
+  });
+
+  it("validates userUpdateSchema", () => {
+    const base = {
+      name: "Usuario Demo",
+      email: "demo@wms.com",
+      roleIds: ["role-1"],
+      isActive: true,
+    };
+    expect(userUpdateSchema.safeParse(base).success).toBe(true);
+    expect(userUpdateSchema.safeParse({
+      ...base,
+      roleIds: [],
+    }).success).toBe(false);
+    expect(userUpdateSchema.safeParse({
+      ...base,
+      email: "correo-invalido",
+    }).success).toBe(false);
+  });
+
+  it("validates userResetPasswordSchema", () => {
+    expect(userResetPasswordSchema.safeParse({
+      password: "Segura123",
+      confirmPassword: "Segura123",
+    }).success).toBe(true);
+    expect(userResetPasswordSchema.safeParse({
+      password: "123",
+      confirmPassword: "123",
+    }).success).toBe(false);
+    expect(userResetPasswordSchema.safeParse({
+      password: "Segura123",
+      confirmPassword: "NoCoincide123",
+    }).success).toBe(false);
   });
 });

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -7,15 +7,9 @@ import {
   productionOrderCreateSchema,
   assemblyOrderHeaderSchema,
   assemblyConfigSchema,
-  assemblyOrderCancelSchema,
-  assemblyOrderConfirmHeaderSchema,
-  assemblyOrderConfirmTaskSchema,
-  assemblyOrderReleaseSchema,
   parsePriority,
   parseDueDate,
   firstErrorMessage,
-  productsLookupQuerySchema,
-  productsSearchQuerySchema,
   salesInternalOrderAssemblyLineCreateSchema,
   salesInternalOrderCreateSchema,
   salesInternalOrderProductLineCreateSchema,
@@ -132,9 +126,7 @@ describe("transferStockSchema", () => {
   });
 
   it("rejects same from and to location", () => {
-    expect(
-      transferStockSchema.safeParse({ ...base, toLocationCode: "LOC-A" }).success
-    ).toBe(false);
+    expect(transferStockSchema.safeParse({ ...base, toLocationCode: "LOC-A" }).success).toBe(false);
   });
 
   it("rejects zero quantity", () => {
@@ -250,98 +242,51 @@ describe("firstErrorMessage", () => {
   });
 });
 
-describe("KAN-9 assembly order action schemas", () => {
-  it("validates release and cancel order id", () => {
-    expect(assemblyOrderReleaseSchema.safeParse({ orderId: "ord-1" }).success).toBe(true);
-    expect(assemblyOrderCancelSchema.safeParse({ orderId: "ord-1" }).success).toBe(true);
-    expect(assemblyOrderReleaseSchema.safeParse({ orderId: "" }).success).toBe(false);
-  });
-
-  it("requires operator and task ids for batch confirm", () => {
-    const ok = assemblyOrderConfirmHeaderSchema.safeParse({
-      orderId: "ord-1",
-      operatorName: "Operador",
-      taskIds: ["task-1"],
-    });
-    expect(ok.success).toBe(true);
-    expect(assemblyOrderConfirmHeaderSchema.safeParse({
-      orderId: "ord-1",
-      operatorName: "",
-      taskIds: ["task-1"],
-    }).success).toBe(false);
-  });
-
-  it("rejects negative picked quantity", () => {
-    expect(assemblyOrderConfirmTaskSchema.safeParse({
-      taskId: "task-1",
-      pickedQty: 0,
-      shortReason: null,
-    }).success).toBe(true);
-    expect(assemblyOrderConfirmTaskSchema.safeParse({
-      taskId: "task-1",
-      pickedQty: -1,
-      shortReason: null,
-    }).success).toBe(false);
-  });
-});
-
-describe("KAN-9 products query schemas", () => {
-  it("applies defaults for search query", () => {
-    const parsed = productsSearchQuerySchema.safeParse({});
-    expect(parsed.success).toBe(true);
-    if (parsed.success) {
-      expect(parsed.data.take).toBe(6);
-      expect(parsed.data.cursor).toBe(0);
-      expect(parsed.data.q).toBe("");
-    }
-  });
-
-  it("rejects malformed numeric params", () => {
-    expect(productsSearchQuerySchema.safeParse({ take: "abc" }).success).toBe(false);
-    expect(productsSearchQuerySchema.safeParse({ cursor: "-2" }).success).toBe(false);
-    expect(productsSearchQuerySchema.safeParse({ requiredQty: "0" }).success).toBe(false);
-  });
-
-  it("normalizes lookup code", () => {
-    const parsed = productsLookupQuerySchema.safeParse({ code: "  abc  " });
-    expect(parsed.success).toBe(true);
-    if (parsed.success) expect(parsed.data.code).toBe("abc");
-  });
-});
-
 describe("sales internal order schemas", () => {
   it("validates salesInternalOrderCreateSchema", () => {
-    expect(salesInternalOrderCreateSchema.safeParse({
-      warehouseId: "wh-1",
-      dueDateRaw: "2026-05-12",
-      customerName: "Cliente",
-    }).success).toBe(true);
-    expect(salesInternalOrderCreateSchema.safeParse({
-      warehouseId: "",
-      dueDateRaw: "2026-05-12",
-    }).success).toBe(false);
-    expect(salesInternalOrderCreateSchema.safeParse({
-      warehouseId: "wh-1",
-      dueDateRaw: "",
-    }).success).toBe(false);
+    expect(
+      salesInternalOrderCreateSchema.safeParse({
+        warehouseId: "wh-1",
+        dueDateRaw: "2026-05-12",
+        customerName: "Cliente",
+      }).success,
+    ).toBe(true);
+    expect(
+      salesInternalOrderCreateSchema.safeParse({
+        warehouseId: "",
+        dueDateRaw: "2026-05-12",
+      }).success,
+    ).toBe(false);
+    expect(
+      salesInternalOrderCreateSchema.safeParse({
+        warehouseId: "wh-1",
+        dueDateRaw: "",
+      }).success,
+    ).toBe(false);
   });
 
   it("validates salesInternalOrderProductLineCreateSchema", () => {
-    expect(salesInternalOrderProductLineCreateSchema.safeParse({
-      orderId: "ord-1",
-      productId: "prod-1",
-      requestedQtyRaw: "2",
-    }).success).toBe(true);
-    expect(salesInternalOrderProductLineCreateSchema.safeParse({
-      orderId: "ord-1",
-      productId: "prod-1",
-      requestedQtyRaw: "0",
-    }).success).toBe(false);
-    expect(salesInternalOrderProductLineCreateSchema.safeParse({
-      orderId: "ord-1",
-      productId: "",
-      requestedQtyRaw: "2",
-    }).success).toBe(false);
+    expect(
+      salesInternalOrderProductLineCreateSchema.safeParse({
+        orderId: "ord-1",
+        productId: "prod-1",
+        requestedQtyRaw: "2",
+      }).success,
+    ).toBe(true);
+    expect(
+      salesInternalOrderProductLineCreateSchema.safeParse({
+        orderId: "ord-1",
+        productId: "prod-1",
+        requestedQtyRaw: "0",
+      }).success,
+    ).toBe(false);
+    expect(
+      salesInternalOrderProductLineCreateSchema.safeParse({
+        orderId: "ord-1",
+        productId: "",
+        requestedQtyRaw: "2",
+      }).success,
+    ).toBe(false);
   });
 
   it("validates salesInternalOrderAssemblyLineCreateSchema", () => {
@@ -355,14 +300,18 @@ describe("sales internal order schemas", () => {
       assemblyQuantityRaw: "1",
     };
     expect(salesInternalOrderAssemblyLineCreateSchema.safeParse(base).success).toBe(true);
-    expect(salesInternalOrderAssemblyLineCreateSchema.safeParse({
-      ...base,
-      hoseLengthRaw: "0",
-    }).success).toBe(false);
-    expect(salesInternalOrderAssemblyLineCreateSchema.safeParse({
-      ...base,
-      assemblyQuantityRaw: "0",
-    }).success).toBe(false);
+    expect(
+      salesInternalOrderAssemblyLineCreateSchema.safeParse({
+        ...base,
+        hoseLengthRaw: "0",
+      }).success,
+    ).toBe(false);
+    expect(
+      salesInternalOrderAssemblyLineCreateSchema.safeParse({
+        ...base,
+        assemblyQuantityRaw: "0",
+      }).success,
+    ).toBe(false);
   });
 });
 
@@ -373,18 +322,24 @@ describe("sales pick schemas", () => {
   });
 
   it("validates salesOrderPickConfirmSchema", () => {
-    expect(salesOrderPickConfirmSchema.safeParse({
-      orderId: "ord-1",
-      operatorName: "Operador",
-    }).success).toBe(true);
-    expect(salesOrderPickConfirmSchema.safeParse({
-      orderId: "",
-      operatorName: "Operador",
-    }).success).toBe(false);
-    expect(salesOrderPickConfirmSchema.safeParse({
-      orderId: "ord-1",
-      operatorName: "",
-    }).success).toBe(false);
+    expect(
+      salesOrderPickConfirmSchema.safeParse({
+        orderId: "ord-1",
+        operatorName: "Operador",
+      }).success,
+    ).toBe(true);
+    expect(
+      salesOrderPickConfirmSchema.safeParse({
+        orderId: "",
+        operatorName: "Operador",
+      }).success,
+    ).toBe(false);
+    expect(
+      salesOrderPickConfirmSchema.safeParse({
+        orderId: "ord-1",
+        operatorName: "",
+      }).success,
+    ).toBe(false);
   });
 });
 
@@ -399,14 +354,18 @@ describe("user schemas", () => {
       isActive: true,
     };
     expect(userCreateSchema.safeParse(base).success).toBe(true);
-    expect(userCreateSchema.safeParse({
-      ...base,
-      confirmPassword: "Distinta123",
-    }).success).toBe(false);
-    expect(userCreateSchema.safeParse({
-      ...base,
-      roleIds: [],
-    }).success).toBe(false);
+    expect(
+      userCreateSchema.safeParse({
+        ...base,
+        confirmPassword: "Distinta123",
+      }).success,
+    ).toBe(false);
+    expect(
+      userCreateSchema.safeParse({
+        ...base,
+        roleIds: [],
+      }).success,
+    ).toBe(false);
   });
 
   it("validates userUpdateSchema", () => {
@@ -417,28 +376,38 @@ describe("user schemas", () => {
       isActive: true,
     };
     expect(userUpdateSchema.safeParse(base).success).toBe(true);
-    expect(userUpdateSchema.safeParse({
-      ...base,
-      roleIds: [],
-    }).success).toBe(false);
-    expect(userUpdateSchema.safeParse({
-      ...base,
-      email: "correo-invalido",
-    }).success).toBe(false);
+    expect(
+      userUpdateSchema.safeParse({
+        ...base,
+        roleIds: [],
+      }).success,
+    ).toBe(false);
+    expect(
+      userUpdateSchema.safeParse({
+        ...base,
+        email: "correo-invalido",
+      }).success,
+    ).toBe(false);
   });
 
   it("validates userResetPasswordSchema", () => {
-    expect(userResetPasswordSchema.safeParse({
-      password: "Segura123",
-      confirmPassword: "Segura123",
-    }).success).toBe(true);
-    expect(userResetPasswordSchema.safeParse({
-      password: "123",
-      confirmPassword: "123",
-    }).success).toBe(false);
-    expect(userResetPasswordSchema.safeParse({
-      password: "Segura123",
-      confirmPassword: "NoCoincide123",
-    }).success).toBe(false);
+    expect(
+      userResetPasswordSchema.safeParse({
+        password: "Segura123",
+        confirmPassword: "Segura123",
+      }).success,
+    ).toBe(true);
+    expect(
+      userResetPasswordSchema.safeParse({
+        password: "123",
+        confirmPassword: "123",
+      }).success,
+    ).toBe(false);
+    expect(
+      userResetPasswordSchema.safeParse({
+        password: "Segura123",
+        confirmPassword: "NoCoincide123",
+      }).success,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Problema corregido
Se corrige inconsistencia de validacion server-side en surtido directo (`fulfillment/[id]`) donde habia parseo manual de `FormData` en acciones sensibles.

## Archivos incluidos
- `app/(shell)/production/fulfillment/[id]/page.tsx`
- `tests/schemas.test.ts`
- `docs/release/2026-05-12-direct-pick-validation-closeout.md`

## Schemas aplicados
- `salesOrderPickListTransitionSchema`
- `salesOrderPickConfirmSchema`

## Validacion local por tarea
Se mantiene validacion local por tarea en `fulfillment/[id]` con schema privado (sin nueva capa compartida).

## Alcance excluido
- sin cambios en `lib/sales/request-service.ts`
- sin cambios en `lib/schemas/wms.ts`
- sin mezcla con otros frentes KAN-9

## Evidencia
- `npm run test:postgres -- tests/schemas.test.ts` ✅
- `npm run typecheck` ✅