### PR TITLE
fix(wms): add OCC guards to inventory reserve/release operations

### DIFF
--- a/lib/inventory-service.ts
+++ b/lib/inventory-service.ts
@@ -520,10 +520,21 @@ export class InventoryService {
 
       const newReserved = existing.reserved + qty;
       const newAvailable = existing.quantity - newReserved;
-      await tx.inventory.update({
-        where: { id: existing.id },
+      const reserveUpdate = await tx.inventory.updateMany({
+        where: {
+          id: existing.id,
+          reserved: existing.reserved,
+          available: existing.available,
+          quantity: existing.quantity,
+        },
         data: { reserved: newReserved, available: newAvailable },
       });
+      if (reserveUpdate.count !== 1) {
+        throw new InventoryServiceError(
+          "CONCURRENT_MODIFICATION",
+          "Conflicto concurrente al reservar inventario; reintente la operacion"
+        );
+      }
 
       await tx.inventoryMovement.create({
         select: { id: true },
@@ -588,10 +599,21 @@ export class InventoryService {
 
       const newReserved = existing.reserved - qty;
       const newAvailable = existing.quantity - newReserved;
-      await tx.inventory.update({
-        where: { id: existing.id },
+      const releaseUpdate = await tx.inventory.updateMany({
+        where: {
+          id: existing.id,
+          reserved: existing.reserved,
+          available: existing.available,
+          quantity: existing.quantity,
+        },
         data: { reserved: newReserved, available: newAvailable },
       });
+      if (releaseUpdate.count !== 1) {
+        throw new InventoryServiceError(
+          "CONCURRENT_MODIFICATION",
+          "Conflicto concurrente al liberar reserva; reintente la operacion"
+        );
+      }
 
       await tx.inventoryMovement.create({
         select: { id: true },


### PR DESCRIPTION
### Motivation
- Reduce risk of silent overwrites in inventory read-modify-write flows when multiple actors reserve or release stock concurrently. 
- Make concurrent collisions explicit so callers can retry safely and preserve idempotent behavior in sensitive WMS flows. 
- Harden core inventory reservation paths that are high-impact for orders, pick tasks and fulfillment consistency. 

### Description
- Replaced direct `update` calls in `InventoryService.reserveStock` and `InventoryService.releaseReservedStock` with conditional `updateMany` guarded by the snapshot fields `id`, `quantity`, `reserved` and `available`. 
- When the conditional update does not affect exactly one row the service now throws an `InventoryServiceError` with code `CONCURRENT_MODIFICATION` and a clear message, exposing collisions to the caller. 
- Changes applied to `lib/inventory-service.ts` around the reserve/release codepaths; all surrounding audit/emit logic is preserved so successful flows still write movements and audit records. 

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully. 
- Attempted to run `npm run test -- tests/inventory-integrity.test.ts` but the run failed due to missing `DATABASE_URL` in the execution environment so PostgreSQL-backed tests could not be executed here. 
- No other automated test failures introduced by the change in this environment; recommend a PostgreSQL integration run to validate OCC behavior under simulated concurrent updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1510e4d79c832bb105e8bf78d0695d)