### PR TITLE
feat(KAN-78): add operational UX visual foundation

### DIFF
--- a/app/(shell)/catalog/page.tsx
+++ b/app/(shell)/catalog/page.tsx
@@ -352,7 +352,7 @@ export default async function CatalogPage({ searchParams }: PageProps) {
                             </Td>
                             <Td>{product.brand ?? "--"}</Td>
                             <Td>{product.category?.name ?? product.subcategory ?? "--"}</Td>
-                            <Td className={`text-right font-semibold ${stock > 0 ? "text-emerald-500" : "text-red-500"}`}>{stock}</Td>
+                            <Td className={`text-right font-semibold ${stock > 0 ? "text-[var(--success)]" : "text-[var(--danger)]"}`}>{stock}</Td>
                             <Td className="text-right font-semibold text-[var(--text-primary)]">${product.price?.toFixed(2) ?? "--"}</Td>
                             <Td className="text-right">
                               <Link href={`/catalog/${product.id}`} className={buttonStyles({ variant: "ghost", size: "sm" })}>
@@ -383,7 +383,7 @@ export default async function CatalogPage({ searchParams }: PageProps) {
                       </div>
                       <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
                         <p className="text-[var(--text-muted)]">Marca: <span className="text-[var(--text-secondary)]">{product.brand ?? "--"}</span></p>
-                        <p className="text-[var(--text-muted)]">Stock: <span className={stock > 0 ? "text-emerald-500" : "text-red-500"}>{stock}</span></p>
+                        <p className="text-[var(--text-muted)]">Stock: <span className={stock > 0 ? "text-[var(--success)]" : "text-[var(--danger)]"}>{stock}</span></p>
                       </div>
                       <div className="mt-2 space-y-1">
                         {attributes && typeof attributes === "object" && Object.entries(attributes).slice(0, 2).map(([key, val]) => (

--- a/app/(shell)/production/requests/page.tsx
+++ b/app/(shell)/production/requests/page.tsx
@@ -7,6 +7,8 @@ import { getSessionContext } from "@/lib/auth/session-context";
 import { pageGuard } from "@/components/rbac/PageGuard";
 import { PageHeader } from "@/components/ui/page-header";
 import { Badge } from "@/components/ui/badge";
+import { buttonStyles } from "@/components/ui/button";
+import { StatCard } from "@/components/ui/stat-card";
 import { hasSalesWriteAccess, requireSalesWriteAccess } from "@/lib/rbac/sales";
 import { pullSalesRequestOrder } from "@/lib/sales/request-service";
 import { firstErrorMessage, salesInternalOrderTransitionSchema } from "@/lib/schemas/wms";
@@ -80,6 +82,12 @@ const FLOW_STAGE_ORDER: SalesOrderFlowStage[] = [
   "entregado",
   "cancelado",
 ];
+
+function getFilterPillClass(active: boolean) {
+  return active
+    ? "border border-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)] font-semibold"
+    : "border border-[var(--border-default)] bg-[var(--bg-surface)] text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--text-primary)]";
+}
 
 function parsePage(value: string | undefined) {
   const parsed = Number.parseInt(value ?? "1", 10);
@@ -450,10 +458,10 @@ export default async function ProductionRequestsPage({
         meta={`${filteredCount.toLocaleString("es-MX")} de ${totalCount.toLocaleString("es-MX")} pedidos${queueFilter ? ` · Pedidos por atender: ${QUEUE_LABELS[queueFilter]}` : ""}${presetFilter ? ` · Preset operativo: ${PRESET_LABELS[presetFilter]}` : ""}${stageFilter ? ` · Etapa: ${SALES_ORDER_FLOW_STAGE_LABELS[stageFilter]}` : ""}`}
         actions={
           <>
-            <Link href="/production/availability" className="rounded-lg border border-white/10 px-4 py-2 text-sm text-slate-300 hover:text-white">
+            <Link href="/production/availability" className={buttonStyles({ variant: "secondary" })}>
               Disponibilidad
             </Link>
-            <Link href="/production/equivalences" className="rounded-lg border border-white/10 px-4 py-2 text-sm text-slate-300 hover:text-white">
+            <Link href="/production/equivalences" className={buttonStyles({ variant: "secondary" })}>
               Equivalencias
             </Link>
             <Link href="/production/requests/new" className="btn-primary">
@@ -463,26 +471,14 @@ export default async function ProductionRequestsPage({
         }
       />
 
-      {sp.ok ? <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">{sp.ok}</div> : null}
-      {sp.error ? <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">{sp.error}</div> : null}
+      {sp.ok ? <div className="rounded-xl border border-[var(--status-success-border)] bg-[var(--status-success-bg)] px-4 py-3 text-sm text-[var(--status-success-text)]">{sp.ok}</div> : null}
+      {sp.error ? <div className="rounded-xl border border-[var(--status-danger-border)] bg-[var(--status-danger-bg)] px-4 py-3 text-sm text-[var(--status-danger-text)]">{sp.error}</div> : null}
 
       <div className="grid gap-4 md:grid-cols-4">
-        <div className="glass-card">
-          <p className="text-xs uppercase tracking-[0.14em] text-slate-400">Pedidos</p>
-          <p className="mt-3 text-3xl font-semibold text-white">{totalCount}</p>
-        </div>
-        <div className="glass-card">
-          <p className="text-xs uppercase tracking-[0.14em] text-slate-400">Borrador</p>
-          <p className="mt-3 text-3xl font-semibold text-white">{statusCountMap.BORRADOR ?? 0}</p>
-        </div>
-        <div className="glass-card">
-          <p className="text-xs uppercase tracking-[0.14em] text-slate-400">Ensamble ligado</p>
-          <p className="mt-3 text-3xl font-semibold text-white">{linkedAssemblyCount}</p>
-        </div>
-        <div className="glass-card">
-          <p className="text-xs uppercase tracking-[0.14em] text-slate-400">Surtidos directos activos</p>
-          <p className="mt-3 text-3xl font-semibold text-white">{directPickCount}</p>
-        </div>
+        <StatCard label="Pedidos" value={totalCount.toString()} />
+        <StatCard label="Borrador" value={(statusCountMap.BORRADOR ?? 0).toString()} tone="accent" />
+        <StatCard label="Ensamble ligado" value={linkedAssemblyCount.toString()} tone="warning" />
+        <StatCard label="Surtidos directos activos" value={directPickCount.toString()} tone="success" />
       </div>
 
       <form method="get" className="glass-card flex flex-col gap-3 md:flex-row md:items-end">
@@ -497,28 +493,28 @@ export default async function ProductionRequestsPage({
             name="customer"
             defaultValue={customerFilter}
             placeholder="Nombre o cuenta del cliente"
-            className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm text-white"
+            className="w-full rounded-lg border border-[var(--border-default)] bg-[var(--bg-surface)] px-4 py-2 text-sm text-[var(--text-primary)]"
           />
         </label>
         <div className="flex gap-2">
-          <button type="submit" className="rounded-lg border border-white/10 px-4 py-2 text-sm text-slate-200 hover:text-white">
+          <button type="submit" className={buttonStyles({ variant: "secondary" })}>
             Filtrar
           </button>
-          <Link href={buildHref(1, undefined, undefined, undefined, undefined)} className="rounded-lg border border-white/10 px-4 py-2 text-sm text-slate-300 hover:text-white">
+          <Link href={buildHref(1, undefined, undefined, undefined, undefined)} className={buttonStyles({ variant: "secondary" })}>
             Limpiar
           </Link>
         </div>
       </form>
 
       <div className="flex flex-wrap gap-2">
-        <Link href={buildHref(1, statusFilter, undefined, stageFilter)} className={`rounded-lg px-3 py-1.5 text-sm glass ${!queueFilter ? "bg-white/10 text-white font-semibold" : "text-slate-400 hover:text-white"}`}>
+        <Link href={buildHref(1, statusFilter, undefined, stageFilter)} className={`rounded-lg px-3 py-1.5 text-sm ${getFilterPillClass(!queueFilter)}`}>
           Todos por atender
         </Link>
         {(Object.keys(QUEUE_LABELS) as FulfillmentQueueFilter[]).map((queue) => (
           <Link
             key={queue}
             href={buildHref(1, statusFilter, queue, stageFilter)}
-            className={`rounded-lg px-3 py-1.5 text-sm glass ${queueFilter === queue ? "bg-white/10 text-white font-semibold" : "text-slate-400 hover:text-white"}`}
+            className={`rounded-lg px-3 py-1.5 text-sm ${getFilterPillClass(queueFilter === queue)}`}
           >
             {QUEUE_LABELS[queue]}
           </Link>
@@ -528,7 +524,7 @@ export default async function ProductionRequestsPage({
       <div className="flex flex-wrap gap-2">
         <Link
           href={buildHref(1, statusFilter, queueFilter, stageFilter, undefined)}
-          className={`rounded-lg px-3 py-1.5 text-sm glass ${!presetFilter ? "bg-white/10 text-white font-semibold" : "text-slate-400 hover:text-white"}`}
+          className={`rounded-lg px-3 py-1.5 text-sm ${getFilterPillClass(!presetFilter)}`}
         >
           Todos presets
         </Link>
@@ -536,7 +532,7 @@ export default async function ProductionRequestsPage({
           <Link
             key={preset}
             href={buildHref(1, statusFilter, queueFilter, stageFilter, preset)}
-            className={`rounded-lg px-3 py-1.5 text-sm glass ${presetFilter === preset ? "bg-white/10 text-white font-semibold" : "text-slate-400 hover:text-white"}`}
+            className={`rounded-lg px-3 py-1.5 text-sm ${getFilterPillClass(presetFilter === preset)}`}
           >
             {PRESET_LABELS[preset]}
           </Link>
@@ -544,14 +540,14 @@ export default async function ProductionRequestsPage({
       </div>
 
       <div className="flex flex-wrap gap-2">
-        <Link href={buildHref(1, statusFilter, queueFilter, undefined)} className={`rounded-lg px-3 py-1.5 text-sm glass ${!stageFilter ? "bg-white/10 text-white font-semibold" : "text-slate-400 hover:text-white"}`}>
+        <Link href={buildHref(1, statusFilter, queueFilter, undefined)} className={`rounded-lg px-3 py-1.5 text-sm ${getFilterPillClass(!stageFilter)}`}>
           Todas etapas
         </Link>
         {FLOW_STAGE_ORDER.map((stage) => (
           <Link
             key={stage}
             href={buildHref(1, statusFilter, queueFilter, stage)}
-            className={`rounded-lg px-3 py-1.5 text-sm glass ${stageFilter === stage ? "bg-white/10 text-white font-semibold" : "text-slate-400 hover:text-white"}`}
+            className={`rounded-lg px-3 py-1.5 text-sm ${getFilterPillClass(stageFilter === stage)}`}
           >
             {SALES_ORDER_FLOW_STAGE_LABELS[stage]}
           </Link>
@@ -559,14 +555,14 @@ export default async function ProductionRequestsPage({
       </div>
 
       <div className="flex flex-wrap gap-2">
-        <Link href={buildHref(1, undefined, queueFilter)} className={`rounded-lg px-3 py-1.5 text-sm glass ${!statusFilter ? "bg-white/10 text-white font-semibold" : "text-slate-400 hover:text-white"}`}>
+        <Link href={buildHref(1, undefined, queueFilter)} className={`rounded-lg px-3 py-1.5 text-sm ${getFilterPillClass(!statusFilter)}`}>
           Todos ({totalCount})
         </Link>
         {Object.entries(SALES_INTERNAL_ORDER_STATUS_LABELS).map(([status, label]) => (
           <Link
             key={status}
             href={buildHref(1, status as SalesInternalOrderStatus, queueFilter)}
-            className={`rounded-lg px-3 py-1.5 text-sm glass ${statusFilter === status ? "bg-white/10 text-white font-semibold" : "text-slate-400 hover:text-white"}`}
+            className={`rounded-lg px-3 py-1.5 text-sm ${getFilterPillClass(statusFilter === status)}`}
           >
             {label} ({statusCountMap[status] ?? 0})
           </Link>
@@ -644,13 +640,13 @@ export default async function ProductionRequestsPage({
               return (
                 <tr key={order.id} className="border-b border-white/5 hover:bg-white/5">
                   <td className="py-3">
-                    <Link href={`/production/requests/${order.id}`} className="font-mono text-cyan-300 hover:text-white">
+                    <Link href={`/production/requests/${order.id}`} className="font-mono text-[var(--accent)] hover:text-[var(--text-primary)]">
                       {order.code}
                     </Link>
                   </td>
                   <td className="py-3 text-slate-300">
                     {order.customerId && canViewCustomers ? (
-                      <Link href={`/sales/customers/${order.customerId}`} className="text-cyan-300 hover:text-white">
+                      <Link href={`/sales/customers/${order.customerId}`} className="text-[var(--accent)] hover:text-[var(--text-primary)]">
                         {displayCustomer}
                       </Link>
                     ) : (
@@ -668,10 +664,10 @@ export default async function ProductionRequestsPage({
                     {order.assignedToUser ? (
                       order.assignedToUser.name ?? order.assignedToUser.email ?? "--"
                     ) : (
-                      <span className="text-slate-500">Sin asignar</span>
+                      <span className="text-[var(--text-muted)]">Sin asignar</span>
                     )}
                     {isAvailableForPull ? (
-                      <span className="ml-2 rounded px-2 py-0.5 text-xs font-semibold text-cyan-200 bg-cyan-500/20">
+                      <span className="ml-2 rounded px-2 py-0.5 text-xs font-semibold text-[var(--accent)] bg-[var(--accent-soft)]">
                         Disponible para pull
                       </span>
                     ) : null}
@@ -680,7 +676,7 @@ export default async function ProductionRequestsPage({
                     <p>{order.dueDate ? new Date(order.dueDate).toLocaleDateString("es-MX") : "--"}</p>
                     <div className="mt-1 flex flex-wrap items-center gap-2">
                       <Badge variant={flowNarrative.flowBadgeVariant}>{flowNarrative.flowStageLabel}</Badge>
-                      <Link href={flowNarrative.nextRecommendedAction.href} className="text-xs text-cyan-300 hover:text-white">
+                      <Link href={flowNarrative.nextRecommendedAction.href} className="text-xs text-[var(--accent)] hover:text-[var(--text-primary)]">
                         {flowNarrative.nextRecommendedAction.label}
                       </Link>
                       {!flowNarrative.primaryCta.isAllowed && flowNarrative.primaryCta.blockedReason ? (
@@ -698,11 +694,13 @@ export default async function ProductionRequestsPage({
                           <button
                             type="submit"
                             disabled={!takeEligibility.canTakeOrder}
-                            className={`rounded-lg border px-3 py-1.5 text-xs ${
-                              takeEligibility.canTakeOrder
-                                ? "border-cyan-500/30 bg-cyan-500/10 text-cyan-200 hover:border-cyan-400/40 hover:text-white"
-                                : "cursor-not-allowed border-white/10 bg-white/5 text-slate-500"
-                            }`}
+                            className={buttonStyles({
+                              variant: "secondary",
+                              size: "sm",
+                              className: takeEligibility.canTakeOrder
+                                ? "border-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)] hover:border-[var(--accent-hover)] hover:bg-[var(--accent-soft)]"
+                                : "cursor-not-allowed",
+                            })}
                           >
                             Tomar pedido
                           </button>
@@ -712,7 +710,7 @@ export default async function ProductionRequestsPage({
                         ) : null}
                       </div>
                     ) : (
-                      <span className="text-xs text-slate-500">--</span>
+                      <span className="text-xs text-[var(--text-muted)]">--</span>
                     )}
                   </td>
                 </tr>
@@ -724,11 +722,11 @@ export default async function ProductionRequestsPage({
 
       {totalPages > 1 ? (
         <div className="flex items-center justify-between gap-3 text-sm">
-          <Link href={buildHref(Math.max(1, safePage - 1))} className={`rounded-lg border border-white/10 px-4 py-2 ${safePage <= 1 ? "pointer-events-none opacity-40" : "text-slate-300 hover:text-white"}`}>
+          <Link href={buildHref(Math.max(1, safePage - 1))} className={buttonStyles({ variant: "secondary", className: safePage <= 1 ? "pointer-events-none opacity-40" : "" })}>
             ← Anterior
           </Link>
-          <span className="text-slate-500">Pagina {safePage} de {totalPages}</span>
-          <Link href={buildHref(Math.min(totalPages, safePage + 1))} className={`rounded-lg border border-white/10 px-4 py-2 ${safePage >= totalPages ? "pointer-events-none opacity-40" : "text-slate-300 hover:text-white"}`}>
+          <span className="text-[var(--text-muted)]">Pagina {safePage} de {totalPages}</span>
+          <Link href={buildHref(Math.min(totalPages, safePage + 1))} className={buttonStyles({ variant: "secondary", className: safePage >= totalPages ? "pointer-events-none opacity-40" : "" })}>
             Siguiente →
           </Link>
         </div>

--- a/app/styles/primitives.css
+++ b/app/styles/primitives.css
@@ -519,8 +519,20 @@
   color: var(--text-accent) !important;
 }
 
+[data-theme="light"] .text-cyan-300,
+[data-theme="light"] .text-cyan-500,
+[data-theme="light"] .hover\:text-cyan-300:hover,
+[data-theme="light"] .hover\:text-cyan-400:hover {
+  color: var(--accent) !important;
+}
+
 [data-theme="light"] .bg-cyan-500\/10 {
   background: var(--status-info-bg) !important;
+}
+
+[data-theme="light"] .bg-cyan-500\/20,
+[data-theme="light"] .bg-cyan-500\/30 {
+  background: var(--accent-soft) !important;
 }
 
 [data-theme="light"] .border-cyan-500\/30,
@@ -528,24 +540,69 @@
   border-color: var(--status-info-border) !important;
 }
 
+[data-theme="light"] .border-cyan-500\/20 {
+  border-color: var(--accent) !important;
+}
+
+[data-theme="light"] .text-emerald-200,
+[data-theme="light"] .text-emerald-300,
 [data-theme="light"] .text-emerald-400 {
   color: var(--status-success-text) !important;
 }
 
+[data-theme="light"] .text-emerald-500 {
+  color: var(--success) !important;
+}
+
+[data-theme="light"] .bg-emerald-500\/10,
+[data-theme="light"] .bg-emerald-500\/20 {
+  background: var(--status-success-bg) !important;
+}
+
+[data-theme="light"] .border-emerald-500\/20,
+[data-theme="light"] .border-emerald-500\/30 {
+  border-color: var(--status-success-border) !important;
+}
+
+[data-theme="light"] .text-amber-200,
+[data-theme="light"] .text-amber-300,
 [data-theme="light"] .text-orange-400,
 [data-theme="light"] .text-amber-400 {
   color: var(--status-warning-text) !important;
 }
 
+[data-theme="light"] .bg-amber-400\/10,
+[data-theme="light"] .bg-amber-500\/10,
+[data-theme="light"] .bg-amber-500\/20,
+[data-theme="light"] .bg-orange-500\/20 {
+  background: var(--status-warning-bg) !important;
+}
+
+[data-theme="light"] .border-amber-400\/20,
+[data-theme="light"] .border-amber-500\/30,
+[data-theme="light"] .border-orange-400\/40 {
+  border-color: var(--status-warning-border) !important;
+}
+
 [data-theme="light"] .text-red-200,
+[data-theme="light"] .text-red-300,
 [data-theme="light"] .text-red-400 {
   color: var(--status-danger-text) !important;
+}
+
+[data-theme="light"] .text-red-500 {
+  color: var(--danger) !important;
 }
 
 [data-theme="light"] .bg-red-500\/10 {
   background: var(--status-danger-bg) !important;
 }
 
+[data-theme="light"] .bg-red-500\/20 {
+  background: color-mix(in oklab, var(--status-danger-bg) 80%, var(--bg-surface)) !important;
+}
+
+[data-theme="light"] .border-red-500\/20,
 [data-theme="light"] .border-red-500\/30,
 [data-theme="light"] .hover\:border-red-400\/40:hover {
   border-color: var(--status-danger-border) !important;

--- a/app/styles/primitives.css
+++ b/app/styles/primitives.css
@@ -13,11 +13,188 @@
   box-shadow: var(--shadow-md);
 }
 
+/* Operational UX layout primitives */
+.op-layout {
+  display: grid;
+  gap: 1rem;
+}
+
+.op-layout-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+}
+
+@media (min-width: 1024px) {
+  .op-layout-split {
+    grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.7fr);
+  }
+}
+
+.op-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  gap: 1rem;
+}
+
+.op-card,
+.op-panel,
+.op-sidebar {
+  background: var(--ops-surface);
+  border: 1px solid var(--ops-panel-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  color: var(--text-primary);
+}
+
+.op-card {
+  padding: 1rem;
+}
+
+.op-panel {
+  padding: 1.25rem;
+}
+
+.op-sidebar {
+  align-self: start;
+  padding: 1rem;
+  background: var(--ops-muted-panel);
+}
+
+.op-card-interactive {
+  cursor: pointer;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
+}
+
+.op-card-interactive:hover,
+.op-card-interactive:focus-visible {
+  border-color: var(--accent);
+  box-shadow: var(--ops-focus-shadow);
+  transform: translateY(-1px);
+}
+
+.op-step-list {
+  display: grid;
+  gap: 0.625rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.op-step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.75rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+}
+
+.op-step-marker {
+  display: inline-flex;
+  width: 1.75rem;
+  height: 1.75rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--execution-active-bg);
+  color: var(--execution-active-text);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.op-step-active {
+  border-color: var(--execution-active-border);
+  background: var(--execution-active-bg);
+}
+
+.op-step-complete .op-step-marker {
+  background: var(--success-soft);
+  color: var(--status-success-text);
+}
+
+.op-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  padding: 0.28rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.op-state-critical {
+  color: var(--status-danger-text);
+  background: var(--risk-critical-bg);
+  border-color: var(--risk-critical-border);
+  box-shadow: 0 0 0 1px var(--risk-critical-glow);
+}
+
+.op-state-active {
+  color: var(--execution-active-text);
+  background: var(--execution-active-bg);
+  border-color: var(--execution-active-border);
+}
+
+.op-state-best {
+  color: var(--slot-best-text);
+  background: var(--slot-best-bg);
+  border-color: var(--slot-best-border);
+}
+
+.op-state-sales {
+  color: var(--sales-cta-text);
+  background: var(--sales-cta);
+  border-color: var(--sales-cta-hover);
+}
+
+.op-state-mobile {
+  color: var(--mobile-cta-text);
+  background: var(--mobile-cta);
+  border-color: var(--mobile-cta-hover);
+}
+
+.role-manager-accent {
+  color: var(--role-manager-accent);
+}
+
+.role-warehouse-accent {
+  color: var(--role-warehouse-accent);
+}
+
+.role-sales-accent {
+  color: var(--role-sales-accent);
+}
+
+.risk-critical {
+  background: var(--risk-critical-bg);
+  border-color: var(--risk-critical-border);
+  box-shadow: 0 0 24px var(--risk-critical-glow);
+}
+
+.execution-active {
+  background: var(--execution-active-bg);
+  border-color: var(--execution-active-border);
+  color: var(--execution-active-text);
+}
+
+.slot-best {
+  background: var(--slot-best-bg);
+  border-color: var(--slot-best-border);
+  color: var(--slot-best-text);
+}
+
 /* Buttons */
 .btn,
 .btn-primary,
 .btn-secondary,
-.btn-ghost {
+.btn-ghost,
+.btn-sales,
+.btn-mobile {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -35,7 +212,9 @@
 .btn:focus-visible,
 .btn-primary:focus-visible,
 .btn-secondary:focus-visible,
-.btn-ghost:focus-visible {
+.btn-ghost:focus-visible,
+.btn-sales:focus-visible,
+.btn-mobile:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--focus-ring);
 }
@@ -47,7 +226,11 @@
 .btn-secondary:disabled,
 .btn-secondary[aria-disabled="true"],
 .btn-ghost:disabled,
-.btn-ghost[aria-disabled="true"] {
+.btn-ghost[aria-disabled="true"],
+.btn-sales:disabled,
+.btn-sales[aria-disabled="true"],
+.btn-mobile:disabled,
+.btn-mobile[aria-disabled="true"] {
   opacity: var(--disabled-opacity);
   pointer-events: none;
 }
@@ -82,6 +265,29 @@
 .btn-ghost:hover {
   background: var(--bg-subtle);
   color: var(--text-primary);
+}
+
+.btn-sales {
+  background: var(--sales-cta);
+  border-color: var(--sales-cta);
+  color: var(--sales-cta-text);
+}
+
+.btn-sales:hover {
+  background: var(--sales-cta-hover);
+  border-color: var(--sales-cta-hover);
+}
+
+.btn-mobile {
+  min-height: 2.75rem;
+  background: var(--mobile-cta);
+  border-color: var(--mobile-cta);
+  color: var(--mobile-cta-text);
+}
+
+.btn-mobile:hover {
+  background: var(--mobile-cta-hover);
+  border-color: var(--mobile-cta-hover);
 }
 
 /* Badges */
@@ -123,6 +329,18 @@
   color: var(--danger);
   border-color: color-mix(in oklab, var(--danger) 34%, var(--border-default));
   background: var(--danger-soft);
+}
+
+.badge-sales {
+  color: var(--sales-cta);
+  border-color: color-mix(in oklab, var(--sales-cta) 36%, var(--border-default));
+  background: var(--sales-cta-soft);
+}
+
+.badge-mobile {
+  color: var(--mobile-cta);
+  border-color: color-mix(in oklab, var(--mobile-cta) 36%, var(--border-default));
+  background: var(--mobile-cta-soft);
 }
 
 /* Form fields and dense controls */

--- a/app/styles/tokens.css
+++ b/app/styles/tokens.css
@@ -60,6 +60,33 @@
   --status-danger-border: rgba(239, 68, 68, 0.28);
   --status-danger-text: #fecaca;
 
+  /* KAN-78 operational UX intent tokens */
+  --ops-surface: color-mix(in oklab, var(--bg-elevated) 86%, var(--bg-surface));
+  --ops-surface-strong: color-mix(in oklab, var(--bg-elevated) 72%, #020617);
+  --ops-panel-border: color-mix(in oklab, var(--border-strong) 70%, var(--accent));
+  --ops-muted-panel: color-mix(in oklab, var(--bg-surface) 68%, transparent);
+  --ops-focus-shadow: 0 0 0 3px var(--focus-ring), 0 14px 34px rgba(15, 23, 42, 0.32);
+  --sales-cta: #22c55e;
+  --sales-cta-hover: #16a34a;
+  --sales-cta-soft: rgba(34, 197, 94, 0.16);
+  --sales-cta-text: #dcfce7;
+  --risk-critical-glow: rgba(239, 68, 68, 0.34);
+  --risk-critical-bg: rgba(127, 29, 29, 0.34);
+  --risk-critical-border: rgba(248, 113, 113, 0.46);
+  --execution-active-bg: rgba(37, 99, 235, 0.18);
+  --execution-active-border: rgba(96, 165, 250, 0.4);
+  --execution-active-text: #bfdbfe;
+  --slot-best-bg: rgba(20, 184, 166, 0.16);
+  --slot-best-border: rgba(45, 212, 191, 0.34);
+  --slot-best-text: #99f6e4;
+  --mobile-cta: #f59e0b;
+  --mobile-cta-hover: #d97706;
+  --mobile-cta-soft: rgba(245, 158, 11, 0.18);
+  --mobile-cta-text: #fff7ed;
+  --role-manager-accent: #38bdf8;
+  --role-warehouse-accent: #f59e0b;
+  --role-sales-accent: var(--sales-cta);
+
   --radius-sm: 0.375rem;
   --radius-md: 0.625rem;
   --radius-lg: 0.875rem;
@@ -134,6 +161,32 @@
   --status-danger-bg: rgba(239, 68, 68, 0.12);
   --status-danger-border: rgba(220, 38, 38, 0.22);
   --status-danger-text: #991b1b;
+
+  --ops-surface: color-mix(in oklab, var(--bg-surface) 88%, var(--bg-elevated));
+  --ops-surface-strong: color-mix(in oklab, var(--bg-surface) 76%, #dbeafe);
+  --ops-panel-border: color-mix(in oklab, var(--border-strong) 74%, var(--accent));
+  --ops-muted-panel: rgba(248, 250, 252, 0.78);
+  --ops-focus-shadow: 0 0 0 3px var(--focus-ring), 0 12px 28px rgba(15, 23, 42, 0.1);
+  --sales-cta: #15803d;
+  --sales-cta-hover: #166534;
+  --sales-cta-soft: rgba(22, 163, 74, 0.12);
+  --sales-cta-text: #ffffff;
+  --risk-critical-glow: rgba(220, 38, 38, 0.2);
+  --risk-critical-bg: rgba(254, 226, 226, 0.82);
+  --risk-critical-border: rgba(220, 38, 38, 0.28);
+  --execution-active-bg: rgba(37, 99, 235, 0.1);
+  --execution-active-border: rgba(37, 99, 235, 0.22);
+  --execution-active-text: #1e3a8a;
+  --slot-best-bg: rgba(20, 184, 166, 0.12);
+  --slot-best-border: rgba(13, 148, 136, 0.22);
+  --slot-best-text: #115e59;
+  --mobile-cta: #b45309;
+  --mobile-cta-hover: #92400e;
+  --mobile-cta-soft: rgba(245, 158, 11, 0.14);
+  --mobile-cta-text: #ffffff;
+  --role-manager-accent: #0369a1;
+  --role-warehouse-accent: #b45309;
+  --role-sales-accent: var(--sales-cta);
 
   --accent-primary: var(--accent);
   --accent-primary-hover: var(--accent-hover);

--- a/lib/sales/internal-orders.ts
+++ b/lib/sales/internal-orders.ts
@@ -11,9 +11,9 @@ export const SALES_INTERNAL_ORDER_STATUS_LABELS: Record<SalesInternalOrderStatus
 };
 
 export const SALES_INTERNAL_ORDER_STATUS_STYLES: Record<SalesInternalOrderStatus, string> = {
-  BORRADOR: "text-slate-300 bg-slate-500/20",
-  CONFIRMADA: "text-emerald-300 bg-emerald-500/20",
-  CANCELADA: "text-red-300 bg-red-500/20",
+  BORRADOR: "border border-[var(--status-neutral-border)] text-[var(--status-neutral-text)] bg-[var(--status-neutral-bg)]",
+  CONFIRMADA: "border border-[var(--status-success-border)] text-[var(--status-success-text)] bg-[var(--status-success-bg)]",
+  CANCELADA: "border border-[var(--status-danger-border)] text-[var(--status-danger-text)] bg-[var(--status-danger-bg)]",
 };
 
 export type SalesOrderFlowStage =


### PR DESCRIPTION
## Motivation

KAN-78 is the prerequisite visual-system slice for the next WMS UX work. The branch was recreated from current `main` and the foundation now goes beyond raw CSS so current operational screens can stay usable in both dark and light themes.

## What changed

- Recreated `feature/KAN-78-operational-ux-tokens` from current `main` and refreshed the PR branch history.
- Preserved the original KAN-78 token/primitives foundation from PR #34.
- Expanded the visual foundation beyond CSS-only changes:
  - `app/styles/tokens.css`
  - `app/styles/primitives.css`
  - `lib/sales/internal-orders.ts`
  - `app/(shell)/production/requests/page.tsx`
  - `app/(shell)/catalog/page.tsx`
- Added broader token-backed compatibility for existing operational screens.
- Reduced hardcoded colors in `production/requests`.
- Tokenized catalog stock emphasis.
- Updated sales status styling to use semantic tokens.

## Validation

- `npm run typecheck` passed.
- `npm run lint` passed with two pre-existing warnings:
  - `lib/sales/internal-orders.ts` unused `nextRecommendedAction`
  - `tests/setup/postgres-worker-isolation.ts` unused eslint-disable directive
- `npm run build` passed.

## Review focus

- Confirm semantic token naming is generic enough for Manager/Admin, Warehouse, and Sales usage.
- Confirm dark/light contrast is readable on production requests and catalog surfaces.
- Confirm focus states and mobile target sizes remain sane in the new primitives.
- Confirm later screen work avoids hardcoded colors and uses the shared foundation instead.
