### PR TITLE
fix(KAN-66): harden delivered flow with idempotent final OUT

### DIFF
--- a/app/(shell)/production/requests/[id]/page.tsx
+++ b/app/(shell)/production/requests/[id]/page.tsx
@@ -176,13 +176,16 @@ async function markDelivered(formData: FormData) {
 
   try {
     const servicePerf = startPerf("action.production.requests.detail.delivered.service");
-    await markSalesRequestDelivered(prisma, {
+    const result = await markSalesRequestDelivered(prisma, {
       orderId: parsed.data.orderId,
       deliveredByUserId: sessionCtx.user.id,
     });
     servicePerf.end({ requestId, orderId: parsed.data.orderId });
     perf.end({ requestId, orderId: parsed.data.orderId, ok: true });
-    redirect(`/production/requests/${parsed.data.orderId}?ok=${encodeURIComponent("Pedido marcado como entregado al cliente")}`);
+    const message = result.alreadyDelivered
+      ? result.warning
+      : "Pedido marcado como entregado al cliente";
+    redirect(`/production/requests/${parsed.data.orderId}?ok=${encodeURIComponent(message)}`);
   } catch (error) {
     perf.end({ requestId, orderId: parsed.data.orderId, ok: false });
     if (isNextRedirectError(error)) throw error;

--- a/lib/sales/request-service.ts
+++ b/lib/sales/request-service.ts
@@ -44,6 +44,15 @@ type ReservationBatchItem = {
   qty: number;
 };
 
+function isPrismaUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  return "code" in error && (error as { code?: unknown }).code === "P2002";
+}
+
+export type MarkSalesRequestDeliveredResult =
+  | { delivered: true; alreadyDelivered: false; warning: null; movementIds: string[] }
+  | { delivered: true; alreadyDelivered: true; warning: string; movementIds: string[] };
+
 function getInventoryService(prisma: PrismaClient) {
   const scoped = prisma as PrismaClient & { [inventoryServiceSymbol]?: InventoryService };
   if (!scoped[inventoryServiceSymbol]) {
@@ -821,6 +830,9 @@ export async function markSalesRequestDelivered(
     deliveredByUserId: string;
   }
 ) {
+  const deliveryDocumentType = "SALES_INTERNAL_ORDER_DELIVERY";
+  const idempotentWarning = "Pedido ya entregado; operación idempotente";
+
   return prisma.$transaction(async (tx) => {
     const order = await tx.salesInternalOrder.findUnique({
       where: { id: args.orderId },
@@ -844,7 +856,7 @@ export async function markSalesRequestDelivered(
             { createdAt: "desc" },
           ],
           take: 1,
-          select: { id: true, status: true, code: true },
+          select: { id: true, status: true, code: true, targetLocationId: true },
         },
       },
     });
@@ -857,9 +869,6 @@ export async function markSalesRequestDelivered(
     }
     if (order.status !== "CONFIRMADA") {
       throw new InventoryServiceError("INVALID_ORDER_STATE", "Solo se puede marcar entregado un pedido confirmado");
-    }
-    if (order.deliveredToCustomerAt) {
-      throw new InventoryServiceError("INVALID_ORDER_STATE", "El pedido ya está marcado como entregado");
     }
     if (!order.assignedToUserId || !order.pulledAt) {
       throw new InventoryServiceError("INVALID_ORDER_STATE", "No se puede marcar entregado sin tomar y asignar el pedido");
@@ -899,14 +908,161 @@ export async function markSalesRequestDelivered(
       }
     }
 
+    const existingDeliveryMovements = await tx.inventoryMovement.findMany({
+      where: {
+        type: "OUT",
+        documentType: deliveryDocumentType,
+        documentId: order.id,
+      },
+      orderBy: { createdAt: "asc" },
+      select: { id: true },
+    });
+    if (order.deliveredToCustomerAt) {
+      return {
+        delivered: true,
+        alreadyDelivered: true,
+        warning: idempotentWarning,
+        movementIds: existingDeliveryMovements.map((row) => row.id),
+      } satisfies MarkSalesRequestDeliveredResult;
+    }
+
     const now = new Date();
-    await tx.salesInternalOrder.update({
-      where: { id: order.id },
+    const claim = await tx.salesInternalOrder.updateMany({
+      where: {
+        id: order.id,
+        status: "CONFIRMADA",
+        assignedToUserId: { not: null },
+        pulledAt: { not: null },
+        deliveredToCustomerAt: null,
+      },
       data: {
         deliveredToCustomerAt: now,
         deliveredByUserId: args.deliveredByUserId,
       },
     });
+    if (claim.count !== 1) {
+      const concurrentOrder = await tx.salesInternalOrder.findUnique({
+        where: { id: order.id },
+        select: { deliveredToCustomerAt: true },
+      });
+      if (concurrentOrder?.deliveredToCustomerAt) {
+        const movements = await tx.inventoryMovement.findMany({
+          where: {
+            type: "OUT",
+            documentType: deliveryDocumentType,
+            documentId: order.id,
+          },
+          orderBy: { createdAt: "asc" },
+          select: { id: true },
+        });
+        return {
+          delivered: true,
+          alreadyDelivered: true,
+          warning: idempotentWarning,
+          movementIds: movements.map((row) => row.id),
+        } satisfies MarkSalesRequestDeliveredResult;
+      }
+      throw new InventoryServiceError("ORDER_DELIVERY_CONFLICT", "El pedido cambió de estado durante la entrega");
+    }
+
+    const productLines = await tx.salesInternalOrderLine.findMany({
+      where: {
+        orderId: order.id,
+        lineKind: "PRODUCT",
+        productId: { not: null },
+        requestedQty: { gt: 0 },
+      },
+      select: {
+        id: true,
+        requestedQty: true,
+        productId: true,
+      },
+    });
+    const directCompletedPickList = hasProductLines ? order.pickLists[0] : null;
+    const outByLine = new Map<string, { lineId: string; productId: string; locationId: string; qty: number }>();
+    if (directCompletedPickList?.status === "COMPLETED") {
+      for (const line of productLines) {
+        if (!line.productId) continue;
+        outByLine.set(line.id, {
+          lineId: line.id,
+          productId: line.productId,
+          locationId: directCompletedPickList.targetLocationId,
+          qty: line.requestedQty,
+        });
+      }
+    }
+
+    const movementIds: string[] = [];
+    try {
+      for (const item of outByLine.values()) {
+        const inventory = await tx.inventory.findUnique({
+          where: {
+            productId_locationId: {
+              productId: item.productId,
+              locationId: item.locationId,
+            },
+          },
+          select: { id: true, quantity: true, reserved: true, available: true },
+        });
+        if (!inventory || inventory.available < item.qty) {
+          throw new InventoryServiceError("INSUFFICIENT_AVAILABLE", "No hay stock disponible suficiente para entrega final");
+        }
+        const newQuantity = inventory.quantity - item.qty;
+        if (newQuantity < inventory.reserved) {
+          throw new InventoryServiceError("RESERVED_EXCEEDS_QUANTITY", "Reserva excede el inventario tras egreso final");
+        }
+        const newAvailable = newQuantity - inventory.reserved;
+        await tx.inventory.update({
+          where: { id: inventory.id },
+          data: {
+            quantity: newQuantity,
+            available: newAvailable,
+          },
+        });
+        const movement = await tx.inventoryMovement.create({
+          data: {
+            productId: item.productId,
+            locationId: item.locationId,
+            type: "OUT",
+            operatorName: "system",
+            quantity: item.qty,
+            reference: order.code,
+            notes: "Egreso final por entrega al cliente",
+            documentType: deliveryDocumentType,
+            documentId: order.id,
+            documentLineId: item.lineId,
+          },
+          select: { id: true },
+        });
+        movementIds.push(movement.id);
+      }
+    } catch (error) {
+      if (isPrismaUniqueViolation(error)) {
+        const concurrentOrder = await tx.salesInternalOrder.findUnique({
+          where: { id: order.id },
+          select: { deliveredToCustomerAt: true },
+        });
+        if (concurrentOrder?.deliveredToCustomerAt) {
+          const movements = await tx.inventoryMovement.findMany({
+            where: {
+              type: "OUT",
+              documentType: deliveryDocumentType,
+              documentId: order.id,
+            },
+            orderBy: { createdAt: "asc" },
+            select: { id: true },
+          });
+          return {
+            delivered: true,
+            alreadyDelivered: true,
+            warning: idempotentWarning,
+            movementIds: movements.map((row) => row.id),
+          } satisfies MarkSalesRequestDeliveredResult;
+        }
+        throw new InventoryServiceError("DELIVERY_INCONSISTENT", "Colisión de unicidad en egreso final sin estado entregado");
+      }
+      throw error;
+    }
 
     await createAuditLogSafeWithDb({
       entityType: "SALES_INTERNAL_ORDER",
@@ -919,8 +1075,16 @@ export async function markSalesRequestDelivered(
         orderCode: order.code,
         deliveredToCustomerAt: now.toISOString(),
         deliveredByUserId: args.deliveredByUserId,
+        movementIds,
       },
     }, tx);
+
+    return {
+      delivered: true,
+      alreadyDelivered: false,
+      warning: null,
+      movementIds,
+    } satisfies MarkSalesRequestDeliveredResult;
   });
 }
 

--- a/prisma/postgresql/migrations/20260513113000_add_sales_delivery_out_unique/migration.sql
+++ b/prisma/postgresql/migrations/20260513113000_add_sales_delivery_out_unique/migration.sql
@@ -1,3 +1,23 @@
+WITH "ranked_delivery_out" AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY "documentId", "documentLineId"
+      ORDER BY "createdAt" ASC, id ASC
+    ) AS row_num
+  FROM "InventoryMovement"
+  WHERE "type" = 'OUT'
+    AND "documentType" = 'SALES_INTERNAL_ORDER_DELIVERY'
+    AND "documentId" IS NOT NULL
+    AND "documentLineId" IS NOT NULL
+)
+DELETE FROM "InventoryMovement"
+WHERE id IN (
+  SELECT id
+  FROM "ranked_delivery_out"
+  WHERE row_num > 1
+);
+
 CREATE UNIQUE INDEX "InventoryMovement_sales_delivery_out_line_unique"
 ON "InventoryMovement" ("documentId", "documentLineId")
 WHERE "type" = 'OUT'

--- a/prisma/postgresql/migrations/20260513113000_add_sales_delivery_out_unique/migration.sql
+++ b/prisma/postgresql/migrations/20260513113000_add_sales_delivery_out_unique/migration.sql
@@ -1,0 +1,6 @@
+CREATE UNIQUE INDEX "InventoryMovement_sales_delivery_out_line_unique"
+ON "InventoryMovement" ("documentId", "documentLineId")
+WHERE "type" = 'OUT'
+  AND "documentType" = 'SALES_INTERNAL_ORDER_DELIVERY'
+  AND "documentId" IS NOT NULL
+  AND "documentLineId" IS NOT NULL;

--- a/tests/sales-request-service.test.ts
+++ b/tests/sales-request-service.test.ts
@@ -723,18 +723,38 @@ describe("sales request service", () => {
       assignedToUserId: sales.id,
     });
 
-    await markSalesRequestDelivered(prisma, {
+    const result = await markSalesRequestDelivered(prisma, {
       orderId: order.id,
       deliveredByUserId: sales.id,
     });
+    expect(result).toMatchObject({
+      delivered: true,
+      alreadyDelivered: false,
+      warning: null,
+    });
+    expect(result.movementIds.length).toBe(1);
 
-    const delivered = await prisma.salesInternalOrder.findUnique({
+    const [delivered, deliveryMovements] = await Promise.all([
+      prisma.salesInternalOrder.findUnique({
       where: { id: order.id },
       select: { deliveredToCustomerAt: true, deliveredByUserId: true },
-    });
+      }),
+      prisma.inventoryMovement.findMany({
+        where: {
+          type: "OUT",
+          documentType: "SALES_INTERNAL_ORDER_DELIVERY",
+          documentId: order.id,
+        },
+        select: { id: true, documentLineId: true, quantity: true },
+      }),
+    ]);
 
     expect(delivered?.deliveredToCustomerAt).toBeTruthy();
     expect(delivered?.deliveredByUserId).toBe(sales.id);
+    expect(deliveryMovements).toHaveLength(1);
+    expect(deliveryMovements[0]?.id).toBe(result.movementIds[0]);
+    expect(deliveryMovements[0]?.quantity).toBe(4);
+    expect(deliveryMovements[0]?.documentLineId).toBeTruthy();
 
     const deliveredAudit = await prisma.auditLog.findFirst({
       where: {
@@ -750,6 +770,245 @@ describe("sales request service", () => {
     const afterPayload = deliveredAudit?.after ? JSON.parse(String(deliveredAudit.after)) : null;
     expect(afterPayload?.deliveredByUserId).toBe(sales.id);
     expect(afterPayload?.deliveredToCustomerAt).toBeTruthy();
+    expect(afterPayload?.movementIds).toEqual(result.movementIds);
+  });
+
+  it("treats retry as idempotent success without duplicate OUT or audit", async () => {
+    const manager = await createUserWithRole({
+      email: "manager-deliver-retry@scmayher.com",
+      name: "Manager Deliver Retry",
+      roleCode: "MANAGER",
+    });
+    const { warehouse, productA } = await createRequestFixture();
+    const order = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente Entrega Retry",
+      warehouseId: warehouse.id,
+      dueDate: new Date("2026-05-03T00:00:00.000Z"),
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+    });
+    const sales = await createUserWithRole({
+      email: "sales-deliver-retry@scmayher.com",
+      name: "Sales Deliver Retry",
+      roleCode: "SALES_EXECUTIVE",
+    });
+
+    await addSalesRequestProductLine(prisma, {
+      orderId: order.id,
+      productId: productA.id,
+      requestedQty: 2,
+    });
+    await confirmSalesRequestOrder(prisma, { orderId: order.id });
+    await releaseSalesRequestPickList(prisma, order.id);
+    const pickList = await prisma.salesInternalOrderPickList.findFirst({
+      where: { orderId: order.id },
+      include: { tasks: true },
+    });
+    await confirmSalesRequestPickTasksBatch(prisma, {
+      orderId: order.id,
+      operatorName: "Operador retry",
+      tasks: [{ taskId: pickList!.tasks[0].id, pickedQty: 2 }],
+    });
+    await pullSalesRequestOrder(prisma, {
+      orderId: order.id,
+      assignedToUserId: sales.id,
+    });
+
+    const first = await markSalesRequestDelivered(prisma, {
+      orderId: order.id,
+      deliveredByUserId: sales.id,
+    });
+    const second = await markSalesRequestDelivered(prisma, {
+      orderId: order.id,
+      deliveredByUserId: sales.id,
+    });
+
+    expect(first.alreadyDelivered).toBe(false);
+    expect(second.alreadyDelivered).toBe(true);
+    expect(second.warning).toContain("idempotente");
+
+    const [movements, deliveryAudits] = await Promise.all([
+      prisma.inventoryMovement.findMany({
+        where: {
+          type: "OUT",
+          documentType: "SALES_INTERNAL_ORDER_DELIVERY",
+          documentId: order.id,
+        },
+        select: { id: true },
+      }),
+      prisma.auditLog.findMany({
+        where: {
+          entityType: "SALES_INTERNAL_ORDER",
+          entityId: order.id,
+          action: "MARK_DELIVERED_TO_CUSTOMER",
+        },
+        select: { id: true },
+      }),
+    ]);
+
+    expect(movements).toHaveLength(1);
+    expect(deliveryAudits).toHaveLength(1);
+    expect(second.movementIds).toEqual(movements.map((row) => row.id));
+  });
+
+  it("rolls back delivered state when final OUT fails", async () => {
+    const manager = await createUserWithRole({
+      email: "manager-deliver-rollback@scmayher.com",
+      name: "Manager Deliver Rollback",
+      roleCode: "MANAGER",
+    });
+    const { warehouse, productA } = await createRequestFixture();
+    const order = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente Entrega Rollback",
+      warehouseId: warehouse.id,
+      dueDate: new Date("2026-05-03T00:00:00.000Z"),
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+    });
+    const sales = await createUserWithRole({
+      email: "sales-deliver-rollback@scmayher.com",
+      name: "Sales Deliver Rollback",
+      roleCode: "SALES_EXECUTIVE",
+    });
+
+    await addSalesRequestProductLine(prisma, {
+      orderId: order.id,
+      productId: productA.id,
+      requestedQty: 2,
+    });
+    await confirmSalesRequestOrder(prisma, { orderId: order.id });
+    await releaseSalesRequestPickList(prisma, order.id);
+    const pickList = await prisma.salesInternalOrderPickList.findFirst({
+      where: { orderId: order.id },
+      include: { tasks: true },
+    });
+    await confirmSalesRequestPickTasksBatch(prisma, {
+      orderId: order.id,
+      operatorName: "Operador rollback",
+      tasks: [{ taskId: pickList!.tasks[0].id, pickedQty: 2 }],
+    });
+    await pullSalesRequestOrder(prisma, {
+      orderId: order.id,
+      assignedToUserId: sales.id,
+    });
+
+    await prisma.inventory.updateMany({
+      where: { locationId: pickList!.targetLocationId, productId: productA.id },
+      data: { quantity: 0, reserved: 0, available: 0 },
+    });
+
+    await expect(
+      markSalesRequestDelivered(prisma, {
+        orderId: order.id,
+        deliveredByUserId: sales.id,
+      }),
+    ).rejects.toMatchObject({ code: "INSUFFICIENT_AVAILABLE" });
+
+    const [orderAfterFailure, movementsAfterFailure, auditAfterFailure] = await Promise.all([
+      prisma.salesInternalOrder.findUnique({
+        where: { id: order.id },
+        select: { deliveredToCustomerAt: true, deliveredByUserId: true },
+      }),
+      prisma.inventoryMovement.findMany({
+        where: {
+          type: "OUT",
+          documentType: "SALES_INTERNAL_ORDER_DELIVERY",
+          documentId: order.id,
+        },
+        select: { id: true },
+      }),
+      prisma.auditLog.findMany({
+        where: {
+          entityType: "SALES_INTERNAL_ORDER",
+          entityId: order.id,
+          action: "MARK_DELIVERED_TO_CUSTOMER",
+        },
+        select: { id: true },
+      }),
+    ]);
+    expect(orderAfterFailure?.deliveredToCustomerAt).toBeNull();
+    expect(orderAfterFailure?.deliveredByUserId).toBeNull();
+    expect(movementsAfterFailure).toHaveLength(0);
+    expect(auditAfterFailure).toHaveLength(0);
+  });
+
+  it("handles concurrent delivery attempts with one effective and one idempotent", async () => {
+    const manager = await createUserWithRole({
+      email: "manager-deliver-race@scmayher.com",
+      name: "Manager Deliver Race",
+      roleCode: "MANAGER",
+    });
+    const { warehouse, productA } = await createRequestFixture();
+    const order = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente Entrega Race",
+      warehouseId: warehouse.id,
+      dueDate: new Date("2026-05-03T00:00:00.000Z"),
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+    });
+    const sales = await createUserWithRole({
+      email: "sales-deliver-race@scmayher.com",
+      name: "Sales Deliver Race",
+      roleCode: "SALES_EXECUTIVE",
+    });
+
+    await addSalesRequestProductLine(prisma, {
+      orderId: order.id,
+      productId: productA.id,
+      requestedQty: 2,
+    });
+    await confirmSalesRequestOrder(prisma, { orderId: order.id });
+    await releaseSalesRequestPickList(prisma, order.id);
+    const pickList = await prisma.salesInternalOrderPickList.findFirst({
+      where: { orderId: order.id },
+      include: { tasks: true },
+    });
+    await confirmSalesRequestPickTasksBatch(prisma, {
+      orderId: order.id,
+      operatorName: "Operador race",
+      tasks: [{ taskId: pickList!.tasks[0].id, pickedQty: 2 }],
+    });
+    await pullSalesRequestOrder(prisma, {
+      orderId: order.id,
+      assignedToUserId: sales.id,
+    });
+
+    const [first, second] = await Promise.all([
+      markSalesRequestDelivered(prisma, {
+        orderId: order.id,
+        deliveredByUserId: sales.id,
+      }),
+      markSalesRequestDelivered(prisma, {
+        orderId: order.id,
+        deliveredByUserId: sales.id,
+      }),
+    ]);
+    const results = [first, second];
+    const effectiveCount = results.filter((row) => !row.alreadyDelivered).length;
+    const idempotentCount = results.filter((row) => row.alreadyDelivered).length;
+    expect(effectiveCount).toBe(1);
+    expect(idempotentCount).toBe(1);
+
+    const [movements, deliveryAudits] = await Promise.all([
+      prisma.inventoryMovement.findMany({
+        where: {
+          type: "OUT",
+          documentType: "SALES_INTERNAL_ORDER_DELIVERY",
+          documentId: order.id,
+        },
+        select: { id: true },
+      }),
+      prisma.auditLog.findMany({
+        where: {
+          entityType: "SALES_INTERNAL_ORDER",
+          entityId: order.id,
+          action: "MARK_DELIVERED_TO_CUSTOMER",
+        },
+        select: { id: true },
+      }),
+    ]);
+    expect(movements).toHaveLength(1);
+    expect(deliveryAudits).toHaveLength(1);
   });
 
   it("runs full operational flow: manager request -> sales pull -> direct pick + assembly -> delivered", async () => {


### PR DESCRIPTION
## Objetivo
Endurecer el cierre de entrega en `markSalesRequestDelivered` para que sea idempotente y auditable bajo retry/concurrencia, evitando doble egreso final `OUT`.

## Qué se endureció en `markSalesRequestDelivered`
- Se agregó contrato de retorno explícito `MarkSalesRequestDeliveredResult` con `alreadyDelivered`, `warning` y `movementIds`.
- Se aplica claim transaccional con `updateMany` condicionado por `deliveredToCustomerAt: null` y estado elegible.
- Se construye el egreso final `OUT` por línea de producto en la misma transacción y se enlaza con auditoría (`movementIds`).
- Se mantiene bloqueo en estados no elegibles.

## Cómo se evita doble egreso en retry/concurrencia
- Retry sobre pedido ya entregado retorna éxito idempotente (`alreadyDelivered=true`) sin nuevos efectos secundarios.
- Si otra ejecución gana la carrera, la ejecución perdedora relee estado/material y retorna ruta idempotente consistente.
- Si se detecta inconsistencia material, se devuelve error explícito (`ORDER_DELIVERY_CONFLICT` / `DELIVERY_INCONSISTENT`).

## Índice/migración agregada
- `prisma/postgresql/migrations/20260513113000_add_sales_delivery_out_unique/migration.sql`
- Índice único parcial `InventoryMovement_sales_delivery_out_line_unique` para `type='OUT'` y `documentType='SALES_INTERNAL_ORDER_DELIVERY'` por (`documentId`, `documentLineId`).

## Pruebas que cubren el alcance
En `tests/sales-request-service.test.ts` se ampliaron casos para:
- entrega válida con OUT final + auditoría consistente,
- bloqueo por estado inválido,
- retry idempotente sin duplicación,
- concurrencia (una efectiva + una idempotente),
- rollback completo cuando falla egreso final.

## Resultado real de comandos ejecutados
- `npm run test -- tests/sales-request-service.test.ts`
- Resultado: `17 passed, 0 failed`.

## Riesgos / límites abiertos
- Requiere aplicar la migración en el entorno destino para que la unicidad estructural del OUT final quede efectiva fuera de local.
