### PR TITLE
fix(KAN-53): sanitize auth callbackUrl boundaries

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -10,6 +10,7 @@ import { SectionCard } from "@/components/ui/section-card";
 import ThemeToggle from "@/components/ThemeToggle";
 import { startPerf } from "@/lib/perf";
 import { getRequestId } from "@/lib/request-meta";
+import { sanitizeCallbackUrl } from "@/lib/auth/callback-url";
 
 const SESSION_COOKIE_NAMES = [
   "authjs.session-token",
@@ -29,7 +30,7 @@ async function loginAction(formData: FormData) {
 
   const perf = startPerf("auth.login_action");
   const requestId = await getRequestId();
-  const callbackUrl = String(formData.get("callbackUrl") ?? "/").trim() || "/";
+  const callbackUrl = sanitizeCallbackUrl(String(formData.get("callbackUrl") ?? "/"));
   const email = String(formData.get("email") ?? "").trim();
   const password = String(formData.get("password") ?? "");
 
@@ -69,7 +70,7 @@ export default async function LoginPage({
   }
 
   const sp = await searchParams;
-  const callbackUrl = String(sp.callbackUrl ?? "/").trim() || "/";
+  const callbackUrl = sanitizeCallbackUrl(sp.callbackUrl);
   const error = String(sp.error ?? "").trim();
 
   return (

--- a/lib/auth/callback-url.ts
+++ b/lib/auth/callback-url.ts
@@ -1,0 +1,18 @@
+const FALLBACK_CALLBACK_URL = "/";
+
+export function sanitizeCallbackUrl(rawValue: string | null | undefined): string {
+  const value = String(rawValue ?? "").trim();
+  if (!value) return FALLBACK_CALLBACK_URL;
+
+  if (!value.startsWith("/")) return FALLBACK_CALLBACK_URL;
+  if (value.startsWith("//")) return FALLBACK_CALLBACK_URL;
+
+  try {
+    const normalized = new URL(value, "http://localhost");
+    if (normalized.origin !== "http://localhost") return FALLBACK_CALLBACK_URL;
+    if (!normalized.pathname.startsWith("/")) return FALLBACK_CALLBACK_URL;
+    return `${normalized.pathname}${normalized.search}${normalized.hash}`;
+  } catch {
+    return FALLBACK_CALLBACK_URL;
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import NextAuth from "next-auth";
 import { NextResponse } from "next/server";
 import authConfig from "@/auth.config";
 import type { NextAuthRequest } from "next-auth";
+import { sanitizeCallbackUrl } from "@/lib/auth/callback-url";
 
 const { auth } = NextAuth(authConfig);
 
@@ -25,7 +26,7 @@ function unauthorizedResponse(pathname: string, requestUrl: string, requestId: s
   }
 
   const loginUrl = new URL("/login", requestUrl);
-  loginUrl.searchParams.set("callbackUrl", pathname);
+  loginUrl.searchParams.set("callbackUrl", sanitizeCallbackUrl(pathname));
   const response = NextResponse.redirect(loginUrl);
   response.headers.set("x-request-id", requestId);
   return response;

--- a/tests/auth/callback-url.test.ts
+++ b/tests/auth/callback-url.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeCallbackUrl } from "@/lib/auth/callback-url";
+
+describe("sanitizeCallbackUrl", () => {
+  it("acepta rutas internas", () => {
+    expect(sanitizeCallbackUrl("/production/requests?stage=en_surtido")).toBe("/production/requests?stage=en_surtido");
+  });
+
+  it("rechaza urls absolutas", () => {
+    expect(sanitizeCallbackUrl("https://evil.example/steal")).toBe("/");
+  });
+
+  it("rechaza protocol-relative", () => {
+    expect(sanitizeCallbackUrl("//evil.example/steal")).toBe("/");
+  });
+
+  it("normaliza vacio a root", () => {
+    expect(sanitizeCallbackUrl(" ")).toBe("/");
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent open-redirect and unsafe callback targets by allowing only normalized internal routes as `callbackUrl` in auth flows.
- Harden authentication boundary used by login and middleware redirects to reduce attack surface for session redirect abuse.
- Align a small security fix with ticket `KAN-53` to lower operational risk without changing business logic.

### Description

- Add `lib/auth/callback-url.ts` with `sanitizeCallbackUrl` to normalize and allow only safe relative internal paths.
- Apply the sanitizer in the login server action and in the rendered hidden `callbackUrl` on `app/(public)/login/page.tsx` to prevent unsafe redirect targets.
- Apply the sanitizer in `proxy.ts` when building the `/login` redirect to avoid propagating unsafe `pathname` values.
- Add unit tests `tests/auth/callback-url.test.ts` covering valid internal paths and rejected payloads (`https://`, protocol-relative `//`, and empty input).

### Testing

- Ran unit tests with `npx vitest run tests/auth/callback-url.test.ts` and all tests passed. 
- Attempting `npm run -s test:postgres -- tests/auth/callback-url.test.ts` failed due to missing environment requirement `DATABASE_URL` which blocks running the PostgreSQL-backed test harness in this environment.
- No other automated test suites were changed in this PR and the change is small in scope with low risk to business logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15158673c0832bba80adbc3b0188f8)