### PR TITLE
chore(KAN-53): harden CI for Next/OpenNext deploy path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   quality:
@@ -62,6 +73,9 @@ jobs:
       - name: Build application
         run: npm run build
 
+      - name: Build OpenNext artifact
+        run: npm run build:opennext
+
   security:
     name: Security Audit (optional)
     runs-on: ubuntu-latest
@@ -104,3 +118,57 @@ jobs:
 
       - name: Run published smoke tests
         run: npm run smoke:published
+
+  nightly-full-regression:
+    name: Nightly Full PostgreSQL Regression (scheduled/manual)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: wms
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U ci -d wms"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      DATABASE_URL: postgresql://ci:ci@127.0.0.1:5432/wms?schema=public
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prisma check
+        run: npm run prisma:validate
+
+      - name: Prisma generate
+        run: npm run prisma:generate
+
+      - name: Sync test schema (PostgreSQL)
+        run: npm run db:push
+
+      - name: Run full PostgreSQL suite
+        run: npm run test:postgres
+
+      - name: Build Next.js runtime
+        run: npm run build
+
+      - name: Build OpenNext artifact
+        run: npm run build:opennext
+


### PR DESCRIPTION
### Motivation
- Asegurar que el pipeline valide el artefacto OpenNext para evitar merges con un `build` que no sea desplegable en la ruta self-hosted. 
- Añadir una corrida nocturna/manual que ejecute la regresión PostgreSQL completa para reducir riesgo operativo y detectar regresiones de plataforma fuera del subset rápido de PR. 
- Reducir ruido de concurrencia en CI y aplicar permisos mínimos del workflow como hardening básico.

### Description
- Se actualiza `.github/workflows/ci.yml` para añadir triggers `schedule` y `workflow_dispatch` y habilitar `concurrency` global para evitar carreras por ref. 
- Se aplica permiso mínimo del workflow con `permissions: contents: read`. 
- Se añade un `Build OpenNext artifact` step en el job `quality` ejecutando `npm run build:opennext` para validar el artefacto durante el quality gate (push/PR). 
- Se crea el job `nightly-full-regression` (scheduled/manual) que prepara entorno, ejecuta `npm run prisma:generate`, `npm run db:push`, corre `npm run test:postgres` y luego construye `npm run build` y `npm run build:opennext`.

### Testing
- Se validó la sintaxis del workflow con `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ok'"`, y la comprobación devolvió éxito. 
- Se intentó validar con Python (`yaml`), pero falló en este entorno por falta del módulo `yaml` (limitación del runner), por lo que se confía en la validación Ruby exitosa. 
- No se ejecutó aún el job en GitHub Actions; la nueva job programada correrá según el cron o mediante `workflow_dispatch` para validar la integración completa en CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15105af40c832b9bfd574da279e25c)