### PR TITLE
chore: reapply local dev/setup improvements from preserved changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ dev-local-launcher.cmd
 
 Notas del launcher AWS local:
 
+- Requiere `DATABASE_URL` PostgreSQL valida ya configurada (en `.env` o entorno de maquina).
+- Si falta, ejecutar antes `maintenance\setup-aws.cmd -Auto` (o `maintenance\setup-aws-auto.cmd`) para cargar valores desde CloudFormation.
 - Acepta `DATABASE_URL` en `.env` con o sin comillas.
-- Si la URL falta o es invalida, ejecuta `maintenance\setup-aws.cmd`, reintenta `.env` y luego `DATABASE_URL` de entorno de maquina.
+- Si la URL de `.env` es invalida, intenta `DATABASE_URL` de entorno de maquina y falla con mensaje accionable.
 
 ## Estructura del Proyecto
 

--- a/dev-local-launcher.cmd
+++ b/dev-local-launcher.cmd
@@ -34,24 +34,6 @@ call :is_valid_postgres_url
 if "%VALID_DATABASE_URL%"=="1" goto :database_ready
 
 echo [WARN] DATABASE_URL no encontrada o invalida en .env.
-echo [INFO] Ejecutando configuracion AWS automatica...
-if not exist "maintenance\setup-aws.cmd" (
-  echo [ERROR] No se encontro maintenance\setup-aws.cmd.
-  popd
-  exit /b 1
-)
-
-call maintenance\setup-aws.cmd
-if errorlevel 1 (
-  echo [WARN] setup-aws.cmd termino con error. Se reintentara validar DATABASE_URL.
-)
-
-echo [INFO] Reintentando deteccion de DATABASE_URL en .env...
-set "ENV_DATABASE_URL="
-call :resolve_database_url_from_env_file
-call :is_valid_postgres_url
-if "%VALID_DATABASE_URL%"=="1" goto :database_ready
-
 echo [INFO] Intentando DATABASE_URL de entorno de maquina...
 set "ENV_DATABASE_URL="
 call :resolve_database_url_from_machine_env
@@ -59,7 +41,9 @@ call :is_valid_postgres_url
 if "%VALID_DATABASE_URL%"=="1" goto :database_ready
 
 echo [ERROR] DATABASE_URL no esta configurada con un valor PostgreSQL valido.
-echo [ERROR] Configura DATABASE_URL con maintenance\setup-aws.cmd y vuelve a intentar.
+echo [ERROR] Este launcher no ejecuta el asistente automatico de setup.
+echo [INFO] Ejecuta maintenance\setup-aws.cmd -Auto para cargar DATABASE_URL desde CloudFormation.
+echo [INFO] Luego vuelve a ejecutar dev-local-launcher.cmd.
 popd
 exit /b 1
 

--- a/scripts/release/common.ps1
+++ b/scripts/release/common.ps1
@@ -599,8 +599,14 @@ function Invoke-AwsDatabaseSetup {
     [System.Environment]::SetEnvironmentVariable("DATABASE_URL", $url, "Machine")
     [System.Environment]::SetEnvironmentVariable("WMS_DB_MODE", "aws", "Machine")
   } catch {
-    Write-Host "  ADVERTENCIA: no se pudo guardar en variables de sistema (requiere Administrador)."
-    Write-Host "  La configuracion aplica solo para esta sesion. Ejecuta maintenance\setup-aws.cmd como Administrador para hacerla permanente."
+    try {
+      [System.Environment]::SetEnvironmentVariable("DATABASE_URL", $url, "User")
+      [System.Environment]::SetEnvironmentVariable("WMS_DB_MODE", "aws", "User")
+      Write-Host "  ADVERTENCIA: no se pudo guardar en Machine. Se guardo en User (persistente para este usuario)."
+    } catch {
+      Write-Host "  ADVERTENCIA: no se pudo guardar en variables de sistema (Machine/User)."
+      Write-Host "  La configuracion aplica solo para esta sesion."
+    }
   }
 
   $env:DATABASE_URL = $url
@@ -722,8 +728,15 @@ function Invoke-SyncSetup {
         Set-Item -Path "Env:$($entry.Key)" -Value $entry.Value
         $persisted++
       } catch {
-        Write-Host "  ADVERTENCIA: no se pudo guardar $($entry.Key) en variables de sistema (requiere Administrador)."
-        Set-Item -Path "Env:$($entry.Key)" -Value $entry.Value
+        try {
+          [System.Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, "User")
+          Set-Item -Path "Env:$($entry.Key)" -Value $entry.Value
+          $persisted++
+          Write-Host "  ADVERTENCIA: $($entry.Key) guardada en User (Machine requiere Administrador)."
+        } catch {
+          Write-Host "  ADVERTENCIA: no se pudo guardar $($entry.Key) en Machine/User."
+          Set-Item -Path "Env:$($entry.Key)" -Value $entry.Value
+        }
       }
     }
   }
