### PR TITLE
hardening(auth): proteger /api/perf/snapshot con RBAC audit.view

### DIFF
--- a/app/api/perf/snapshot/route.ts
+++ b/app/api/perf/snapshot/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from "next/server";
 import { getSnapshot, clearSnapshot } from "@/lib/perf-snapshot";
+import { requirePermission } from "@/lib/rbac";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  await requirePermission("audit.view");
   if (process.env.NODE_ENV === "production" && process.env.PERF_SNAPSHOT_ENABLED !== "true") {
     return NextResponse.json({ error: "disabled in production" }, { status: 404 });
   }
@@ -11,6 +13,7 @@ export async function GET() {
 }
 
 export async function DELETE() {
+  await requirePermission("audit.view");
   if (process.env.NODE_ENV === "production" && process.env.PERF_SNAPSHOT_ENABLED !== "true") {
     return NextResponse.json({ error: "disabled in production" }, { status: 404 });
   }

--- a/tests/rbac/server-actions-guards.integration.test.ts
+++ b/tests/rbac/server-actions-guards.integration.test.ts
@@ -106,4 +106,10 @@ describe("rbac guards in critical server actions/pages", () => {
     expect(newContent).toContain('requirePermission("customers.manage")');
     expect(editContent).toContain('requirePermission("customers.manage")');
   });
+
+  it("perf snapshot api enforces audit.view", () => {
+    const content = readWorkspaceFile("app/api/perf/snapshot/route.ts");
+
+    expect(content).toContain('requirePermission("audit.view")');
+  });
 });


### PR DESCRIPTION
### Motivation
- Detecté que el endpoint de observabilidad `/api/perf/snapshot` quedaba protegido solo por flags de entorno y no por control RBAC explícito, lo que deja una superficie sensible con control demasiado débil/tardío.
- Alinear la frontera de seguridad para que proxy/middleware haga checks tempranos ligeros y la autorización sensible viva en handlers/servicios según la regla de separación indicada.
- Trabajo orientado a reducir deuda técnica de auth/RBAC referenciada en la documentación local (p. ej. `KAN-25`, `KAN-53`).

### Description
- Añadí la importación y llamada a `requirePermission("audit.view")` en los handlers `GET` y `DELETE` de `app/api/perf/snapshot/route.ts` para exigir autorización en el handler.
- Añadí una aserción en `tests/rbac/server-actions-guards.integration.test.ts` que verifica que el archivo `app/api/perf/snapshot/route.ts` contiene `requirePermission("audit.view")` para evitar regresiones.
- Mantengo `proxy.ts` sin cambios funcionales y mantengo la responsabilidad del proxy como check temprano de auth, desplazando el control sensible al handler.
- Archivos modificados: `app/api/perf/snapshot/route.ts` y `tests/rbac/server-actions-guards.integration.test.ts`.

### Testing
- Ejecuté `npx vitest run tests/rbac/server-actions-guards.integration.test.ts` y la suite específica pasó con `13 tests, 0 failures` (verde).
- Intenté `npm run -s test:rbac:integration -- tests/rbac/server-actions-guards.integration.test.ts` pero falló por entorno local sin `DATABASE_URL` y no por regresión de código; esto es una limitación de entorno, no del cambio.
- Recomendación de validación adicional: ejecutar `npm run test:rbac:integration` completo en CI/entorno con `DATABASE_URL` disponible para cerrar la validación nocturna de regresiones RBAC.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15107f3f54832bae061795d067affe)