### PR TITLE
KAN-84B: polish supplier-facing purchase order PDF

### DIFF
--- a/app/(shell)/purchasing/orders/[id]/document/page.tsx
+++ b/app/(shell)/purchasing/orders/[id]/document/page.tsx
@@ -6,6 +6,7 @@ import {
   loadLatestPurchaseOrderDocument,
   parsePurchaseOrderDocumentSnapshot,
 } from "@/lib/purchasing/purchase-order-document-service";
+import { getSupplierDisplayLines } from "@/lib/purchasing/purchase-order-pdf";
 
 function money(value: number, currency: string) {
   return new Intl.NumberFormat("es-MX", {
@@ -75,13 +76,15 @@ export default async function PurchaseOrderDocumentPage({
     );
   }
 
+  const supplierLines = getSupplierDisplayLines(snapshot.supplier);
+
   return (
     <div className="max-w-5xl mx-auto space-y-6 print:max-w-none print:space-y-4">
       <div className="flex items-start justify-between gap-4 print:hidden">
         <div>
-          <h1 className="text-2xl font-bold">Documento oficial de OC</h1>
+          <h1 className="text-2xl font-bold">Orden de Compra oficial</h1>
           <p className="text-sm text-slate-400">
-            Vista congelada de la orden {snapshot.purchaseOrder.folio} v{snapshot.documentVersion}
+            Vista congelada para revisión de la orden {snapshot.purchaseOrder.folio} v{snapshot.documentVersion}
           </p>
         </div>
         <div className="flex gap-3">
@@ -98,37 +101,67 @@ export default async function PurchaseOrderDocumentPage({
       <div className="glass-card print:shadow-none print:border print:border-black/20">
         <div className="flex items-start justify-between gap-4 border-b border-white/10 pb-3">
           <div>
-            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Orden de compra oficial</p>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Orden de Compra</p>
             <h2 className="text-3xl font-bold font-mono mt-1">{snapshot.purchaseOrder.folio}</h2>
             <p className="text-sm text-slate-400 mt-1">
-              Versión v{snapshot.documentVersion} · Generado {new Date(snapshot.generatedAt).toLocaleString("es-MX")}
+              Fecha de emisión {new Date(snapshot.generatedAt).toLocaleString("es-MX")} · Versión v{snapshot.documentVersion}
             </p>
           </div>
           <div className="text-right text-sm text-slate-300">
-            <p className="font-semibold text-slate-200">{snapshot.supplier.businessName ?? snapshot.supplier.name}</p>
-            <p>{snapshot.supplier.legalName ?? "—"}</p>
-            <p className="text-xs text-slate-500">RFC: {snapshot.supplier.taxId ?? "—"}</p>
+            <p className="font-semibold text-slate-200">{supplierLines.primary}</p>
+            {supplierLines.secondary ? <p>{supplierLines.secondary}</p> : null}
+            <p className="text-xs text-slate-500">Código: {snapshot.supplier.code}</p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-4 mt-4">
+          <div className="space-y-1 text-sm">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Fecha esperada / entrega solicitada</p>
+            <p>{formatDate(snapshot.purchaseOrder.expectedDate)}</p>
+          </div>
+          <div className="space-y-1 text-sm">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Estado</p>
+            <p>{snapshot.purchaseOrder.status}</p>
+          </div>
+          <div className="space-y-1 text-sm">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Moneda</p>
+            <p>{snapshot.totals.currency}</p>
+          </div>
+          <div className="space-y-1 text-sm">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Creada</p>
+            <p>{new Date(snapshot.purchaseOrder.createdAt).toLocaleString("es-MX")}</p>
           </div>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2 mt-4">
           <div className="space-y-1 text-sm">
-            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Datos de la OC</p>
-            <p>Estado: {snapshot.purchaseOrder.status}</p>
-            <p>Fecha esperada: {formatDate(snapshot.purchaseOrder.expectedDate)}</p>
-            <p>Creada: {new Date(snapshot.purchaseOrder.createdAt).toLocaleString("es-MX")}</p>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Comprador</p>
+            <p className="text-slate-200">WMS Mangueras y Conexiones</p>
+            <p className="text-slate-400">RFC: Por definir</p>
+            <p className="text-slate-400">Dirección: Por definir</p>
+            <p className="text-slate-400">Contacto: Por definir</p>
           </div>
           <div className="space-y-1 text-sm">
-            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Contacto proveedor</p>
-            <p>Correo: {snapshot.supplier.email ?? "—"}</p>
-            <p>Teléfono: {snapshot.supplier.phone ?? "—"}</p>
-            <p>Dirección: {snapshot.supplier.address ?? "—"}</p>
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Proveedor</p>
+            <p className="text-slate-200">{supplierLines.primary}</p>
+            {supplierLines.secondary ? <p className="text-slate-400">{supplierLines.secondary}</p> : null}
+            <p className="text-slate-400">RFC: {snapshot.supplier.taxId ?? "—"}</p>
+            <p className="text-slate-400">Correo: {snapshot.supplier.email ?? "—"}</p>
+            <p className="text-slate-400">Teléfono: {snapshot.supplier.phone ?? "—"}</p>
+            <p className="text-slate-400">Dirección: {snapshot.supplier.address ?? "—"}</p>
           </div>
         </div>
 
-        <div className="mt-4">
-          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Notas</p>
-          <p className="text-sm text-slate-200 mt-1">{snapshot.purchaseOrder.notes ?? "—"}</p>
+        <div className="grid gap-4 md:grid-cols-2 mt-4">
+          <div className="space-y-1 text-sm">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Entrega y términos</p>
+            <p className="text-slate-200">Dirección de entrega: Por definir</p>
+            <p className="text-slate-200">Términos de pago: Por definir</p>
+          </div>
+          <div className="space-y-1 text-sm">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Notas</p>
+            <p className="text-slate-200 mt-1">{snapshot.purchaseOrder.notes ?? "—"}</p>
+          </div>
         </div>
 
         <div className="mt-5 overflow-x-auto">
@@ -137,12 +170,10 @@ export default async function PurchaseOrderDocumentPage({
               <tr className="border-b border-white/10 text-slate-400">
                 <th className="py-2 text-left">SKU</th>
                 <th className="py-2 text-left">Producto</th>
-                <th className="py-2 text-right">Pedido</th>
-                <th className="py-2 text-right">Recibido</th>
-                <th className="py-2 text-right">Pendiente</th>
+                <th className="py-2 text-right">Cantidad</th>
                 <th className="py-2 text-center">Unidad</th>
-                <th className="py-2 text-right">Precio</th>
-                <th className="py-2 text-right">Subtotal</th>
+                <th className="py-2 text-right">Precio unitario</th>
+                <th className="py-2 text-right">Importe</th>
               </tr>
             </thead>
             <tbody>
@@ -151,8 +182,6 @@ export default async function PurchaseOrderDocumentPage({
                   <td className="py-2 font-mono text-cyan-400 text-xs">{line.sku}</td>
                   <td className="py-2 text-slate-200">{line.name}</td>
                   <td className="py-2 text-right">{line.qtyOrdered}</td>
-                  <td className="py-2 text-right">{line.qtyReceived}</td>
-                  <td className="py-2 text-right">{line.pendingQty}</td>
                   <td className="py-2 text-center text-slate-400">{line.unitLabel}</td>
                   <td className="py-2 text-right">{money(line.unitPrice, line.currency)}</td>
                   <td className="py-2 text-right">{money(line.subtotal, line.currency)}</td>

--- a/app/api/purchasing/orders/[id]/pdf/route.ts
+++ b/app/api/purchasing/orders/[id]/pdf/route.ts
@@ -6,7 +6,7 @@ import {
   loadLatestPurchaseOrderDocument,
   parsePurchaseOrderDocumentSnapshot,
 } from "@/lib/purchasing/purchase-order-document-service";
-import { PurchaseOrderPdfDocument } from "@/lib/purchasing/purchase-order-pdf";
+import { buildPurchaseOrderPdfFilename, PurchaseOrderPdfDocument } from "@/lib/purchasing/purchase-order-pdf";
 import { renderToBuffer } from "@react-pdf/renderer";
 
 export const runtime = "nodejs";
@@ -29,7 +29,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   const pdfBuffer = await renderToBuffer(
     React.createElement(PurchaseOrderPdfDocument, { snapshot }) as unknown as Parameters<typeof renderToBuffer>[0],
   );
-  const filename = `OC-${snapshot.purchaseOrder.folio}.pdf`;
+  const filename = buildPurchaseOrderPdfFilename(snapshot.purchaseOrder.folio);
 
   return new NextResponse(new Uint8Array(pdfBuffer), {
     headers: {

--- a/lib/purchasing/purchase-order-pdf.tsx
+++ b/lib/purchasing/purchase-order-pdf.tsx
@@ -2,10 +2,33 @@ import React from "react";
 import { Document, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
 import type { PurchaseOrderDocumentSnapshot } from "@/lib/purchasing/purchase-order-document-service";
 
+export function buildPurchaseOrderPdfFilename(folio: string): string {
+  const normalizedFolio = String(folio ?? "").trim();
+  const prefixedFolio = normalizedFolio.startsWith("OC-") ? normalizedFolio : `OC-${normalizedFolio}`;
+  const safeBase = prefixedFolio
+    .normalize("NFKD")
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[.-]+|[.-]+$/g, "");
+
+  return `${safeBase || "OC-orden-compra"}.pdf`;
+}
+
+export function getSupplierDisplayLines(supplier: PurchaseOrderDocumentSnapshot["supplier"]) {
+  const primary = supplier.businessName || supplier.legalName || supplier.name || "—";
+  const secondary = supplier.legalName && supplier.legalName !== primary
+    ? supplier.legalName
+    : supplier.name && supplier.name !== primary && supplier.name !== supplier.legalName
+      ? supplier.name
+      : null;
+
+  return { primary, secondary };
+}
+
 const styles = StyleSheet.create({
   page: {
     fontFamily: "Helvetica",
-    fontSize: 9,
+    fontSize: 8.8,
     paddingTop: 28,
     paddingHorizontal: 24,
     paddingBottom: 24,
@@ -19,7 +42,7 @@ const styles = StyleSheet.create({
     borderBottomStyle: "solid",
   },
   title: {
-    fontSize: 18,
+    fontSize: 19,
     fontWeight: 700,
     marginBottom: 4,
   },
@@ -36,7 +59,7 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   sectionTitle: {
-    fontSize: 10,
+    fontSize: 10.5,
     fontWeight: 700,
     marginBottom: 4,
   },
@@ -59,6 +82,10 @@ const styles = StyleSheet.create({
   textMuted: {
     color: "#4b5563",
   },
+  smallMuted: {
+    color: "#6b7280",
+    fontSize: 8,
+  },
   lineTable: {
     borderWidth: 1,
     borderColor: "#d1d5db",
@@ -77,6 +104,7 @@ const styles = StyleSheet.create({
     borderRightWidth: 1,
     borderRightColor: "#e5e7eb",
     borderRightStyle: "solid",
+    justifyContent: "flex-start",
   },
   lineBody: {
     flexDirection: "row",
@@ -88,25 +116,21 @@ const styles = StyleSheet.create({
     borderBottomWidth: 0,
   },
   lineSku: {
-    width: "10%",
+    width: "16%",
   },
   lineProduct: {
-    width: "24%",
+    width: "34%",
   },
   lineQty: {
-    width: "8%",
-    textAlign: "right",
-  },
-  lineQtyWide: {
-    width: "9%",
+    width: "11%",
     textAlign: "right",
   },
   lineUnit: {
-    width: "8%",
+    width: "9%",
     textAlign: "center",
   },
   lineMoney: {
-    width: "11%",
+    width: "15%",
     textAlign: "right",
   },
   totals: {
@@ -129,6 +153,45 @@ const styles = StyleSheet.create({
   notes: {
     minHeight: 34,
   },
+  footer: {
+    position: "absolute",
+    left: 24,
+    right: 24,
+    bottom: 18,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    color: "#6b7280",
+    fontSize: 8,
+  },
+  documentMetaGrid: {
+    flexDirection: "row",
+    gap: 10,
+    marginTop: 8,
+  },
+  metaCard: {
+    flexGrow: 1,
+    flexBasis: 0,
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderStyle: "solid",
+    borderRadius: 3,
+    padding: 8,
+  },
+  metaLabel: {
+    fontSize: 8,
+    color: "#6b7280",
+    textTransform: "uppercase",
+    marginBottom: 3,
+  },
+  metaValue: {
+    fontSize: 9.5,
+    color: "#111827",
+  },
+  supplierPrimary: {
+    fontSize: 10,
+    fontWeight: 700,
+    color: "#111827",
+  },
 });
 
 function money(value: number, currency: string) {
@@ -147,42 +210,73 @@ function formatDate(value: string | null) {
 }
 
 export function PurchaseOrderPdfDocument({ snapshot }: { snapshot: PurchaseOrderDocumentSnapshot }) {
+  const supplierLines = getSupplierDisplayLines(snapshot.supplier);
   return (
     <Document>
-      <Page size="A4" style={styles.page}>
+      <Page size="A4" orientation="landscape" style={styles.page}>
         <View style={styles.header}>
-          <Text style={styles.title}>Orden de Compra Oficial</Text>
+          <Text style={styles.title}>Orden de Compra</Text>
           <Text style={styles.subtitle}>WMS Mangueras y Conexiones</Text>
           <View style={styles.metaRow}>
             <Text>Folio: {snapshot.purchaseOrder.folio}</Text>
-            <Text>Versión: v{snapshot.documentVersion}</Text>
+            <Text>Versión documento: v{snapshot.documentVersion}</Text>
           </View>
           <View style={styles.metaRow}>
-            <Text>Generado: {new Date(snapshot.generatedAt).toLocaleString("es-MX")}</Text>
+            <Text>Fecha de emisión: {new Date(snapshot.generatedAt).toLocaleString("es-MX")}</Text>
             <Text>Estado: {snapshot.purchaseOrder.status}</Text>
           </View>
         </View>
 
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Proveedor</Text>
-          <View style={styles.card}>
-            <Text>{snapshot.supplier.businessName ?? snapshot.supplier.name}</Text>
-            <Text style={styles.textMuted}>{snapshot.supplier.legalName ?? "—"}</Text>
-            <Text style={styles.textMuted}>Código: {snapshot.supplier.code}</Text>
-            <Text style={styles.textMuted}>RFC: {snapshot.supplier.taxId ?? "—"}</Text>
-            <Text style={styles.textMuted}>Correo: {snapshot.supplier.email ?? "—"}</Text>
-            <Text style={styles.textMuted}>Teléfono: {snapshot.supplier.phone ?? "—"}</Text>
-            <Text style={styles.textMuted}>Dirección: {snapshot.supplier.address ?? "—"}</Text>
+        <View style={styles.documentMetaGrid}>
+          <View style={styles.metaCard}>
+            <Text style={styles.metaLabel}>Fecha esperada / entrega solicitada</Text>
+            <Text style={styles.metaValue}>{formatDate(snapshot.purchaseOrder.expectedDate)}</Text>
+          </View>
+          <View style={styles.metaCard}>
+            <Text style={styles.metaLabel}>Compra</Text>
+            <Text style={styles.metaValue}>Orden congelada para uso oficial</Text>
+          </View>
+          <View style={styles.metaCard}>
+            <Text style={styles.metaLabel}>Moneda</Text>
+            <Text style={styles.metaValue}>{snapshot.totals.currency}</Text>
+          </View>
+          <View style={styles.metaCard}>
+            <Text style={styles.metaLabel}>Versión documento</Text>
+            <Text style={styles.metaValue}>v{snapshot.documentVersion}</Text>
           </View>
         </View>
 
-        <View style={styles.row}>
+        <View style={[styles.row, { marginTop: 10 }]}>
           <View style={[styles.section, styles.column]}>
-            <Text style={styles.sectionTitle}>Datos de la OC</Text>
+            <Text style={styles.sectionTitle}>Comprador</Text>
             <View style={styles.card}>
-              <Text>Creada: {new Date(snapshot.purchaseOrder.createdAt).toLocaleString("es-MX")}</Text>
-              <Text>Fecha esperada: {formatDate(snapshot.purchaseOrder.expectedDate)}</Text>
-              <Text>Versión documento: v{snapshot.documentVersion}</Text>
+              <Text style={styles.supplierPrimary}>WMS Mangueras y Conexiones</Text>
+              <Text style={styles.textMuted}>RFC: Por definir</Text>
+              <Text style={styles.textMuted}>Dirección: Por definir</Text>
+              <Text style={styles.textMuted}>Contacto: Por definir</Text>
+            </View>
+          </View>
+          <View style={[styles.section, styles.column]}>
+            <Text style={styles.sectionTitle}>Proveedor</Text>
+            <View style={styles.card}>
+              <Text style={styles.supplierPrimary}>{supplierLines.primary}</Text>
+              {supplierLines.secondary ? <Text style={styles.textMuted}>{supplierLines.secondary}</Text> : null}
+              <Text style={styles.textMuted}>Código: {snapshot.supplier.code}</Text>
+              <Text style={styles.textMuted}>RFC: {snapshot.supplier.taxId ?? "—"}</Text>
+              <Text style={styles.textMuted}>Correo: {snapshot.supplier.email ?? "—"}</Text>
+              <Text style={styles.textMuted}>Teléfono: {snapshot.supplier.phone ?? "—"}</Text>
+              <Text style={styles.textMuted}>Dirección: {snapshot.supplier.address ?? "—"}</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={[styles.row, { marginTop: 10 }]}>
+          <View style={[styles.section, styles.column]}>
+            <Text style={styles.sectionTitle}>Entrega y términos</Text>
+            <View style={styles.card}>
+              <Text>Dirección de entrega: Por definir</Text>
+              <Text>Términos de pago: Por definir</Text>
+              <Text>Moneda: {snapshot.totals.currency}</Text>
             </View>
           </View>
           <View style={[styles.section, styles.column]}>
@@ -199,12 +293,10 @@ export function PurchaseOrderPdfDocument({ snapshot }: { snapshot: PurchaseOrder
             <View style={styles.lineHeader}>
               <Text style={[styles.lineCell, styles.lineSku]}>SKU</Text>
               <Text style={[styles.lineCell, styles.lineProduct]}>Producto</Text>
-              <Text style={[styles.lineCell, styles.lineQty]}>Ped.</Text>
-              <Text style={[styles.lineCell, styles.lineQty]}>Rec.</Text>
-              <Text style={[styles.lineCell, styles.lineQty]}>Pend.</Text>
-              <Text style={[styles.lineCell, styles.lineUnit]}>U.</Text>
-              <Text style={[styles.lineCell, styles.lineMoney]}>P. Unit.</Text>
-              <Text style={[styles.lineCell, styles.lineMoney]}>Subtotal</Text>
+              <Text style={[styles.lineCell, styles.lineQty]}>Cantidad</Text>
+              <Text style={[styles.lineCell, styles.lineUnit]}>Unidad</Text>
+              <Text style={[styles.lineCell, styles.lineMoney]}>Precio unitario</Text>
+              <Text style={[styles.lineCell, styles.lineMoney]}>Importe</Text>
             </View>
             {snapshot.lines.map((line, index) => (
               <View
@@ -214,8 +306,6 @@ export function PurchaseOrderPdfDocument({ snapshot }: { snapshot: PurchaseOrder
                 <Text style={[styles.lineCell, styles.lineSku]}>{line.sku}</Text>
                 <Text style={[styles.lineCell, styles.lineProduct]}>{line.name}</Text>
                 <Text style={[styles.lineCell, styles.lineQty]}>{line.qtyOrdered}</Text>
-                <Text style={[styles.lineCell, styles.lineQty]}>{line.qtyReceived}</Text>
-                <Text style={[styles.lineCell, styles.lineQty]}>{line.pendingQty}</Text>
                 <Text style={[styles.lineCell, styles.lineUnit]}>{line.unitLabel}</Text>
                 <Text style={[styles.lineCell, styles.lineMoney]}>{money(line.unitPrice, line.currency)}</Text>
                 <Text style={[styles.lineCell, styles.lineMoney]}>{money(line.subtotal, line.currency)}</Text>
@@ -235,6 +325,12 @@ export function PurchaseOrderPdfDocument({ snapshot }: { snapshot: PurchaseOrder
               <Text>{money(snapshot.totals.total, snapshot.totals.currency)}</Text>
             </View>
           </View>
+        </View>
+
+        <View style={styles.footer} fixed>
+          <Text>Documento generado automáticamente desde WMS.</Text>
+          <Text render={({ pageNumber, totalPages }) => `Página ${pageNumber} de ${totalPages}`} />
+          <Text>Esta orden de compra está sujeta a validación administrativa.</Text>
         </View>
       </Page>
     </Document>

--- a/tests/purchasing/purchase-order-document-route.integration.test.ts
+++ b/tests/purchasing/purchase-order-document-route.integration.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { PrismaClient } from "@prisma/client";
 import { NextRequest } from "next/server";
 import { updatePurchaseOrderStatusWithDocument } from "@/lib/purchasing/purchase-order-document-service";
+import { buildPurchaseOrderPdfFilename } from "@/lib/purchasing/purchase-order-pdf";
 
 vi.mock("@/lib/rbac", () => ({
   requirePermission: vi.fn(async () => undefined),
@@ -86,10 +87,16 @@ describePostgres("purchase order document pdf route integration", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("application/pdf");
-    expect(response.headers.get("content-disposition")).toBe(`attachment; filename="OC-${order.folio}.pdf"`);
+    expect(response.headers.get("content-disposition")).toBe(`attachment; filename="${buildPurchaseOrderPdfFilename(order.folio)}"`);
 
     const bytes = new Uint8Array(await response.arrayBuffer());
     expect(Buffer.from(bytes).subarray(0, 4).toString("utf8")).toBe("%PDF");
+  });
+
+  it("sanitizes unsafe file names without duplicating prefixes", () => {
+    expect(buildPurchaseOrderPdfFilename("OC-2026-0004")).toBe("OC-2026-0004.pdf");
+    expect(buildPurchaseOrderPdfFilename("2026-0004")).toBe("OC-2026-0004.pdf");
+    expect(buildPurchaseOrderPdfFilename("OC-2026/0004?*")).toBe("OC-2026-0004.pdf");
   });
 
   it("fails cleanly when no official document exists", async () => {

--- a/tests/purchasing/purchase-order-document.contract.test.ts
+++ b/tests/purchasing/purchase-order-document.contract.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { buildPurchaseOrderPdfFilename, getSupplierDisplayLines } from "@/lib/purchasing/purchase-order-pdf";
 
 function readWorkspaceFile(relativePath: string) {
   return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
@@ -30,5 +31,53 @@ describe("purchase order document contracts", () => {
     expect(content).toContain('export const runtime = "nodejs"');
     expect(content).toContain('"Content-Type": "application/pdf"');
     expect(content).toContain('attachment; filename="${filename}"');
+    expect(content).toContain("buildPurchaseOrderPdfFilename");
+  });
+
+  it("builds sanitized filenames without double OC prefixes", () => {
+    expect(buildPurchaseOrderPdfFilename("OC-2026-0004")).toBe("OC-2026-0004.pdf");
+    expect(buildPurchaseOrderPdfFilename("2026-0004")).toBe("OC-2026-0004.pdf");
+    expect(buildPurchaseOrderPdfFilename("OC-2026/0004?*")).toBe("OC-2026-0004.pdf");
+  });
+
+  it("collapses identical supplier display values", () => {
+    const identical = getSupplierDisplayLines({
+      code: "SUP-001",
+      name: "Parker",
+      businessName: "Parker",
+      legalName: "Parker",
+      taxId: null,
+      email: null,
+      phone: null,
+      address: null,
+    });
+
+    expect(identical.primary).toBe("Parker");
+    expect(identical.secondary).toBeNull();
+
+    const distinct = getSupplierDisplayLines({
+      code: "SUP-002",
+      name: "Parker México",
+      businessName: "Parker Industrial",
+      legalName: "Parker México SA de CV",
+      taxId: null,
+      email: null,
+      phone: null,
+      address: null,
+    });
+
+    expect(distinct.primary).toBe("Parker Industrial");
+    expect(distinct.secondary).toBe("Parker México SA de CV");
+  });
+
+  it("exposes supplier-facing labels and hides internal receiving headers in the PDF source", () => {
+    const content = readWorkspaceFile("lib/purchasing/purchase-order-pdf.tsx");
+    expect(content).toContain("Cantidad");
+    expect(content).toContain("Unidad");
+    expect(content).toContain("Precio unitario");
+    expect(content).toContain("Importe");
+    expect(content).not.toContain("Ped.");
+    expect(content).not.toContain("Rec.");
+    expect(content).not.toContain("Pend.");
   });
 });


### PR DESCRIPTION
## Summary

* Improved the official Purchase Order PDF so it is supplier-facing and ready to support KAN-85 later.
* Fixed duplicate `OC-` filename issue.
* Improved PDF layout, supplier display, table headers and formal document structure.
* Kept PDF generated on demand from persisted `snapshotJson`.

## Changes

* `lib/purchasing/purchase-order-pdf.tsx`

  * Added `buildPurchaseOrderPdfFilename(folio)`.
  * Added supplier display fallback helper.
  * Refactored PDF layout to formal supplier-facing format.
  * Removed internal receiving columns from supplier-facing PDF.
* `app/api/purchasing/orders/[id]/pdf/route.ts`

  * Uses safe filename helper for `Content-Disposition`.
* `app/(shell)/purchasing/orders/[id]/document/page.tsx`

  * Aligned preview wording and document labels.
* Tests updated:

  * `tests/purchasing/purchase-order-document-route.integration.test.ts`
  * `tests/purchasing/purchase-order-document.contract.test.ts`

## Validation

* `npm run prisma:validate` passed.
* `npm run typecheck` passed.
* Targeted purchase document/PDF tests passed: `3 passed`, `16 tests passed`.
* `npm run test:postgres` passed: `211 passed, 13 skipped`.

## Smoke Evidence

* Confirmed OC:

  * `95adf3d9-3dc2-4deb-bbc6-bdbc9a6f0339`
  * `OC-2026-0004`
* PDF endpoint:

  * `200`
  * `Content-Type: application/pdf`
  * `Content-Disposition: attachment; filename="OC-2026-0004.pdf"`
  * valid PDF bytes `%PDF`

## Explicit Non-Changes

* No Prisma schema changes.
* No migrations.
* No inventory or receiving behavior changes.
* No PDF, HTML, image, blob or binary stored in PostgreSQL.
* No CSV/import/catalog files touched.
* KAN-85 email sending was not implemented.

## Residual Limitation

The PDF uses placeholders where the current data model does not yet provide full buyer legal/contact fields. This is acceptable for this polish but should be addressed before sending real supplier-facing OCs at scale through a follow-up configuration/data ticket.