### PR TITLE
KAN-84: add official purchase order document snapshot and PDF download

### DIFF
--- a/app/(shell)/purchasing/orders/[id]/document/page.tsx
+++ b/app/(shell)/purchasing/orders/[id]/document/page.tsx
@@ -1,0 +1,180 @@
+import Link from "next/link";
+import prisma from "@/lib/prisma";
+import { pageGuard } from "@/components/rbac/PageGuard";
+import { PurchaseOrderDocumentPrintButton } from "@/components/purchasing/PurchaseOrderDocumentPrintButton";
+import {
+  loadLatestPurchaseOrderDocument,
+  parsePurchaseOrderDocumentSnapshot,
+} from "@/lib/purchasing/purchase-order-document-service";
+
+function money(value: number, currency: string) {
+  return new Intl.NumberFormat("es-MX", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleDateString("es-MX");
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function PurchaseOrderDocumentPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  await pageGuard("purchasing.manage");
+  const { id } = await params;
+
+  const documentRecord = await loadLatestPurchaseOrderDocument({ purchaseOrderId: id, prismaClient: prisma });
+
+  if (!documentRecord) {
+    return (
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">Documento oficial de OC</h1>
+            <p className="text-sm text-slate-400">Revisión del documento oficial congelado.</p>
+          </div>
+          <Link href={`/purchasing/orders/${id}`} className="px-4 py-2 glass rounded-lg text-slate-300 hover:text-white">
+            ← Volver a la OC
+          </Link>
+        </div>
+        <div className="glass-card border border-amber-500/30 text-amber-100 text-sm">
+          No existe un documento oficial persistido para esta OC. Revisión requerida.
+        </div>
+      </div>
+    );
+  }
+
+  let snapshot;
+  try {
+    snapshot = parsePurchaseOrderDocumentSnapshot(documentRecord.snapshotJson);
+  } catch {
+    return (
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">Documento oficial de OC</h1>
+            <p className="text-sm text-slate-400">No fue posible leer el snapshot persistido.</p>
+          </div>
+          <Link href={`/purchasing/orders/${id}`} className="px-4 py-2 glass rounded-lg text-slate-300 hover:text-white">
+            ← Volver a la OC
+          </Link>
+        </div>
+        <div className="glass-card border border-red-500/30 text-red-100 text-sm">
+          El snapshot oficial está corrupto o es inválido. Revisión requerida.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6 print:max-w-none print:space-y-4">
+      <div className="flex items-start justify-between gap-4 print:hidden">
+        <div>
+          <h1 className="text-2xl font-bold">Documento oficial de OC</h1>
+          <p className="text-sm text-slate-400">
+            Vista congelada de la orden {snapshot.purchaseOrder.folio} v{snapshot.documentVersion}
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Link href={`/purchasing/orders/${id}`} className="px-4 py-2 glass rounded-lg text-slate-300 hover:text-white">
+            ← Volver
+          </Link>
+          <PurchaseOrderDocumentPrintButton />
+          <a href={`/api/purchasing/orders/${id}/pdf`} className="btn-primary">
+            Descargar PDF
+          </a>
+        </div>
+      </div>
+
+      <div className="glass-card print:shadow-none print:border print:border-black/20">
+        <div className="flex items-start justify-between gap-4 border-b border-white/10 pb-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Orden de compra oficial</p>
+            <h2 className="text-3xl font-bold font-mono mt-1">{snapshot.purchaseOrder.folio}</h2>
+            <p className="text-sm text-slate-400 mt-1">
+              Versión v{snapshot.documentVersion} · Generado {new Date(snapshot.generatedAt).toLocaleString("es-MX")}
+            </p>
+          </div>
+          <div className="text-right text-sm text-slate-300">
+            <p className="font-semibold text-slate-200">{snapshot.supplier.businessName ?? snapshot.supplier.name}</p>
+            <p>{snapshot.supplier.legalName ?? "—"}</p>
+            <p className="text-xs text-slate-500">RFC: {snapshot.supplier.taxId ?? "—"}</p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 mt-4">
+          <div className="space-y-1 text-sm">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Datos de la OC</p>
+            <p>Estado: {snapshot.purchaseOrder.status}</p>
+            <p>Fecha esperada: {formatDate(snapshot.purchaseOrder.expectedDate)}</p>
+            <p>Creada: {new Date(snapshot.purchaseOrder.createdAt).toLocaleString("es-MX")}</p>
+          </div>
+          <div className="space-y-1 text-sm">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Contacto proveedor</p>
+            <p>Correo: {snapshot.supplier.email ?? "—"}</p>
+            <p>Teléfono: {snapshot.supplier.phone ?? "—"}</p>
+            <p>Dirección: {snapshot.supplier.address ?? "—"}</p>
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Notas</p>
+          <p className="text-sm text-slate-200 mt-1">{snapshot.purchaseOrder.notes ?? "—"}</p>
+        </div>
+
+        <div className="mt-5 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-white/10 text-slate-400">
+                <th className="py-2 text-left">SKU</th>
+                <th className="py-2 text-left">Producto</th>
+                <th className="py-2 text-right">Pedido</th>
+                <th className="py-2 text-right">Recibido</th>
+                <th className="py-2 text-right">Pendiente</th>
+                <th className="py-2 text-center">Unidad</th>
+                <th className="py-2 text-right">Precio</th>
+                <th className="py-2 text-right">Subtotal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {snapshot.lines.map((line) => (
+                <tr key={line.productId} className="border-b border-white/5">
+                  <td className="py-2 font-mono text-cyan-400 text-xs">{line.sku}</td>
+                  <td className="py-2 text-slate-200">{line.name}</td>
+                  <td className="py-2 text-right">{line.qtyOrdered}</td>
+                  <td className="py-2 text-right">{line.qtyReceived}</td>
+                  <td className="py-2 text-right">{line.pendingQty}</td>
+                  <td className="py-2 text-center text-slate-400">{line.unitLabel}</td>
+                  <td className="py-2 text-right">{money(line.unitPrice, line.currency)}</td>
+                  <td className="py-2 text-right">{money(line.subtotal, line.currency)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-5 flex justify-end">
+          <div className="w-full max-w-xs rounded-lg border border-white/10 p-4">
+            <div className="flex justify-between text-sm">
+              <span className="text-slate-400">Subtotal</span>
+              <span>{money(snapshot.totals.subtotal, snapshot.totals.currency)}</span>
+            </div>
+            <div className="mt-2 flex justify-between text-base font-semibold">
+              <span>Total</span>
+              <span>{money(snapshot.totals.total, snapshot.totals.currency)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(shell)/purchasing/orders/[id]/page.tsx
+++ b/app/(shell)/purchasing/orders/[id]/page.tsx
@@ -2,7 +2,12 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import prisma from "@/lib/prisma";
 import { purchaseOrderLineSchema, firstErrorMessage } from "@/lib/schemas/wms";
-import { createAuditLogSafe } from "@/lib/audit-log";
+import { pageGuard } from "@/components/rbac/PageGuard";
+import {
+  loadLatestPurchaseOrderDocument,
+  parsePurchaseOrderDocumentSnapshot,
+  updatePurchaseOrderStatusWithDocument,
+} from "@/lib/purchasing/purchase-order-document-service";
 
 const STATUS_LABELS: Record<string, string> = {
   BORRADOR: "Borrador",
@@ -34,44 +39,18 @@ const TRANSITIONS: Record<string, string[]> = {
 
 async function updateStatus(orderId: string, formData: FormData) {
   "use server";
+  await (await import("@/lib/rbac")).requirePermission("purchasing.manage");
 
   const newStatus = String(formData.get("status") ?? "").trim();
-
-  const order = await prisma.purchaseOrder.findUnique({
-    where: { id: orderId },
-    select: {
-      status: true,
-      lines: { select: { qtyOrdered: true, qtyReceived: true } },
-    },
+  const result = await updatePurchaseOrderStatusWithDocument({
+    purchaseOrderId: orderId,
+    newStatus,
+    prismaClient: prisma,
   });
-  if (!order) redirect(`/purchasing/orders/${orderId}?error=Orden no encontrada`);
 
-  const allowed = TRANSITIONS[order.status] ?? [];
-  if (!allowed.includes(newStatus)) {
-    redirect(`/purchasing/orders/${orderId}?error=${encodeURIComponent(`Transición ${order.status} → ${newStatus} no permitida`)}`);
+  if ("error" in result) {
+    redirect(`/purchasing/orders/${orderId}?error=${encodeURIComponent(result.error)}`);
   }
-
-  if (newStatus === "CONFIRMADA" && order.lines.length === 0) {
-    redirect(`/purchasing/orders/${orderId}?error=${encodeURIComponent("Agrega al menos una línea antes de confirmar")}`);
-  }
-
-  if (newStatus === "RECIBIDA") {
-    const allComplete = order.lines.every((l) => l.qtyReceived >= l.qtyOrdered);
-    if (!allComplete) {
-      redirect(`/purchasing/orders/${orderId}?error=${encodeURIComponent("Hay líneas con pendiente de recibir — usa Recepción Parcial")}`);
-    }
-  }
-
-  await prisma.purchaseOrder.update({ where: { id: orderId }, data: { status: newStatus as never } });
-
-  await createAuditLogSafe({
-    entityType: "PURCHASE_ORDER",
-    entityId: orderId,
-    action: "STATUS_CHANGE",
-    before: JSON.stringify({ status: order.status }),
-    after: JSON.stringify({ status: newStatus }),
-    source: "purchasing/orders",
-  });
 
   const { emitSyncEventSafe } = await import("@/lib/sync/sync-events");
   await emitSyncEventSafe({
@@ -86,6 +65,7 @@ async function updateStatus(orderId: string, formData: FormData) {
 
 async function addLine(orderId: string, formData: FormData) {
   "use server";
+  await (await import("@/lib/rbac")).requirePermission("purchasing.manage");
 
   const productId = String(formData.get("productId") ?? "").trim();
   const qtyOrderedRaw = String(formData.get("qtyOrderedRaw") ?? "").trim();
@@ -124,6 +104,7 @@ async function addLine(orderId: string, formData: FormData) {
 
 async function removeLine(orderId: string, formData: FormData) {
   "use server";
+  await (await import("@/lib/rbac")).requirePermission("purchasing.manage");
 
   const lineId = String(formData.get("lineId") ?? "").trim();
 
@@ -150,6 +131,7 @@ export default async function PurchaseOrderDetailPage({
   params: Promise<{ id: string }>;
   searchParams: Promise<{ ok?: string; error?: string }>;
 }) {
+  await pageGuard("purchasing.manage");
   const { id } = await params;
   const sp = await searchParams;
 
@@ -202,6 +184,15 @@ export default async function PurchaseOrderDetailPage({
   const totalReceived = order.lines.reduce((s, l) => s + l.qtyReceived, 0);
   const pctReceived = totalOrdered > 0 ? Math.round((totalReceived / totalOrdered) * 100) : 0;
   const totalValue = order.lines.reduce((s, l) => s + (l.unitPrice ?? 0) * l.qtyOrdered, 0);
+  const documentRecord = await loadLatestPurchaseOrderDocument({ purchaseOrderId: id, prismaClient: prisma });
+  let documentSnapshot = null;
+  if (documentRecord) {
+    try {
+      documentSnapshot = parsePurchaseOrderDocumentSnapshot(documentRecord.snapshotJson);
+    } catch {
+      documentSnapshot = null;
+    }
+  }
 
   const allowedTransitions = TRANSITIONS[order.status] ?? [];
   const hasPending = order.lines.some((l) => l.qtyReceived < l.qtyOrdered);
@@ -283,6 +274,40 @@ export default async function PurchaseOrderDetailPage({
           </div>
         </div>
       )}
+
+      <div className="glass-card space-y-3">
+        <h2 className="text-lg font-bold border-b border-white/10 pb-2">Documento oficial</h2>
+        {order.status === "BORRADOR" ? (
+          <p className="text-sm text-slate-400">Documento oficial disponible al confirmar.</p>
+        ) : documentSnapshot ? (
+          <div className="space-y-3">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3 text-sm">
+              <div className="glass p-3 rounded-lg">
+                <p className="text-xs uppercase text-slate-400">Versión</p>
+                <p className="text-white font-semibold">v{documentSnapshot.documentVersion}</p>
+              </div>
+              <div className="glass p-3 rounded-lg">
+                <p className="text-xs uppercase text-slate-400">Generado</p>
+                <p className="text-white font-semibold">{new Date(documentSnapshot.generatedAt).toLocaleString("es-MX")}</p>
+              </div>
+              <div className="glass p-3 rounded-lg">
+                <p className="text-xs uppercase text-slate-400">Estado congelado</p>
+                <p className="text-white font-semibold">{documentSnapshot.purchaseOrder.status}</p>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link href={`/purchasing/orders/${id}/document`} className="px-4 py-2 glass rounded-lg text-slate-300 hover:text-white">
+                Ver documento oficial
+              </Link>
+              <a href={`/api/purchasing/orders/${id}/pdf`} className="btn-primary">
+                Descargar PDF
+              </a>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-amber-200">Documento oficial no generado para esta OC. Revisión requerida.</p>
+        )}
+      </div>
 
       {/* Líneas */}
       <div className="glass-card space-y-4">

--- a/app/api/purchasing/orders/[id]/pdf/route.ts
+++ b/app/api/purchasing/orders/[id]/pdf/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import React from "react";
+import prisma from "@/lib/prisma";
+import { requirePermission } from "@/lib/rbac";
+import {
+  loadLatestPurchaseOrderDocument,
+  parsePurchaseOrderDocumentSnapshot,
+} from "@/lib/purchasing/purchase-order-document-service";
+import { PurchaseOrderPdfDocument } from "@/lib/purchasing/purchase-order-pdf";
+import { renderToBuffer } from "@react-pdf/renderer";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requirePermission("purchasing.manage");
+  const { id } = await params;
+
+  const documentRecord = await loadLatestPurchaseOrderDocument({ purchaseOrderId: id, prismaClient: prisma });
+
+  if (!documentRecord) {
+    return NextResponse.json(
+      { error: "Documento oficial no generado para esta orden de compra" },
+      { status: 404 },
+    );
+  }
+
+  const snapshot = parsePurchaseOrderDocumentSnapshot(documentRecord.snapshotJson);
+  const pdfBuffer = await renderToBuffer(React.createElement(PurchaseOrderPdfDocument, { snapshot }) as any);
+  const filename = `OC-${snapshot.purchaseOrder.folio}.pdf`;
+
+  return new NextResponse(new Uint8Array(pdfBuffer), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "private, no-store, max-age=0",
+    },
+  });
+}

--- a/app/api/purchasing/orders/[id]/pdf/route.ts
+++ b/app/api/purchasing/orders/[id]/pdf/route.ts
@@ -26,7 +26,9 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   }
 
   const snapshot = parsePurchaseOrderDocumentSnapshot(documentRecord.snapshotJson);
-  const pdfBuffer = await renderToBuffer(React.createElement(PurchaseOrderPdfDocument, { snapshot }) as any);
+  const pdfBuffer = await renderToBuffer(
+    React.createElement(PurchaseOrderPdfDocument, { snapshot }) as unknown as Parameters<typeof renderToBuffer>[0],
+  );
   const filename = `OC-${snapshot.purchaseOrder.folio}.pdf`;
 
   return new NextResponse(new Uint8Array(pdfBuffer), {

--- a/components/purchasing/PurchaseOrderDocumentPrintButton.tsx
+++ b/components/purchasing/PurchaseOrderDocumentPrintButton.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+export function PurchaseOrderDocumentPrintButton() {
+  return (
+    <button
+      type="button"
+      className="px-4 py-2 glass rounded-lg text-slate-300 hover:text-white"
+      onClick={() => window.print()}
+    >
+      Imprimir / Guardar PDF
+    </button>
+  );
+}

--- a/lib/purchasing/purchase-order-document-service.ts
+++ b/lib/purchasing/purchase-order-document-service.ts
@@ -1,0 +1,445 @@
+import { createHash } from "node:crypto";
+import prisma from "@/lib/prisma";
+import { createAuditLogSafeWithDb } from "@/lib/audit-log";
+import { Prisma, PrismaClient } from "@prisma/client";
+
+export type PrismaTransactionLike = PrismaClient | Prisma.TransactionClient;
+
+export type PurchaseOrderDocumentSupplierSnapshot = {
+  code: string;
+  name: string;
+  businessName: string | null;
+  legalName: string | null;
+  taxId: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+};
+
+export type PurchaseOrderDocumentLineSnapshot = {
+  productId: string;
+  sku: string;
+  name: string;
+  unitLabel: string;
+  qtyOrdered: number;
+  qtyReceived: number;
+  pendingQty: number;
+  unitPrice: number;
+  currency: string;
+  subtotal: number;
+};
+
+export type PurchaseOrderDocumentSnapshot = {
+  documentVersion: number;
+  generatedAt: string;
+  purchaseOrder: {
+    id: string;
+    folio: string;
+    status: string;
+    expectedDate: string | null;
+    notes: string | null;
+    createdAt: string;
+  };
+  supplier: PurchaseOrderDocumentSupplierSnapshot;
+  lines: PurchaseOrderDocumentLineSnapshot[];
+  totals: {
+    subtotal: number;
+    total: number;
+    currency: string;
+  };
+  metadata: {
+    source: string;
+    snapshotHash: string;
+    lineCount: number;
+  };
+};
+
+export type PurchaseOrderDocumentRecord = {
+  id: string;
+  purchaseOrderId: string;
+  versionNumber: number;
+  snapshotJson: string;
+  snapshotHash: string | null;
+  createdForStatus: string;
+  createdAt: Date;
+};
+
+export class PurchaseOrderDocumentError extends Error {
+  code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "PurchaseOrderDocumentError";
+    this.code = code;
+  }
+}
+
+function getDb(prismaClient: PrismaTransactionLike = prisma) {
+  return prismaClient;
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableSerialize(entry)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableSerialize(entry)}`);
+
+  return `{${entries.join(",")}}`;
+}
+
+function toIsoDate(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function buildSnapshotHash(payload: Omit<PurchaseOrderDocumentSnapshot, "metadata">): string {
+  return createHash("sha256").update(stableSerialize(payload)).digest("hex");
+}
+
+function normalizeCurrency(value: string | null | undefined) {
+  const currency = String(value ?? "").trim();
+  return currency || "MXN";
+}
+
+function mapPurchaseOrderToSnapshot(input: {
+  documentVersion: number;
+  purchaseOrder: {
+    id: string;
+    folio: string;
+    status: string;
+    expectedDate: Date | null;
+    notes: string | null;
+    createdAt: Date;
+    supplier: {
+      code: string;
+      name: string;
+      legalName: string | null;
+      businessName: string | null;
+      taxId: string | null;
+      email: string | null;
+      phone: string | null;
+      address: string | null;
+    };
+    lines: Array<{
+      productId: string;
+      qtyOrdered: number;
+      qtyReceived: number;
+      unitPrice: number | null;
+      currency: string | null;
+      product: {
+        sku: string;
+        name: string;
+        unitLabel: string;
+      };
+    }>;
+  };
+}): PurchaseOrderDocumentSnapshot {
+  const lines = input.purchaseOrder.lines.map((line) => {
+    const unitPrice = line.unitPrice ?? 0;
+    const currency = normalizeCurrency(line.currency);
+    const pendingQty = Math.max(line.qtyOrdered - line.qtyReceived, 0);
+    const subtotal = Number((unitPrice * line.qtyOrdered).toFixed(2));
+
+    return {
+      productId: line.productId,
+      sku: line.product.sku,
+      name: line.product.name,
+      unitLabel: line.product.unitLabel,
+      qtyOrdered: line.qtyOrdered,
+      qtyReceived: line.qtyReceived,
+      pendingQty,
+      unitPrice: Number(unitPrice.toFixed(2)),
+      currency,
+      subtotal,
+    };
+  });
+
+  const currency = lines[0]?.currency ?? "MXN";
+  const subtotal = Number(lines.reduce((sum, line) => sum + line.subtotal, 0).toFixed(2));
+  const payloadWithoutHash = {
+    documentVersion: input.documentVersion,
+    generatedAt: new Date().toISOString(),
+    purchaseOrder: {
+      id: input.purchaseOrder.id,
+      folio: input.purchaseOrder.folio,
+      status: input.purchaseOrder.status,
+      expectedDate: toIsoDate(input.purchaseOrder.expectedDate),
+      notes: input.purchaseOrder.notes,
+      createdAt: input.purchaseOrder.createdAt.toISOString(),
+    },
+    supplier: {
+      code: input.purchaseOrder.supplier.code,
+      name: input.purchaseOrder.supplier.name,
+      businessName: input.purchaseOrder.supplier.businessName,
+      legalName: input.purchaseOrder.supplier.legalName,
+      taxId: input.purchaseOrder.supplier.taxId,
+      email: input.purchaseOrder.supplier.email,
+      phone: input.purchaseOrder.supplier.phone,
+      address: input.purchaseOrder.supplier.address,
+    },
+    lines,
+    totals: {
+      subtotal,
+      total: subtotal,
+      currency,
+    },
+  };
+
+  const snapshotHash = buildSnapshotHash(payloadWithoutHash);
+
+  return {
+    ...payloadWithoutHash,
+    metadata: {
+      source: "purchasing/purchase-order-document-service",
+      snapshotHash,
+      lineCount: lines.length,
+    },
+  };
+}
+
+async function loadPurchaseOrderForDocument(db: PrismaTransactionLike, purchaseOrderId: string) {
+  return db.purchaseOrder.findUnique({
+    where: { id: purchaseOrderId },
+    select: {
+      id: true,
+      folio: true,
+      status: true,
+      expectedDate: true,
+      notes: true,
+      createdAt: true,
+      supplier: {
+        select: {
+          code: true,
+          name: true,
+          legalName: true,
+          businessName: true,
+          taxId: true,
+          email: true,
+          phone: true,
+          address: true,
+        },
+      },
+      lines: {
+        orderBy: [{ product: { sku: "asc" } }, { productId: "asc" }],
+        select: {
+          productId: true,
+          qtyOrdered: true,
+          qtyReceived: true,
+          unitPrice: true,
+          currency: true,
+          product: {
+            select: {
+              sku: true,
+              name: true,
+              unitLabel: true,
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+export function parsePurchaseOrderDocumentSnapshot(snapshotJson: string): PurchaseOrderDocumentSnapshot {
+  try {
+    const parsed = JSON.parse(snapshotJson) as PurchaseOrderDocumentSnapshot;
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error("invalid snapshot");
+    }
+    return parsed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new PurchaseOrderDocumentError("INVALID_DOCUMENT_SNAPSHOT", `Invalid purchase order document snapshot: ${message}`);
+  }
+}
+
+export async function buildPurchaseOrderDocumentSnapshot(input: {
+  purchaseOrderId: string;
+  prismaClient?: PrismaTransactionLike;
+  documentVersion?: number;
+}): Promise<PurchaseOrderDocumentSnapshot> {
+  const db = getDb(input.prismaClient);
+  const purchaseOrder = await loadPurchaseOrderForDocument(db, input.purchaseOrderId);
+
+  if (!purchaseOrder) {
+    throw new PurchaseOrderDocumentError("PURCHASE_ORDER_NOT_FOUND", "Purchase order not found");
+  }
+
+  if (purchaseOrder.lines.length === 0) {
+    throw new PurchaseOrderDocumentError("PURCHASE_ORDER_HAS_NO_LINES", "Purchase order has no lines");
+  }
+
+  return mapPurchaseOrderToSnapshot({
+    documentVersion: input.documentVersion ?? 1,
+    purchaseOrder,
+  });
+}
+
+export async function loadLatestPurchaseOrderDocument(input: {
+  purchaseOrderId: string;
+  prismaClient?: PrismaTransactionLike;
+}): Promise<PurchaseOrderDocumentRecord | null> {
+  const db = getDb(input.prismaClient);
+  return db.purchaseOrderDocument.findFirst({
+    where: { purchaseOrderId: input.purchaseOrderId },
+    orderBy: { versionNumber: "desc" },
+  });
+}
+
+export async function ensurePurchaseOrderDocumentVersion(input: {
+  purchaseOrderId: string;
+  versionNumber?: number;
+  createdForStatus?: string;
+  prismaClient?: PrismaTransactionLike;
+}): Promise<PurchaseOrderDocumentRecord> {
+  const db = getDb(input.prismaClient);
+  const versionNumber = input.versionNumber ?? 1;
+  const createdForStatus = input.createdForStatus ?? "CONFIRMADA";
+
+  const existing = await db.purchaseOrderDocument.findUnique({
+    where: {
+      purchaseOrderId_versionNumber: {
+        purchaseOrderId: input.purchaseOrderId,
+        versionNumber,
+      },
+    },
+  });
+
+  if (existing) {
+    return existing;
+  }
+
+  const snapshot = await buildPurchaseOrderDocumentSnapshot({
+    purchaseOrderId: input.purchaseOrderId,
+    prismaClient: db,
+    documentVersion: versionNumber,
+  });
+
+  try {
+    return await db.purchaseOrderDocument.create({
+      data: {
+        purchaseOrderId: input.purchaseOrderId,
+        versionNumber,
+        snapshotJson: JSON.stringify(snapshot),
+        snapshotHash: snapshot.metadata.snapshotHash,
+        createdForStatus,
+      },
+    });
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code?: string }).code === "P2002") {
+      const retry = await db.purchaseOrderDocument.findUnique({
+        where: {
+          purchaseOrderId_versionNumber: {
+            purchaseOrderId: input.purchaseOrderId,
+            versionNumber,
+          },
+        },
+      });
+
+      if (retry) {
+        return retry;
+      }
+    }
+
+    throw error;
+  }
+}
+
+const PURCHASE_ORDER_STATUS_TRANSITIONS: Record<string, string[]> = {
+  BORRADOR: ["CONFIRMADA", "CANCELADA"],
+  CONFIRMADA: ["EN_TRANSITO", "CANCELADA"],
+  EN_TRANSITO: ["RECIBIDA", "CANCELADA"],
+  PARCIAL: ["EN_TRANSITO", "CANCELADA"],
+  RECIBIDA: [],
+  CANCELADA: [],
+};
+
+export async function updatePurchaseOrderStatusWithDocument(input: {
+  purchaseOrderId: string;
+  newStatus: string;
+  prismaClient?: PrismaClient;
+}): Promise<{ ok: true } | { error: string }> {
+  const db = input.prismaClient ?? prisma;
+
+  return db.$transaction(async (tx) => {
+    const order = await tx.purchaseOrder.findUnique({
+      where: { id: input.purchaseOrderId },
+      select: {
+        status: true,
+        lines: { select: { qtyOrdered: true, qtyReceived: true } },
+      },
+    });
+
+    if (!order) {
+      return { error: "Orden no encontrada" };
+    }
+
+    const allowed = PURCHASE_ORDER_STATUS_TRANSITIONS[order.status] ?? [];
+    if (!allowed.includes(input.newStatus)) {
+      return { error: `Transición ${order.status} → ${input.newStatus} no permitida` };
+    }
+
+    if (input.newStatus === "CONFIRMADA" && order.lines.length === 0) {
+      return { error: "Agrega al menos una línea antes de confirmar" };
+    }
+
+    if (input.newStatus === "RECIBIDA") {
+      const allComplete = order.lines.every((line) => line.qtyReceived >= line.qtyOrdered);
+      if (!allComplete) {
+        return { error: "Hay líneas con pendiente de recibir — usa Recepción Parcial" };
+      }
+    }
+
+    await tx.purchaseOrder.update({
+      where: { id: input.purchaseOrderId },
+      data: { status: input.newStatus as never },
+    });
+
+    if (input.newStatus === "CONFIRMADA") {
+      const documentRecord = await ensurePurchaseOrderDocumentVersion({
+        purchaseOrderId: input.purchaseOrderId,
+        versionNumber: 1,
+        createdForStatus: "CONFIRMADA",
+        prismaClient: tx,
+      });
+
+      await createAuditLogSafeWithDb(
+        {
+          entityType: "PURCHASE_ORDER_DOCUMENT",
+          entityId: documentRecord.id,
+          action: "CREATE_PURCHASE_ORDER_DOCUMENT_VERSION",
+          after: {
+            purchaseOrderId: input.purchaseOrderId,
+            versionNumber: documentRecord.versionNumber,
+            createdForStatus: documentRecord.createdForStatus,
+            snapshotHash: documentRecord.snapshotHash,
+          },
+          source: "purchasing/order-confirmation",
+        },
+        tx,
+      );
+    }
+
+    await createAuditLogSafeWithDb(
+      {
+        entityType: "PURCHASE_ORDER",
+        entityId: input.purchaseOrderId,
+        action: "STATUS_CHANGE",
+        before: { status: order.status },
+        after: { status: input.newStatus },
+        source: "purchasing/orders",
+      },
+      tx,
+    );
+
+    return { ok: true as const };
+  });
+}

--- a/lib/purchasing/purchase-order-pdf.tsx
+++ b/lib/purchasing/purchase-order-pdf.tsx
@@ -1,0 +1,242 @@
+import React from "react";
+import { Document, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+import type { PurchaseOrderDocumentSnapshot } from "@/lib/purchasing/purchase-order-document-service";
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: "Helvetica",
+    fontSize: 9,
+    paddingTop: 28,
+    paddingHorizontal: 24,
+    paddingBottom: 24,
+    color: "#111827",
+  },
+  header: {
+    marginBottom: 14,
+    paddingBottom: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: "#111827",
+    borderBottomStyle: "solid",
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 700,
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 10,
+    color: "#4b5563",
+  },
+  metaRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 8,
+  },
+  section: {
+    marginBottom: 10,
+  },
+  sectionTitle: {
+    fontSize: 10,
+    fontWeight: 700,
+    marginBottom: 4,
+  },
+  card: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderStyle: "solid",
+    borderRadius: 3,
+    padding: 8,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  column: {
+    flexGrow: 1,
+    flexBasis: 0,
+  },
+  textMuted: {
+    color: "#4b5563",
+  },
+  lineTable: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderStyle: "solid",
+  },
+  lineHeader: {
+    flexDirection: "row",
+    backgroundColor: "#f3f4f6",
+    borderBottomWidth: 1,
+    borderBottomColor: "#d1d5db",
+    borderBottomStyle: "solid",
+  },
+  lineCell: {
+    paddingVertical: 5,
+    paddingHorizontal: 4,
+    borderRightWidth: 1,
+    borderRightColor: "#e5e7eb",
+    borderRightStyle: "solid",
+  },
+  lineBody: {
+    flexDirection: "row",
+    borderBottomWidth: 1,
+    borderBottomColor: "#e5e7eb",
+    borderBottomStyle: "solid",
+  },
+  lineBodyLast: {
+    borderBottomWidth: 0,
+  },
+  lineSku: {
+    width: "10%",
+  },
+  lineProduct: {
+    width: "24%",
+  },
+  lineQty: {
+    width: "8%",
+    textAlign: "right",
+  },
+  lineQtyWide: {
+    width: "9%",
+    textAlign: "right",
+  },
+  lineUnit: {
+    width: "8%",
+    textAlign: "center",
+  },
+  lineMoney: {
+    width: "11%",
+    textAlign: "right",
+  },
+  totals: {
+    marginTop: 8,
+    width: "100%",
+    alignItems: "flex-end",
+  },
+  totalsBox: {
+    width: 170,
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderStyle: "solid",
+    padding: 8,
+  },
+  totalsRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 3,
+  },
+  notes: {
+    minHeight: 34,
+  },
+});
+
+function money(value: number, currency: string) {
+  return new Intl.NumberFormat("es-MX", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleDateString("es-MX");
+}
+
+export function PurchaseOrderPdfDocument({ snapshot }: { snapshot: PurchaseOrderDocumentSnapshot }) {
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Orden de Compra Oficial</Text>
+          <Text style={styles.subtitle}>WMS Mangueras y Conexiones</Text>
+          <View style={styles.metaRow}>
+            <Text>Folio: {snapshot.purchaseOrder.folio}</Text>
+            <Text>Versión: v{snapshot.documentVersion}</Text>
+          </View>
+          <View style={styles.metaRow}>
+            <Text>Generado: {new Date(snapshot.generatedAt).toLocaleString("es-MX")}</Text>
+            <Text>Estado: {snapshot.purchaseOrder.status}</Text>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Proveedor</Text>
+          <View style={styles.card}>
+            <Text>{snapshot.supplier.businessName ?? snapshot.supplier.name}</Text>
+            <Text style={styles.textMuted}>{snapshot.supplier.legalName ?? "—"}</Text>
+            <Text style={styles.textMuted}>Código: {snapshot.supplier.code}</Text>
+            <Text style={styles.textMuted}>RFC: {snapshot.supplier.taxId ?? "—"}</Text>
+            <Text style={styles.textMuted}>Correo: {snapshot.supplier.email ?? "—"}</Text>
+            <Text style={styles.textMuted}>Teléfono: {snapshot.supplier.phone ?? "—"}</Text>
+            <Text style={styles.textMuted}>Dirección: {snapshot.supplier.address ?? "—"}</Text>
+          </View>
+        </View>
+
+        <View style={styles.row}>
+          <View style={[styles.section, styles.column]}>
+            <Text style={styles.sectionTitle}>Datos de la OC</Text>
+            <View style={styles.card}>
+              <Text>Creada: {new Date(snapshot.purchaseOrder.createdAt).toLocaleString("es-MX")}</Text>
+              <Text>Fecha esperada: {formatDate(snapshot.purchaseOrder.expectedDate)}</Text>
+              <Text>Versión documento: v{snapshot.documentVersion}</Text>
+            </View>
+          </View>
+          <View style={[styles.section, styles.column]}>
+            <Text style={styles.sectionTitle}>Notas</Text>
+            <View style={[styles.card, styles.notes]}>
+              <Text>{snapshot.purchaseOrder.notes ?? "—"}</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Líneas</Text>
+          <View style={styles.lineTable}>
+            <View style={styles.lineHeader}>
+              <Text style={[styles.lineCell, styles.lineSku]}>SKU</Text>
+              <Text style={[styles.lineCell, styles.lineProduct]}>Producto</Text>
+              <Text style={[styles.lineCell, styles.lineQty]}>Ped.</Text>
+              <Text style={[styles.lineCell, styles.lineQty]}>Rec.</Text>
+              <Text style={[styles.lineCell, styles.lineQty]}>Pend.</Text>
+              <Text style={[styles.lineCell, styles.lineUnit]}>U.</Text>
+              <Text style={[styles.lineCell, styles.lineMoney]}>P. Unit.</Text>
+              <Text style={[styles.lineCell, styles.lineMoney]}>Subtotal</Text>
+            </View>
+            {snapshot.lines.map((line, index) => (
+              <View
+                key={`${line.productId}-${index}`}
+                style={index === snapshot.lines.length - 1 ? [styles.lineBody, styles.lineBodyLast] : styles.lineBody}
+              >
+                <Text style={[styles.lineCell, styles.lineSku]}>{line.sku}</Text>
+                <Text style={[styles.lineCell, styles.lineProduct]}>{line.name}</Text>
+                <Text style={[styles.lineCell, styles.lineQty]}>{line.qtyOrdered}</Text>
+                <Text style={[styles.lineCell, styles.lineQty]}>{line.qtyReceived}</Text>
+                <Text style={[styles.lineCell, styles.lineQty]}>{line.pendingQty}</Text>
+                <Text style={[styles.lineCell, styles.lineUnit]}>{line.unitLabel}</Text>
+                <Text style={[styles.lineCell, styles.lineMoney]}>{money(line.unitPrice, line.currency)}</Text>
+                <Text style={[styles.lineCell, styles.lineMoney]}>{money(line.subtotal, line.currency)}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.totals}>
+          <View style={styles.totalsBox}>
+            <View style={styles.totalsRow}>
+              <Text>Subtotal</Text>
+              <Text>{money(snapshot.totals.subtotal, snapshot.totals.currency)}</Text>
+            </View>
+            <View style={styles.totalsRow}>
+              <Text>Total</Text>
+              <Text>{money(snapshot.totals.total, snapshot.totals.currency)}</Text>
+            </View>
+          </View>
+        </View>
+      </Page>
+    </Document>
+  );
+}

--- a/lib/rbac/route-permissions.ts
+++ b/lib/rbac/route-permissions.ts
@@ -58,6 +58,7 @@ export const ROUTE_PERMISSION_RULES: RoutePermissionRule[] = [
 
   { prefix: "/api/export/kardex", permission: "kardex.view" },
   { prefix: "/api/export/audit", permission: "audit.view" },
+  { prefix: "/api/purchasing/orders/", permission: "purchasing.manage" },
   { prefix: "/api/products/lookup", permission: "catalog.view" },
   { prefix: "/api/products/search", permission: "catalog.view" },
   { prefix: "/api/labels/jobs/", permission: "labels.manage" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@aws-sdk/client-dynamodb": "^3.1029.0",
         "@aws-sdk/client-sqs": "^3.1029.0",
         "@prisma/client": "6.19.2",
+        "@react-pdf/renderer": "^4.5.1",
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
         "bcryptjs": "^3.0.3",
@@ -1770,6 +1771,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -3173,6 +3183,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@node-minify/core": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/@node-minify/core/-/core-8.0.6.tgz",
@@ -3991,6 +4025,183 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.2"
+      }
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6225,6 +6436,12 @@
       "license": "(Unlicense OR Apache-2.0)",
       "optional": true
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6558,6 +6775,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -6574,6 +6811,15 @@
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/body-parser": {
@@ -6629,6 +6875,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -6898,6 +7162,15 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6915,6 +7188,27 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -7215,6 +7509,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
@@ -7299,6 +7599,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/empathic": {
@@ -8037,6 +8343,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -8135,7 +8450,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -8227,6 +8541,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8312,6 +8632,23 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -8765,6 +9102,21 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -8785,6 +9137,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -8844,7 +9202,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -9257,6 +9614,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -9335,6 +9698,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -9354,11 +9726,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9742,6 +10119,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -9769,7 +10165,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -9814,6 +10209,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -10125,6 +10526,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/nypm": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
@@ -10163,7 +10573,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10395,6 +10804,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10407,6 +10822,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -10602,6 +11023,14 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/pngjs": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
@@ -10649,6 +11078,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/preact": {
       "version": "10.24.3",
@@ -10711,7 +11146,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -10791,6 +11225,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -10878,7 +11321,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
@@ -10948,6 +11390,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -10994,6 +11445,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -11122,6 +11579,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -11529,6 +12006,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -11778,6 +12264,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -11817,6 +12309,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -12162,6 +12660,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -12255,6 +12779,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -12339,6 +12869,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vite-node": {
@@ -12776,6 +13320,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@aws-sdk/client-dynamodb": "^3.1029.0",
     "@aws-sdk/client-sqs": "^3.1029.0",
     "@prisma/client": "6.19.2",
+    "@react-pdf/renderer": "^4.5.1",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
     "bcryptjs": "^3.0.3",

--- a/prisma/migrations/20260602120000_kan84_purchase_order_documents/migration.sql
+++ b/prisma/migrations/20260602120000_kan84_purchase_order_documents/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "PurchaseOrderDocument" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "purchaseOrderId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "snapshotJson" TEXT NOT NULL,
+    "snapshotHash" TEXT,
+    "createdForStatus" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PurchaseOrderDocument_purchaseOrderId_fkey" FOREIGN KEY ("purchaseOrderId") REFERENCES "PurchaseOrder" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PurchaseOrderDocument_purchaseOrderId_versionNumber_key"
+ON "PurchaseOrderDocument"("purchaseOrderId", "versionNumber");
+
+-- CreateIndex
+CREATE INDEX "PurchaseOrderDocument_purchaseOrderId_createdAt_idx"
+ON "PurchaseOrderDocument"("purchaseOrderId", "createdAt");

--- a/prisma/postgresql/migrations/20260602120000_kan84_purchase_order_documents/migration.sql
+++ b/prisma/postgresql/migrations/20260602120000_kan84_purchase_order_documents/migration.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "PurchaseOrderDocument" (
+    "id" TEXT NOT NULL,
+    "purchaseOrderId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "snapshotJson" TEXT NOT NULL,
+    "snapshotHash" TEXT,
+    "createdForStatus" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PurchaseOrderDocument_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "PurchaseOrderDocument_purchaseOrderId_fkey" FOREIGN KEY ("purchaseOrderId") REFERENCES "PurchaseOrder" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "PurchaseOrderDocument_purchaseOrderId_versionNumber_key"
+ON "PurchaseOrderDocument"("purchaseOrderId", "versionNumber");
+
+CREATE INDEX "PurchaseOrderDocument_purchaseOrderId_createdAt_idx"
+ON "PurchaseOrderDocument"("purchaseOrderId", "createdAt");

--- a/prisma/postgresql/schema.prisma
+++ b/prisma/postgresql/schema.prisma
@@ -973,6 +973,7 @@ model PurchaseOrder {
   supplier Supplier           @relation(fields: [supplierId], references: [id], onDelete: Restrict)
   lines    PurchaseOrderLine[]
   receipts PurchaseReceipt[]
+  documents PurchaseOrderDocument[]
 
   @@index([supplierId])
   @@index([status])
@@ -995,6 +996,21 @@ model PurchaseOrderLine {
   @@unique([purchaseOrderId, productId])
   @@index([purchaseOrderId])
   @@index([productId])
+}
+
+model PurchaseOrderDocument {
+  id              String   @id @default(uuid())
+  purchaseOrderId String
+  versionNumber   Int
+  snapshotJson    String
+  snapshotHash    String?
+  createdForStatus String
+  createdAt       DateTime @default(now())
+
+  purchaseOrder PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+
+  @@unique([purchaseOrderId, versionNumber])
+  @@index([purchaseOrderId, createdAt])
 }
 
 model PurchaseReceipt {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -944,6 +944,7 @@ model PurchaseOrder {
   supplier Supplier           @relation(fields: [supplierId], references: [id], onDelete: Restrict)
   lines    PurchaseOrderLine[]
   receipts PurchaseReceipt[]
+  documents PurchaseOrderDocument[]
 
   @@index([supplierId])
   @@index([status])
@@ -966,6 +967,21 @@ model PurchaseOrderLine {
   @@unique([purchaseOrderId, productId])
   @@index([purchaseOrderId])
   @@index([productId])
+}
+
+model PurchaseOrderDocument {
+  id              String   @id @default(uuid())
+  purchaseOrderId String
+  versionNumber   Int
+  snapshotJson    String
+  snapshotHash    String?
+  createdForStatus String
+  createdAt       DateTime @default(now())
+
+  purchaseOrder PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+
+  @@unique([purchaseOrderId, versionNumber])
+  @@index([purchaseOrderId, createdAt])
 }
 
 model PurchaseReceipt {

--- a/tests/purchasing/purchase-order-document-route.integration.test.ts
+++ b/tests/purchasing/purchase-order-document-route.integration.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { updatePurchaseOrderStatusWithDocument } from "@/lib/purchasing/purchase-order-document-service";
+
+vi.mock("@/lib/rbac", () => ({
+  requirePermission: vi.fn(async () => undefined),
+}));
+
+const shouldRunPostgresSuite = process.env.RUN_POSTGRES_TESTS === "1"
+  && /^postgres(ql)?:\/\//i.test(String(process.env.DATABASE_URL ?? ""));
+
+const describePostgres = shouldRunPostgresSuite ? describe : describe.skip;
+
+describePostgres("purchase order document pdf route integration", () => {
+  const prisma = new PrismaClient();
+  const unique = () => `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+  async function resetDb() {
+    await prisma.purchaseOrderDocument.deleteMany();
+    await prisma.purchaseReceiptLine.deleteMany();
+    await prisma.purchaseReceipt.deleteMany();
+    await prisma.purchaseOrderLine.deleteMany();
+    await prisma.purchaseOrder.deleteMany();
+    await prisma.supplierProduct.deleteMany();
+    await prisma.supplier.deleteMany();
+    await prisma.product.deleteMany();
+  }
+
+  async function createFixture() {
+    const supplier = await prisma.supplier.create({
+      data: {
+        code: `SUP-${unique()}`,
+        name: "Proveedor PDF",
+      },
+    });
+    const product = await prisma.product.create({
+      data: {
+        sku: `SKU-${unique()}`,
+        name: "Producto PDF",
+        type: "HOSE",
+      },
+    });
+    const order = await prisma.purchaseOrder.create({
+      data: {
+        folio: `OC-${unique()}`,
+        supplierId: supplier.id,
+        status: "BORRADOR",
+        lines: {
+          create: [{
+            productId: product.id,
+            qtyOrdered: 2,
+            qtyReceived: 0,
+            unitPrice: 20,
+          }],
+        },
+      },
+      select: { id: true, folio: true },
+    });
+
+    await updatePurchaseOrderStatusWithDocument({
+      purchaseOrderId: order.id,
+      newStatus: "CONFIRMADA",
+      prismaClient: prisma,
+    });
+
+    return { order };
+  }
+
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  afterAll(async () => {
+    await resetDb();
+    await prisma.$disconnect();
+  });
+
+  it("returns application/pdf and attachment filename", async () => {
+    const { order } = await createFixture();
+    const { GET } = await import("@/app/api/purchasing/orders/[id]/pdf/route");
+
+    const response = await GET(new NextRequest(`http://localhost/api/purchasing/orders/${order.id}/pdf`), {
+      params: { id: order.id },
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/pdf");
+    expect(response.headers.get("content-disposition")).toBe(`attachment; filename="OC-${order.folio}.pdf"`);
+
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    expect(Buffer.from(bytes).subarray(0, 4).toString("utf8")).toBe("%PDF");
+  });
+
+  it("fails cleanly when no official document exists", async () => {
+    const supplier = await prisma.supplier.create({
+      data: {
+        code: `SUP-${unique()}`,
+        name: "Proveedor Sin Doc",
+      },
+    });
+    const product = await prisma.product.create({
+      data: {
+        sku: `SKU-${unique()}-missing`,
+        name: "Producto",
+        type: "HOSE",
+      },
+    });
+    const order = await prisma.purchaseOrder.create({
+      data: {
+        folio: `OC-${unique()}`,
+        supplierId: supplier.id,
+        status: "CONFIRMADA",
+        lines: {
+          create: [{
+            productId: product.id,
+            qtyOrdered: 1,
+            qtyReceived: 0,
+            unitPrice: 10,
+          }],
+        },
+      },
+      select: { id: true },
+    });
+
+    const { GET } = await import("@/app/api/purchasing/orders/[id]/pdf/route");
+    const response = await GET(new NextRequest(`http://localhost/api/purchasing/orders/${order.id}/pdf`), {
+      params: { id: order.id },
+    } as never);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Documento oficial no generado para esta orden de compra",
+    });
+  });
+
+  it("does not create a new version on repeated PDF reads", async () => {
+    const { order } = await createFixture();
+    const { GET } = await import("@/app/api/purchasing/orders/[id]/pdf/route");
+
+    await GET(new NextRequest(`http://localhost/api/purchasing/orders/${order.id}/pdf`), {
+      params: { id: order.id },
+    } as never);
+    await GET(new NextRequest(`http://localhost/api/purchasing/orders/${order.id}/pdf`), {
+      params: { id: order.id },
+    } as never);
+
+    const count = await prisma.purchaseOrderDocument.count({ where: { purchaseOrderId: order.id } });
+    expect(count).toBe(1);
+  });
+});

--- a/tests/purchasing/purchase-order-document-service.integration.test.ts
+++ b/tests/purchasing/purchase-order-document-service.integration.test.ts
@@ -1,0 +1,222 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import {
+  buildPurchaseOrderDocumentSnapshot,
+  ensurePurchaseOrderDocumentVersion,
+  loadLatestPurchaseOrderDocument,
+  parsePurchaseOrderDocumentSnapshot,
+  updatePurchaseOrderStatusWithDocument,
+} from "@/lib/purchasing/purchase-order-document-service";
+
+const shouldRunPostgresSuite = process.env.RUN_POSTGRES_TESTS === "1"
+  && /^postgres(ql)?:\/\//i.test(String(process.env.DATABASE_URL ?? ""));
+
+const describePostgres = shouldRunPostgresSuite ? describe : describe.skip;
+
+describePostgres("purchase order document service integration", () => {
+  const prisma = new PrismaClient();
+  const unique = () => `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+  async function resetDb() {
+    await prisma.purchaseOrderDocument.deleteMany();
+    await prisma.purchaseReceiptLine.deleteMany();
+    await prisma.purchaseReceipt.deleteMany();
+    await prisma.purchaseOrderLine.deleteMany();
+    await prisma.purchaseOrder.deleteMany();
+    await prisma.supplierProduct.deleteMany();
+    await prisma.supplier.deleteMany();
+    await prisma.product.deleteMany();
+  }
+
+  async function createFixture(options?: { unitPrice?: number | null }) {
+    const supplier = await prisma.supplier.create({
+      data: {
+        code: `SUP-${unique()}`,
+        name: "Proveedor Documento",
+        businessName: "Proveedor Documento SA",
+        legalName: "Proveedor Documento SA de CV",
+        taxId: "TAX-123",
+        email: "compras@proveedor.test",
+        phone: "555-111-2222",
+        address: "Calle 1",
+      },
+    });
+
+    const productA = await prisma.product.create({
+      data: {
+        sku: `SKU-${unique()}-1`,
+        name: "Manguera A",
+        type: "HOSE",
+        unitLabel: "metro",
+      },
+    });
+
+    const productB = await prisma.product.create({
+      data: {
+        sku: `SKU-${unique()}-2`,
+        name: "Conexión B",
+        type: "FITTING",
+      },
+    });
+
+    const order = await prisma.purchaseOrder.create({
+      data: {
+        folio: `OC-${unique()}`,
+        supplierId: supplier.id,
+        status: "BORRADOR",
+        notes: "OC para snapshot",
+        lines: {
+          create: [
+            {
+              productId: productA.id,
+              qtyOrdered: 4,
+              qtyReceived: 1,
+              unitPrice: options?.unitPrice ?? 12.5,
+            },
+            {
+              productId: productB.id,
+              qtyOrdered: 2,
+              qtyReceived: 0,
+              unitPrice: null,
+            },
+          ],
+        },
+      },
+    });
+
+    return { supplier, productA, productB, order };
+  }
+
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  afterAll(async () => {
+    await resetDb();
+    await prisma.$disconnect();
+  });
+
+  it("fails when purchase order does not exist", async () => {
+    await expect(
+      buildPurchaseOrderDocumentSnapshot({ purchaseOrderId: "missing-id", prismaClient: prisma }),
+    ).rejects.toMatchObject({ code: "PURCHASE_ORDER_NOT_FOUND" });
+  });
+
+  it("fails when purchase order has no lines", async () => {
+    const supplier = await prisma.supplier.create({
+      data: {
+        code: `SUP-${unique()}`,
+        name: "Proveedor Vacío",
+      },
+    });
+    const order = await prisma.purchaseOrder.create({
+      data: {
+        folio: `OC-${unique()}`,
+        supplierId: supplier.id,
+        status: "BORRADOR",
+      },
+    });
+
+    await expect(
+      buildPurchaseOrderDocumentSnapshot({ purchaseOrderId: order.id, prismaClient: prisma }),
+    ).rejects.toMatchObject({ code: "PURCHASE_ORDER_HAS_NO_LINES" });
+  });
+
+  it("builds a deterministic snapshot with supplier, totals and pending quantities", async () => {
+    const { order } = await createFixture();
+
+    const snapshot = await buildPurchaseOrderDocumentSnapshot({
+      purchaseOrderId: order.id,
+      prismaClient: prisma,
+    });
+
+    expect(snapshot.purchaseOrder.folio).toBe(order.folio);
+    expect(snapshot.purchaseOrder.status).toBe("BORRADOR");
+    expect(snapshot.supplier.businessName).toBe("Proveedor Documento SA");
+    expect(snapshot.lines).toHaveLength(2);
+    expect(snapshot.lines[0].pendingQty).toBe(3);
+    expect(snapshot.lines[0].currency).toBe("MXN");
+    expect(snapshot.lines[1].unitPrice).toBe(0);
+    expect(snapshot.lines[1].subtotal).toBe(0);
+    expect(snapshot.totals.subtotal).toBeCloseTo(50);
+    expect(snapshot.totals.total).toBeCloseTo(50);
+    expect(snapshot.totals.currency).toBe("MXN");
+    expect(snapshot.metadata.lineCount).toBe(2);
+    expect(snapshot.metadata.snapshotHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("creates version v1 once and keeps it idempotent", async () => {
+    const { order } = await createFixture();
+
+    const first = await ensurePurchaseOrderDocumentVersion({
+      purchaseOrderId: order.id,
+      prismaClient: prisma,
+      createdForStatus: "CONFIRMADA",
+    });
+
+    const second = await ensurePurchaseOrderDocumentVersion({
+      purchaseOrderId: order.id,
+      prismaClient: prisma,
+      createdForStatus: "CONFIRMADA",
+    });
+
+    const count = await prisma.purchaseOrderDocument.count({ where: { purchaseOrderId: order.id } });
+
+    expect(first.versionNumber).toBe(1);
+    expect(first.createdForStatus).toBe("CONFIRMADA");
+    expect(second.id).toBe(first.id);
+    expect(count).toBe(1);
+  });
+
+  it("freezes supplier and product data after live relations change", async () => {
+    const { supplier, productA, order } = await createFixture({ unitPrice: 15 });
+
+    await ensurePurchaseOrderDocumentVersion({
+      purchaseOrderId: order.id,
+      prismaClient: prisma,
+      createdForStatus: "CONFIRMADA",
+    });
+
+    await prisma.supplier.update({
+      where: { id: supplier.id },
+      data: { businessName: "Proveedor Mutado" },
+    });
+    await prisma.product.update({
+      where: { id: productA.id },
+      data: { name: "Producto Mutado" },
+    });
+
+    const persisted = await loadLatestPurchaseOrderDocument({ purchaseOrderId: order.id, prismaClient: prisma });
+    expect(persisted).toBeTruthy();
+    const snapshot = parsePurchaseOrderDocumentSnapshot(persisted?.snapshotJson ?? "");
+    expect(snapshot.supplier.businessName).toBe("Proveedor Documento SA");
+    expect(snapshot.lines[0].name).toBe("Manguera A");
+    expect(snapshot.lines[0].subtotal).toBeCloseTo(60);
+  });
+
+  it("confirms BORRADOR to CONFIRMADA creates one document v1", async () => {
+    const { order } = await createFixture();
+
+    const result = await updatePurchaseOrderStatusWithDocument({
+      purchaseOrderId: order.id,
+      newStatus: "CONFIRMADA",
+      prismaClient: prisma,
+    });
+
+    expect(result).toEqual({ ok: true });
+
+    const updated = await prisma.purchaseOrder.findUnique({
+      where: { id: order.id },
+      select: { status: true },
+    });
+    const documents = await prisma.purchaseOrderDocument.findMany({
+      where: { purchaseOrderId: order.id },
+      orderBy: { versionNumber: "asc" },
+    });
+
+    expect(updated?.status).toBe("CONFIRMADA");
+    expect(documents).toHaveLength(1);
+    expect(documents[0]?.versionNumber).toBe(1);
+    expect(documents[0]?.createdForStatus).toBe("CONFIRMADA");
+  });
+});

--- a/tests/purchasing/purchase-order-document.contract.test.ts
+++ b/tests/purchasing/purchase-order-document.contract.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readWorkspaceFile(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+describe("purchase order document contracts", () => {
+  it("guards the detail page and exposes document actions", () => {
+    const content = readWorkspaceFile("app/(shell)/purchasing/orders/[id]/page.tsx");
+    expect(content).toContain('pageGuard("purchasing.manage")');
+    expect(content).toContain("Documento oficial disponible al confirmar.");
+    expect(content).toContain("Ver documento oficial");
+    expect(content).toContain("Descargar PDF");
+    expect(content).toContain("Documento oficial no generado para esta OC. Revisión requerida.");
+  });
+
+  it("guards the document preview page and print action", () => {
+    const content = readWorkspaceFile("app/(shell)/purchasing/orders/[id]/document/page.tsx");
+    const buttonContent = readWorkspaceFile("components/purchasing/PurchaseOrderDocumentPrintButton.tsx");
+    expect(content).toContain('pageGuard("purchasing.manage")');
+    expect(content).toContain("PurchaseOrderDocumentPrintButton");
+    expect(buttonContent).toContain("Imprimir / Guardar PDF");
+  });
+
+  it("pdf route returns application/pdf with attachment disposition", () => {
+    const content = readWorkspaceFile("app/api/purchasing/orders/[id]/pdf/route.ts");
+    expect(content).toContain('requirePermission("purchasing.manage")');
+    expect(content).toContain('export const runtime = "nodejs"');
+    expect(content).toContain('"Content-Type": "application/pdf"');
+    expect(content).toContain('attachment; filename="${filename}"');
+  });
+});

--- a/tests/rbac/route-access.integration.test.ts
+++ b/tests/rbac/route-access.integration.test.ts
@@ -20,6 +20,10 @@ describe("rbac role-route access matrix", () => {
     "/inventory/transfer",
     "/inventory/pick",
     "/audit",
+    "/purchasing/orders",
+    "/purchasing/orders/new",
+    "/purchasing/orders/abc",
+    "/purchasing/orders/abc/receive",
     "/production/requests",
     "/production/requests/new",
     "/production/availability",
@@ -43,6 +47,10 @@ describe("rbac role-route access matrix", () => {
     expect(getRequiredPermissionForPath("/production/availability")).toBe("sales.view");
     expect(getRequiredPermissionForPath("/production/equivalences")).toBe("sales.view");
     expect(getRequiredPermissionForPath("/sales/orders")).toBe("sales.view");
+    expect(getRequiredPermissionForPath("/purchasing/orders")).toBe("purchasing.view");
+    expect(getRequiredPermissionForPath("/purchasing/orders/new")).toBe("purchasing.manage");
+    expect(getRequiredPermissionForPath("/purchasing/orders/abc")).toBe("purchasing.manage");
+    expect(getRequiredPermissionForPath("/purchasing/orders/abc/receive")).toBe("purchasing.manage");
     expect(getRequiredPermissionForPath("/sales/customers")).toBe("customers.view");
     expect(getRequiredPermissionForPath("/sales/customers/new")).toBe("customers.manage");
     expect(getRequiredPermissionForPath("/sales/customers/abc")).toBe("customers.view");
@@ -110,6 +118,18 @@ describe("rbac role-route access matrix", () => {
     expect(canAccess("MANAGER", "/sales/orders/new")).toBe(true);
     expect(canAccess("SALES_EXECUTIVE", "/sales/orders")).toBe(true);
     expect(canAccess("SALES_EXECUTIVE", "/sales/orders/new")).toBe(true);
+  });
+
+  it("purchasing routes respect view/manage split", () => {
+    expect(canAccess("MANAGER", "/purchasing/orders")).toBe(true);
+    expect(canAccess("MANAGER", "/purchasing/orders/new")).toBe(true);
+    expect(canAccess("MANAGER", "/purchasing/orders/abc")).toBe(true);
+    expect(canAccess("MANAGER", "/purchasing/orders/abc/receive")).toBe(true);
+
+    expect(canAccess("SALES_EXECUTIVE", "/purchasing/orders")).toBe(false);
+    expect(canAccess("SALES_EXECUTIVE", "/purchasing/orders/new")).toBe(false);
+    expect(canAccess("SALES_EXECUTIVE", "/purchasing/orders/abc")).toBe(false);
+    expect(canAccess("SALES_EXECUTIVE", "/purchasing/orders/abc/receive")).toBe(false);
   });
 
   it("users.manage remains restricted to SYSTEM_ADMIN", () => {

--- a/tests/rbac/server-actions-guards.integration.test.ts
+++ b/tests/rbac/server-actions-guards.integration.test.ts
@@ -68,6 +68,20 @@ describe("rbac guards in critical server actions/pages", () => {
     expect(formContent).toContain("ProductSearchField");
   });
 
+  it("purchase order detail and receive flows are protected by purchasing.manage", () => {
+    const detailContent = readWorkspaceFile("app/(shell)/purchasing/orders/[id]/page.tsx");
+    const receiveContent = readWorkspaceFile("app/(shell)/purchasing/orders/[id]/receive/page.tsx");
+    const documentContent = readWorkspaceFile("app/(shell)/purchasing/orders/[id]/document/page.tsx");
+    const pdfRouteContent = readWorkspaceFile("app/api/purchasing/orders/[id]/pdf/route.ts");
+
+    expect(detailContent).toContain('pageGuard("purchasing.manage")');
+    expect(detailContent).toContain('requirePermission("purchasing.manage")');
+    expect(receiveContent).toContain('pageGuard("purchasing.manage")');
+    expect(receiveContent).toContain('requirePermission("purchasing.manage")');
+    expect(documentContent).toContain('pageGuard("purchasing.manage")');
+    expect(pdfRouteContent).toContain('requirePermission("purchasing.manage")');
+  });
+
   it("product search wiring keeps direct request lines broad and assembly search typed", () => {
     const directFormContent = readWorkspaceFile("components/RequestProductLineForm.tsx");
     const assemblyFormContent = readWorkspaceFile("components/AssemblyConfiguratorForm.tsx");


### PR DESCRIPTION
## Summary
- Added frozen purchase order document snapshots created when `BORRADOR -> CONFIRMADA`.
- Added a persisted official document model, document service, preview page, and server-side PDF download endpoint.
- Kept receiving and inventory behavior unchanged.

## Files Changed by Area
- Purchasing UI: `app/(shell)/purchasing/orders/[id]/page.tsx`, `app/(shell)/purchasing/orders/[id]/document/page.tsx`
- API/PDF: `app/api/purchasing/orders/[id]/pdf/route.ts`, `lib/purchasing/purchase-order-pdf.tsx`
- Domain/service: `lib/purchasing/purchase-order-document-service.ts`
- RBAC: `lib/rbac/route-permissions.ts`, `tests/rbac/route-access.integration.test.ts`, `tests/rbac/server-actions-guards.integration.test.ts`
- Prisma + migration: `prisma/schema.prisma`, `prisma/postgresql/schema.prisma`, `prisma/migrations/20260602120000_kan84_purchase_order_documents/migration.sql`, `prisma/postgresql/migrations/20260602120000_kan84_purchase_order_documents/migration.sql`
- Tests: `tests/purchasing/purchase-order-document*.test.ts`
- Dependencies: `package.json`, `package-lock.json`

## Migration
- `20260602120000_kan84_purchase_order_documents`

## PDF / Storage
- PDF is generated server-side with `@react-pdf/renderer`.
- No PDF, HTML blob, image, or binary file is stored in PostgreSQL.
- The PDF is generated on demand from persisted `snapshotJson`.

## API Verification
- `/api/purchasing/orders/[id]/pdf` returns `application/pdf` with attachment disposition `OC-{folio}.pdf`.

## Validation
- `npm run prisma:validate` passed.
- `npm run typecheck` passed.
- Targeted purchasing/document tests passed.
- `npm run test:postgres` passed: `207 passed, 13 skipped`.

## Protected Files
- Confirmed that the protected CSV/import/catalog files were not modified.

## Out of Scope
- KAN-85 email sending was not implemented.