@@ -884,6 +897,7 @@ function Invoke-AutoSetup {
 
   $persisted = 0
   $failed    = 0
+  $userScope = 0
   foreach ($entry in $allVars.GetEnumerator()) {
     if ($entry.Value) {
       try {
@@ -891,15 +905,25 @@ function Invoke-AutoSetup {
         Set-Item -Path "Env:$($entry.Key)" -Value $entry.Value
         $persisted++
       } catch {
-        Set-Item -Path "Env:$($entry.Key)" -Value $entry.Value
-        $failed++
+        try {
+          [System.Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, "User")
+          Set-Item -Path "Env:$($entry.Key)" -Value $entry.Value
+          $persisted++
+          $userScope++
+        } catch {
+          Set-Item -Path "Env:$($entry.Key)" -Value $entry.Value
+          $failed++
+        }
       }
     }
   }
 
   if ($failed -gt 0) {
-    Write-Host "  ADVERTENCIA: $failed variables no se pudieron guardar permanentemente (requiere Administrador)."
-    Write-Host "  Esta sesion queda configurada. Ejecuta como Administrador para hacerlo permanente."
+    Write-Host "  ADVERTENCIA: $failed variables no se pudieron guardar permanentemente."
+    Write-Host "  Esta sesion queda configurada."
+  }
+  if ($userScope -gt 0) {
+    Write-Host "  INFO: $userScope variables quedaron en scope User (persistente para este usuario)."
   }
 
   Write-Host ""

--- a/scripts/release/maintenance/setup-aws.ps1
+++ b/scripts/release/maintenance/setup-aws.ps1
@@ -1,5 +1,23 @@
+param(
+  [switch]$Auto,
+  [string]$Profile = "wms-mobile-dev",
+  [string]$WebStackName = "WmsWebDevStack",
+  [string]$MobileStackName = "RigentecWmsMobileDevStack"
+)
+
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "..\common.ps1")
+
+function Read-TrimmedInput {
+  param([string]$Prompt)
+
+  $raw = Read-Host $Prompt
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    return ""
+  }
+
+  return $raw.Trim()
+}
 
 Write-Host ""
 Write-Host "=== Configuracion de WMS para AWS ==="
@@ -8,20 +26,30 @@ Write-Host "  [1] Automatico - Lee todo desde los stacks de CloudFormation (reco
 Write-Host "  [2] Manual     - Ingresar DATABASE_URL y sync manualmente"
 Write-Host ""
 
-$mode = (Read-Host "Selecciona modo (1/2)").Trim()
+if ($Auto) {
+  $mode = "1"
+} else {
+  $mode = Read-TrimmedInput "Selecciona modo (1/2)"
+  if (-not $mode) {
+    $mode = "1"
+    Write-Host "[INFO] Sin seleccion. Usando modo automatico (1)."
+  }
+}
 
 if ($mode -eq "1") {
   Write-Host ""
-  $profile = (Read-Host "Perfil AWS CLI (default: wms-mobile-dev)").Trim()
-  if (-not $profile) { $profile = "wms-mobile-dev" }
+  if (-not $Auto) {
+    $profileInput = Read-TrimmedInput "Perfil AWS CLI (default: $Profile)"
+    if ($profileInput) { $Profile = $profileInput }
 
-  $webStack = (Read-Host "Nombre del stack web (default: WmsWebDevStack)").Trim()
-  if (-not $webStack) { $webStack = "WmsWebDevStack" }
+    $webStackInput = Read-TrimmedInput "Nombre del stack web (default: $WebStackName)"
+    if ($webStackInput) { $WebStackName = $webStackInput }
 
-  $mobileStack = (Read-Host "Nombre del stack mobile (default: RigentecWmsMobileDevStack)").Trim()
-  if (-not $mobileStack) { $mobileStack = "RigentecWmsMobileDevStack" }
+    $mobileStackInput = Read-TrimmedInput "Nombre del stack mobile (default: $MobileStackName)"
+    if ($mobileStackInput) { $MobileStackName = $mobileStackInput }
+  }
 
-  $ok = Invoke-AutoSetup -Profile $profile -WebStackName $webStack -MobileStackName $mobileStack
+  $ok = Invoke-AutoSetup -Profile $Profile -WebStackName $WebStackName -MobileStackName $MobileStackName
   if (-not $ok) {
     Write-Host ""
     Write-Host "Configuracion automatica fallo. Intenta con la opcion manual (2)."
@@ -44,7 +72,7 @@ if ($mode -eq "1") {
   Write-Host "Base de datos configurada."
   Write-Host ""
 
-  $setupSync = (Read-Host "Deseas configurar sincronizacion movil? (S/N)").Trim()
+  $setupSync = Read-TrimmedInput "Deseas configurar sincronizacion movil? (S/N)"
   if ($setupSync -match "^[SsYy]") {
     Invoke-SyncSetup
   }


### PR DESCRIPTION
Reapplies selectively reviewed local changes from the preserved pre-KAN-14 workspace changes.

## What changed

- `README.md`: clarifies `DATABASE_URL` requirements and AWS setup guidance.
- `dev-local-launcher.cmd`: removes automatic setup execution to avoid local setup loops; now guides the user to run AWS setup manually.
- `scripts/release/common.ps1`: improves environment variable persistence with User-scope fallback when Machine scope is unavailable.
- `scripts/release/maintenance/setup-aws.ps1`: adds parameters and improves AWS setup wizard input/default handling.

## Scope boundaries

- No production requests UI changes.
- No `tokens.css` / KAN-78 visual-token changes.
- No KAN-14 / Jira changes.
- No generated artifacts.
- No deletion of coordination files.

## Validation

- `npm run -s typecheck` -> PASS

## Follow-up

Production requests UI changes from the preserved branch should be reviewed in a separate feature branch.