### PR TITLE
KAN-110: Freeze delivery address and payment terms in PO documents

### DIFF
--- a/app/(shell)/purchasing/orders/[id]/document/page.tsx
+++ b/app/(shell)/purchasing/orders/[id]/document/page.tsx
@@ -155,8 +155,8 @@ export default async function PurchaseOrderDocumentPage({
         <div className="grid gap-4 md:grid-cols-2 mt-4">
           <div className="space-y-1 text-sm">
             <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Entrega y términos</p>
-            <p className="text-slate-200">Dirección de entrega: Por definir</p>
-            <p className="text-slate-200">Términos de pago: Por definir</p>
+            <p className="text-slate-200">Dirección de entrega: {snapshot.purchaseOrder.deliveryAddressSnapshot ?? "—"}</p>
+            <p className="text-slate-200">Términos de pago: {snapshot.supplier.paymentTerms ?? "—"}</p>
           </div>
           <div className="space-y-1 text-sm">
             <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Notas</p>

--- a/app/(shell)/purchasing/orders/[id]/page.tsx
+++ b/app/(shell)/purchasing/orders/[id]/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import prisma from "@/lib/prisma";
-import { purchaseOrderLineSchema, firstErrorMessage } from "@/lib/schemas/wms";
+import { purchaseOrderLineSchema, purchaseOrderUpdateSchema, firstErrorMessage } from "@/lib/schemas/wms";
 import { pageGuard } from "@/components/rbac/PageGuard";
 import {
   loadLatestPurchaseOrderDocument,
   parsePurchaseOrderDocumentSnapshot,
+  resolvePurchaseOrderFrozenFields,
   updatePurchaseOrderStatusWithDocument,
 } from "@/lib/purchasing/purchase-order-document-service";
 
@@ -36,6 +37,12 @@ const TRANSITIONS: Record<string, string[]> = {
   RECIBIDA: [],
   CANCELADA: [],
 };
+
+function formatDateInput(value: string | Date | null | undefined) {
+  if (!value) return "";
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString().slice(0, 10);
+}
 
 async function updateStatus(orderId: string, formData: FormData) {
   "use server";
@@ -102,6 +109,58 @@ async function addLine(orderId: string, formData: FormData) {
   redirect(`/purchasing/orders/${orderId}`);
 }
 
+async function updateDraftMetadata(orderId: string, formData: FormData) {
+  "use server";
+  await (await import("@/lib/rbac")).requirePermission("purchasing.manage");
+
+  const deliveryWarehouseId = String(formData.get("deliveryWarehouseId") ?? "").trim();
+  const expectedDate = String(formData.get("expectedDate") ?? "").trim() || undefined;
+  const notes = String(formData.get("notes") ?? "").trim() || undefined;
+
+  const parsed = purchaseOrderUpdateSchema.safeParse({ deliveryWarehouseId, expectedDate, notes });
+  if (!parsed.success) {
+    redirect(`/purchasing/orders/${orderId}?error=${encodeURIComponent(firstErrorMessage(parsed.error))}`);
+  }
+
+  const order = await prisma.purchaseOrder.findUnique({
+    where: { id: orderId },
+    select: {
+      status: true,
+      paymentTermsSnapshot: true,
+      supplier: { select: { paymentTerms: true } },
+    },
+  });
+  if (!order || order.status !== "BORRADOR") {
+    redirect(`/purchasing/orders/${orderId}?error=${encodeURIComponent("Solo se pueden editar datos de OCs en Borrador")}`);
+  }
+
+  const warehouse = await prisma.warehouse.findUnique({
+    where: { id: parsed.data.deliveryWarehouseId },
+    select: { id: true, address: true, isActive: true },
+  });
+  if (!warehouse || !warehouse.isActive) {
+    redirect(`/purchasing/orders/${orderId}?error=${encodeURIComponent("Almacén destino no encontrado o inactivo")}`);
+  }
+
+  const frozenFields = resolvePurchaseOrderFrozenFields({
+    deliveryWarehouse: warehouse,
+    supplierPaymentTerms: order.paymentTermsSnapshot ?? order.supplier.paymentTerms,
+  });
+
+  await prisma.purchaseOrder.update({
+    where: { id: orderId },
+    data: {
+      deliveryWarehouseId: frozenFields.deliveryWarehouseId,
+      deliveryAddressSnapshot: frozenFields.deliveryAddressSnapshot,
+      paymentTermsSnapshot: frozenFields.paymentTermsSnapshot,
+      expectedDate: parsed.data.expectedDate ? new Date(parsed.data.expectedDate) : null,
+      notes: parsed.data.notes ?? null,
+    },
+  });
+
+  redirect(`/purchasing/orders/${orderId}?ok=1`);
+}
+
 async function removeLine(orderId: string, formData: FormData) {
   "use server";
   await (await import("@/lib/rbac")).requirePermission("purchasing.manage");
@@ -142,9 +201,14 @@ export default async function PurchaseOrderDetailPage({
       supplierId: true,
       folio: true,
       status: true,
+      deliveryWarehouseId: true,
       expectedDate: true,
       notes: true,
-      supplier: { select: { id: true, code: true, name: true, businessName: true } },
+      deliveryAddressSnapshot: true,
+      paymentTermsSnapshot: true,
+      emailSendState: true,
+      supplier: { select: { id: true, code: true, name: true, businessName: true, paymentTerms: true } },
+      deliveryWarehouse: { select: { id: true, code: true, name: true, address: true, isActive: true } },
       lines: {
         select: {
           id: true,
@@ -179,6 +243,13 @@ export default async function PurchaseOrderDetailPage({
   const updateStatusBound = updateStatus.bind(null, id);
   const addLineBound = addLine.bind(null, id);
   const removeLineBound = removeLine.bind(null, id);
+  const updateDraftMetadataBound = updateDraftMetadata.bind(null, id);
+
+  const activeWarehouses = await prisma.warehouse.findMany({
+    where: { isActive: true },
+    orderBy: { name: "asc" },
+    select: { id: true, code: true, name: true, address: true },
+  });
 
   const totalOrdered = order.lines.reduce((s, l) => s + l.qtyOrdered, 0);
   const totalReceived = order.lines.reduce((s, l) => s + l.qtyReceived, 0);
@@ -193,7 +264,6 @@ export default async function PurchaseOrderDetailPage({
       documentSnapshot = null;
     }
   }
-
   const allowedTransitions = TRANSITIONS[order.status] ?? [];
   const hasPending = order.lines.some((l) => l.qtyReceived < l.qtyOrdered);
   const canReceive = ["CONFIRMADA", "EN_TRANSITO", "PARCIAL"].includes(order.status) && hasPending;
@@ -274,6 +344,80 @@ export default async function PurchaseOrderDetailPage({
           </div>
         </div>
       )}
+
+      <div className="glass-card space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-bold">Entrega y términos oficiales</h2>
+            <p className="text-sm text-slate-400 mt-1">Estos valores se congelan en el documento oficial de la orden de compra.</p>
+          </div>
+          <span className="text-xs uppercase tracking-[0.2em] text-slate-500">
+            {order.status === "BORRADOR" ? "Editable" : "Congelado"}
+          </span>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 text-sm">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Dirección de entrega</p>
+            <p className="text-slate-200">{order.deliveryAddressSnapshot ?? order.deliveryWarehouse?.address ?? "—"}</p>
+            <p className="text-slate-500 text-xs">
+              {order.deliveryWarehouse ? `${order.deliveryWarehouse.code} — ${order.deliveryWarehouse.name}` : "Sin almacén seleccionado"}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Términos de pago</p>
+            <p className="text-slate-200">{order.paymentTermsSnapshot ?? order.supplier.paymentTerms ?? "—"}</p>
+            <p className="text-slate-500 text-xs">Origen: ficha del proveedor.</p>
+          </div>
+        </div>
+
+        {order.status === "BORRADOR" && (
+          <form action={updateDraftMetadataBound} className="grid gap-4 md:grid-cols-2 border-t border-white/10 pt-4">
+            <label className="space-y-1 md:col-span-2">
+              <span className="text-xs text-slate-400">Almacén destino *</span>
+              <select
+                name="deliveryWarehouseId"
+                required
+                defaultValue={order.deliveryWarehouseId ?? ""}
+                className="w-full px-3 py-2 glass rounded-lg text-sm"
+              >
+                <option value="">Seleccionar almacén...</option>
+                {activeWarehouses.map((warehouse) => (
+                  <option key={warehouse.id} value={warehouse.id}>
+                    {warehouse.code} — {warehouse.name} {warehouse.address ? `(${warehouse.address})` : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-1">
+              <span className="text-xs text-slate-400">Fecha esperada</span>
+              <input
+                name="expectedDate"
+                type="date"
+                defaultValue={formatDateInput(order.expectedDate)}
+                className="w-full px-3 py-2 glass rounded-lg text-sm"
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className="text-xs text-slate-400">Notas</span>
+              <textarea
+                name="notes"
+                rows={3}
+                defaultValue={order.notes ?? ""}
+                className="w-full px-3 py-2 glass rounded-lg text-sm min-h-[96px]"
+              />
+            </label>
+
+            <div className="md:col-span-2 flex justify-end">
+              <button type="submit" className="btn-primary text-sm py-2 px-4">
+                Guardar datos de borrador
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
 
       <div className="glass-card space-y-3">
         <h2 className="text-lg font-bold border-b border-white/10 pb-2">Documento oficial</h2>

--- a/app/(shell)/purchasing/orders/new/page.tsx
+++ b/app/(shell)/purchasing/orders/new/page.tsx
@@ -11,24 +11,37 @@ import { SectionCard } from "@/components/ui/section-card";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { pageGuard } from "@/components/rbac/PageGuard";
+import { resolvePurchaseOrderFrozenFields } from "@/lib/purchasing/purchase-order-document-service";
 
 async function createOrder(formData: FormData) {
   "use server";
   await (await import("@/lib/rbac")).requirePermission("purchasing.manage");
 
   const supplierId = String(formData.get("supplierId") ?? "").trim();
+  const deliveryWarehouseId = String(formData.get("deliveryWarehouseId") ?? "").trim();
   const expectedDate = String(formData.get("expectedDate") ?? "").trim() || undefined;
   const notes = String(formData.get("notes") ?? "").trim() || undefined;
 
-  const parsed = purchaseOrderCreateSchema.safeParse({ supplierId, expectedDate, notes });
+  const parsed = purchaseOrderCreateSchema.safeParse({ supplierId, deliveryWarehouseId, expectedDate, notes });
   if (!parsed.success) {
     redirect(`/purchasing/orders/new?error=${encodeURIComponent(firstErrorMessage(parsed.error))}`);
   }
 
-  const supplier = await prisma.supplier.findUnique({ where: { id: parsed.data.supplierId } });
+  const [supplier, warehouse] = await Promise.all([
+    prisma.supplier.findUnique({ where: { id: parsed.data.supplierId } }),
+    prisma.warehouse.findUnique({ where: { id: parsed.data.deliveryWarehouseId } }),
+  ]);
   if (!supplier || !supplier.isActive) {
     redirect(`/purchasing/orders/new?error=${encodeURIComponent("Proveedor no encontrado o inactivo")}`);
   }
+  if (!warehouse || !warehouse.isActive) {
+    redirect(`/purchasing/orders/new?error=${encodeURIComponent("Almacén destino no encontrado o inactivo")}`);
+  }
+
+  const frozenFields = resolvePurchaseOrderFrozenFields({
+    deliveryWarehouse: { id: warehouse.id, address: warehouse.address ?? null },
+    supplierPaymentTerms: supplier.paymentTerms,
+  });
 
   const count = await prisma.purchaseOrder.count();
   const year = new Date().getFullYear();
@@ -38,8 +51,11 @@ async function createOrder(formData: FormData) {
     data: {
       folio,
       supplierId: parsed.data.supplierId,
+      deliveryWarehouseId: frozenFields.deliveryWarehouseId,
       expectedDate: parsed.data.expectedDate ? new Date(parsed.data.expectedDate) : null,
       notes: parsed.data.notes ?? null,
+      deliveryAddressSnapshot: frozenFields.deliveryAddressSnapshot,
+      paymentTermsSnapshot: frozenFields.paymentTermsSnapshot,
     },
     select: { id: true, folio: true },
   });
@@ -76,6 +92,11 @@ export default async function NewPurchaseOrderPage({
     orderBy: { name: "asc" },
     select: { id: true, code: true, name: true },
   });
+  const warehouses = await prisma.warehouse.findMany({
+    where: { isActive: true },
+    orderBy: { name: "asc" },
+    select: { id: true, code: true, name: true, address: true },
+  });
 
   return (
     <div className="max-w-2xl mx-auto space-y-6">
@@ -93,12 +114,23 @@ export default async function NewPurchaseOrderPage({
         <section className="surface border-[var(--danger)]/40 bg-[var(--danger-soft)] p-4 text-sm text-[var(--danger)]">{sp.error}</section>
       )}
 
-      {suppliers.length === 0 && (
+      {(suppliers.length === 0 || warehouses.length === 0) && (
         <EmptyState
           compact
-          title="No hay proveedores activos"
-          description="Registra un proveedor antes de generar nuevas ordenes de compra."
-          actions={<Link href="/purchasing/suppliers/new" className={buttonStyles({ variant: "secondary", size: "sm" })}>Crear proveedor</Link>}
+          title={suppliers.length === 0 ? "No hay proveedores activos" : "No hay almacenes activos"}
+          description={
+            suppliers.length === 0
+              ? "Registra un proveedor antes de generar nuevas ordenes de compra."
+              : "Registra un almacén activo antes de generar nuevas ordenes de compra."
+          }
+          actions={
+            <Link
+              href={suppliers.length === 0 ? "/purchasing/suppliers/new" : "/warehouse/new"}
+              className={buttonStyles({ variant: "secondary", size: "sm" })}
+            >
+              {suppliers.length === 0 ? "Crear proveedor" : "Crear almacén"}
+            </Link>
+          }
         />
       )}
 
@@ -108,7 +140,7 @@ export default async function NewPurchaseOrderPage({
           footer={
             <>
               <Link href="/purchasing/orders" className={buttonStyles({ variant: "secondary" })}>Cancelar</Link>
-              <Button type="submit" disabled={suppliers.length === 0}>Crear OC</Button>
+              <Button type="submit" disabled={suppliers.length === 0 || warehouses.length === 0}>Crear OC</Button>
             </>
           }
         >
@@ -116,6 +148,20 @@ export default async function NewPurchaseOrderPage({
             {suppliers.map((s) => (
               <option key={s.id} value={s.id}>
                 {s.code} - {s.name}
+              </option>
+            ))}
+          </Select>
+
+          <Select
+            name="deliveryWarehouseId"
+            required
+            label="Almacén destino"
+            placeholder="Seleccionar almacén..."
+            hint="La dirección de este almacén se congelará como dirección de entrega."
+          >
+            {warehouses.map((warehouse) => (
+              <option key={warehouse.id} value={warehouse.id}>
+                {warehouse.code} - {warehouse.name} {warehouse.address ? `(${warehouse.address})` : ""}
               </option>
             ))}
           </Select>

--- a/app/(shell)/purchasing/suppliers/[id]/page.tsx
+++ b/app/(shell)/purchasing/suppliers/[id]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import prisma from "@/lib/prisma";
 import { createAuditLogSafe } from "@/lib/audit-log";
-import { firstErrorMessage, supplierBrandSchema } from "@/lib/schemas/wms";
+import { firstErrorMessage, supplierBrandSchema, supplierUpdateSchema } from "@/lib/schemas/wms";
 import { z } from "zod";
 
 async function linkProduct(supplierId: string, formData: FormData) {
@@ -66,6 +66,31 @@ async function toggleActive(supplierId: string, formData: FormData) {
   const isActive = formData.get("isActive") === "true";
   await prisma.supplier.update({ where: { id: supplierId }, data: { isActive: !isActive } });
   redirect(`/purchasing/suppliers/${supplierId}`);
+}
+
+async function updatePaymentTerms(supplierId: string, formData: FormData) {
+  "use server";
+
+  const paymentTerms = String(formData.get("paymentTerms") ?? "").trim() || undefined;
+  const parsed = supplierUpdateSchema.safeParse({ paymentTerms });
+  if (!parsed.success) {
+    redirect(`/purchasing/suppliers/${supplierId}?error=${encodeURIComponent(firstErrorMessage(parsed.error))}`);
+  }
+
+  await prisma.supplier.update({
+    where: { id: supplierId },
+    data: { paymentTerms: parsed.data.paymentTerms ?? null },
+  });
+
+  await createAuditLogSafe({
+    entityType: "SUPPLIER",
+    entityId: supplierId,
+    action: "UPDATE",
+    after: JSON.stringify({ paymentTerms: parsed.data.paymentTerms ?? null }),
+    source: "purchasing/suppliers",
+  });
+
+  redirect(`/purchasing/suppliers/${supplierId}?ok=terms`);
 }
 
 async function addBrand(supplierId: string, formData: FormData) {
@@ -146,6 +171,7 @@ export default async function SupplierDetailPage({
       email: true,
       phone: true,
       address: true,
+      paymentTerms: true,
       isActive: true,
       brands: {
         orderBy: { name: "asc" },
@@ -180,6 +206,7 @@ export default async function SupplierDetailPage({
   const linkProductBound = linkProduct.bind(null, id);
   const unlinkProductBound = unlinkProduct.bind(null, id);
   const toggleActiveBound = toggleActive.bind(null, id);
+  const updatePaymentTermsBound = updatePaymentTerms.bind(null, id);
   const addBrandBound = addBrand.bind(null, id);
 
   return (
@@ -209,6 +236,7 @@ export default async function SupplierDetailPage({
       {sp.error && <div className="glass-card border border-red-500/30 text-red-200 text-sm">{sp.error}</div>}
       {sp.ok === "1" && <div className="glass-card border border-green-500/30 text-green-200 text-sm">Producto vinculado correctamente.</div>}
       {sp.ok === "brand" && <div className="glass-card border border-green-500/30 text-green-200 text-sm">Marca agregada correctamente.</div>}
+      {sp.ok === "terms" && <div className="glass-card border border-green-500/30 text-green-200 text-sm">Términos de pago actualizados correctamente.</div>}
 
       {/* Info del proveedor */}
       <div className="glass-card grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
@@ -235,6 +263,26 @@ export default async function SupplierDetailPage({
           </div>
         )}
       </div>
+
+      <form action={updatePaymentTermsBound} className="glass-card space-y-4">
+        <div>
+          <h2 className="text-lg font-bold">Términos de pago</h2>
+          <p className="text-sm text-slate-400 mt-1">Este valor se copia a nuevas órdenes de compra y se congela en el documento oficial.</p>
+        </div>
+        <textarea
+          name="paymentTerms"
+          rows={3}
+          defaultValue={supplier.paymentTerms ?? ""}
+          maxLength={500}
+          placeholder="Contado, 30 días, transferencia..."
+          className="w-full px-3 py-2 glass rounded-lg text-sm min-h-[96px]"
+        />
+        <div className="flex justify-end">
+          <button type="submit" className="btn-primary text-sm py-2 px-4">
+            Guardar términos
+          </button>
+        </div>
+      </form>
 
       {/* Marcas del proveedor */}
       <div className="glass-card space-y-4">

--- a/app/(shell)/purchasing/suppliers/new/page.tsx
+++ b/app/(shell)/purchasing/suppliers/new/page.tsx
@@ -22,8 +22,9 @@ async function createSupplier(formData: FormData) {
   const email = String(formData.get("email") ?? "").trim() || undefined;
   const phone = String(formData.get("phone") ?? "").trim() || undefined;
   const address = String(formData.get("address") ?? "").trim() || undefined;
+  const paymentTerms = String(formData.get("paymentTerms") ?? "").trim() || undefined;
 
-  const parsed = supplierCreateSchema.safeParse({ code, name, legalName, businessName, taxId, email, phone, address });
+  const parsed = supplierCreateSchema.safeParse({ code, name, legalName, businessName, taxId, email, phone, address, paymentTerms });
   if (!parsed.success) {
     redirect(`/purchasing/suppliers/new?error=${encodeURIComponent(firstErrorMessage(parsed.error))}`);
   }
@@ -43,6 +44,7 @@ async function createSupplier(formData: FormData) {
       email: parsed.data.email || null,
       phone: parsed.data.phone ?? null,
       address: parsed.data.address ?? null,
+      paymentTerms: parsed.data.paymentTerms ?? null,
     },
     select: { id: true },
   });
@@ -142,6 +144,15 @@ export default async function NewSupplierPage({
             maxLength={500}
             label="Direccion"
             placeholder="Calle, Numero, Colonia, CP, Ciudad"
+            textareaClassName="resize-none"
+          />
+
+          <Textarea
+            name="paymentTerms"
+            rows={2}
+            maxLength={500}
+            label="Términos de pago"
+            placeholder="Contado, 30 días, transferencia..."
             textareaClassName="resize-none"
           />
         </SectionCard>

--- a/lib/purchasing/purchase-order-document-service.ts
+++ b/lib/purchasing/purchase-order-document-service.ts
@@ -14,6 +14,7 @@ export type PurchaseOrderDocumentSupplierSnapshot = {
   email: string | null;
   phone: string | null;
   address: string | null;
+  paymentTerms: string | null;
 };
 
 export type PurchaseOrderDocumentLineSnapshot = {
@@ -36,8 +37,11 @@ export type PurchaseOrderDocumentSnapshot = {
     id: string;
     folio: string;
     status: string;
+    deliveryWarehouseId: string | null;
     expectedDate: string | null;
     notes: string | null;
+    deliveryAddressSnapshot: string | null;
+    paymentTermsSnapshot: string | null;
     createdAt: string;
   };
   supplier: PurchaseOrderDocumentSupplierSnapshot;
@@ -109,14 +113,33 @@ function normalizeCurrency(value: string | null | undefined) {
   return currency || "MXN";
 }
 
+function normalizeOptionalText(value: string | null | undefined) {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+export function resolvePurchaseOrderFrozenFields(input: {
+  deliveryWarehouse: { id: string; address: string | null } | null;
+  supplierPaymentTerms: string | null | undefined;
+}) {
+  return {
+    deliveryWarehouseId: input.deliveryWarehouse?.id ?? null,
+    deliveryAddressSnapshot: normalizeOptionalText(input.deliveryWarehouse?.address),
+    paymentTermsSnapshot: normalizeOptionalText(input.supplierPaymentTerms),
+  };
+}
+
 function mapPurchaseOrderToSnapshot(input: {
   documentVersion: number;
   purchaseOrder: {
     id: string;
     folio: string;
     status: string;
+    deliveryWarehouseId: string | null;
     expectedDate: Date | null;
     notes: string | null;
+    deliveryAddressSnapshot: string | null;
+    paymentTermsSnapshot: string | null;
     createdAt: Date;
     supplier: {
       code: string;
@@ -127,7 +150,11 @@ function mapPurchaseOrderToSnapshot(input: {
       email: string | null;
       phone: string | null;
       address: string | null;
+      paymentTerms: string | null;
     };
+    deliveryWarehouse: {
+      address: string | null;
+    } | null;
     lines: Array<{
       productId: string;
       qtyOrdered: number;
@@ -164,6 +191,10 @@ function mapPurchaseOrderToSnapshot(input: {
 
   const currency = lines[0]?.currency ?? "MXN";
   const subtotal = Number(lines.reduce((sum, line) => sum + line.subtotal, 0).toFixed(2));
+  const deliveryAddressSnapshot = normalizeOptionalText(input.purchaseOrder.deliveryAddressSnapshot)
+    ?? normalizeOptionalText(input.purchaseOrder.deliveryWarehouse?.address);
+  const paymentTermsSnapshot = normalizeOptionalText(input.purchaseOrder.paymentTermsSnapshot)
+    ?? normalizeOptionalText(input.purchaseOrder.supplier.paymentTerms);
   const payloadWithoutHash = {
     documentVersion: input.documentVersion,
     generatedAt: new Date().toISOString(),
@@ -171,8 +202,11 @@ function mapPurchaseOrderToSnapshot(input: {
       id: input.purchaseOrder.id,
       folio: input.purchaseOrder.folio,
       status: input.purchaseOrder.status,
+      deliveryWarehouseId: input.purchaseOrder.deliveryWarehouseId,
       expectedDate: toIsoDate(input.purchaseOrder.expectedDate),
       notes: input.purchaseOrder.notes,
+      deliveryAddressSnapshot,
+      paymentTermsSnapshot,
       createdAt: input.purchaseOrder.createdAt.toISOString(),
     },
     supplier: {
@@ -184,6 +218,7 @@ function mapPurchaseOrderToSnapshot(input: {
       email: input.purchaseOrder.supplier.email,
       phone: input.purchaseOrder.supplier.phone,
       address: input.purchaseOrder.supplier.address,
+      paymentTerms: paymentTermsSnapshot,
     },
     lines,
     totals: {
@@ -212,8 +247,11 @@ async function loadPurchaseOrderForDocument(db: PrismaTransactionLike, purchaseO
       id: true,
       folio: true,
       status: true,
+      deliveryWarehouseId: true,
       expectedDate: true,
       notes: true,
+      deliveryAddressSnapshot: true,
+      paymentTermsSnapshot: true,
       createdAt: true,
       supplier: {
         select: {
@@ -224,6 +262,12 @@ async function loadPurchaseOrderForDocument(db: PrismaTransactionLike, purchaseO
           taxId: true,
           email: true,
           phone: true,
+          address: true,
+          paymentTerms: true,
+        },
+      },
+      deliveryWarehouse: {
+        select: {
           address: true,
         },
       },
@@ -375,6 +419,19 @@ export async function updatePurchaseOrderStatusWithDocument(input: {
       select: {
         status: true,
         lines: { select: { qtyOrdered: true, qtyReceived: true } },
+        deliveryWarehouseId: true,
+        deliveryAddressSnapshot: true,
+        paymentTermsSnapshot: true,
+        supplier: {
+          select: {
+            paymentTerms: true,
+          },
+        },
+        deliveryWarehouse: {
+          select: {
+            address: true,
+          },
+        },
       },
     });
 
@@ -398,9 +455,28 @@ export async function updatePurchaseOrderStatusWithDocument(input: {
       }
     }
 
+    const frozenFields =
+      input.newStatus === "CONFIRMADA"
+        ? resolvePurchaseOrderFrozenFields({
+            deliveryWarehouse: order.deliveryWarehouseId
+              ? { id: order.deliveryWarehouseId, address: order.deliveryWarehouse?.address ?? null }
+              : null,
+            supplierPaymentTerms: order.paymentTermsSnapshot ?? order.supplier.paymentTerms,
+          })
+        : null;
+
     await tx.purchaseOrder.update({
       where: { id: input.purchaseOrderId },
-      data: { status: input.newStatus as never },
+      data: {
+        status: input.newStatus as never,
+        ...(frozenFields
+          ? {
+              deliveryWarehouseId: frozenFields.deliveryWarehouseId,
+              deliveryAddressSnapshot: frozenFields.deliveryAddressSnapshot,
+              paymentTermsSnapshot: frozenFields.paymentTermsSnapshot,
+            }
+          : {}),
+      },
     });
 
     if (input.newStatus === "CONFIRMADA") {

--- a/lib/purchasing/purchase-order-pdf.tsx
+++ b/lib/purchasing/purchase-order-pdf.tsx
@@ -25,50 +25,126 @@ export function getSupplierDisplayLines(supplier: PurchaseOrderDocumentSnapshot[
   return { primary, secondary };
 }
 
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatSingleLineText(value: string) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) return "—";
+  return normalized.replace(/\s+/g, "\u00A0");
+}
+
+export function getPurchaseOrderPdfLineTypography(line: Pick<PurchaseOrderDocumentSnapshot["lines"][number], "sku" | "name">) {
+  const sku = String(line.sku ?? "").trim();
+  const name = String(line.name ?? "").trim();
+  const nameLength = name.length;
+
+  const skuFontSize = clamp(6.9 - Math.max(0, sku.length - 18) * 0.03, 5.6, 6.9);
+  const productFontSize = clamp(8.0 - Math.max(0, nameLength - 52) * 0.025, 6.7, 8.0);
+
+  return {
+    skuFontSize,
+    skuLineHeight: 1,
+    productFontSize,
+    productLineHeight: 1.02,
+    rowMinHeight: nameLength > 135 ? 36 : nameLength > 90 ? 30 : nameLength > 55 ? 26 : 22,
+  };
+}
+
+export function injectSoftBreaks(value: string) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) return "—";
+
+  const withSeparatorBreaks = normalized.replace(/([/._-])/g, "$1\u200B");
+
+  if (withSeparatorBreaks.includes(" ")) {
+    return withSeparatorBreaks;
+  }
+
+  return withSeparatorBreaks.replace(/(.{8})(?=.)/g, "$1\u200B");
+}
+
 const styles = StyleSheet.create({
   page: {
     fontFamily: "Helvetica",
-    fontSize: 8.8,
-    paddingTop: 28,
-    paddingHorizontal: 24,
-    paddingBottom: 24,
-    color: "#111827",
+    fontSize: 8.2,
+    paddingTop: 22,
+    paddingHorizontal: 18,
+    paddingBottom: 20,
+    color: "#0f172a",
+    backgroundColor: "#f8fafc",
   },
   header: {
-    marginBottom: 14,
+    marginBottom: 12,
     paddingBottom: 10,
     borderBottomWidth: 1,
-    borderBottomColor: "#111827",
+    borderBottomColor: "#94a3b8",
     borderBottomStyle: "solid",
   },
-  title: {
-    fontSize: 19,
+  headerAccent: {
+    width: 64,
+    height: 4,
+    borderRadius: 999,
+    backgroundColor: "#1d4ed8",
+    marginBottom: 8,
+  },
+  headerTop: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 12,
+    marginBottom: 6,
+  },
+  headerTitleBlock: {
+    flexGrow: 1,
+    flexBasis: 0,
+  },
+  headerTitleRight: {
+    flexGrow: 0,
+    flexShrink: 0,
+    alignItems: "flex-end",
+  },
+  headerFolio: {
+    fontSize: 10.5,
     fontWeight: 700,
-    marginBottom: 4,
+    color: "#0f172a",
+    textAlign: "right",
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 700,
+    color: "#0f172a",
+    marginBottom: 3,
   },
   subtitle: {
     fontSize: 10,
-    color: "#4b5563",
+    color: "#475569",
   },
   metaRow: {
     flexDirection: "row",
     justifyContent: "space-between",
-    marginTop: 8,
+    marginTop: 4,
+    color: "#475569",
   },
   section: {
-    marginBottom: 10,
+    marginBottom: 8,
   },
   sectionTitle: {
-    fontSize: 10.5,
+    fontSize: 9.8,
     fontWeight: 700,
-    marginBottom: 4,
+    marginBottom: 5,
+    color: "#0f172a",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
   },
   card: {
     borderWidth: 1,
-    borderColor: "#d1d5db",
+    borderColor: "#cbd5e1",
     borderStyle: "solid",
-    borderRadius: 3,
-    padding: 8,
+    borderRadius: 4,
+    padding: 9,
+    backgroundColor: "#ffffff",
   },
   row: {
     flexDirection: "row",
@@ -80,78 +156,146 @@ const styles = StyleSheet.create({
     flexBasis: 0,
   },
   textMuted: {
-    color: "#4b5563",
+    color: "#475569",
   },
   smallMuted: {
-    color: "#6b7280",
-    fontSize: 8,
+    color: "#64748b",
+    fontSize: 7.8,
   },
   lineTable: {
     borderWidth: 1,
-    borderColor: "#d1d5db",
+    borderColor: "#cbd5e1",
     borderStyle: "solid",
+    borderRadius: 4,
+    overflow: "hidden",
   },
   lineHeader: {
     flexDirection: "row",
-    backgroundColor: "#f3f4f6",
+    backgroundColor: "#e2e8f0",
     borderBottomWidth: 1,
-    borderBottomColor: "#d1d5db",
+    borderBottomColor: "#94a3b8",
     borderBottomStyle: "solid",
   },
   lineCell: {
-    paddingVertical: 5,
+    paddingVertical: 4.5,
     paddingHorizontal: 4,
     borderRightWidth: 1,
-    borderRightColor: "#e5e7eb",
+    borderRightColor: "#dbe3ea",
     borderRightStyle: "solid",
     justifyContent: "flex-start",
+    overflow: "hidden",
   },
   lineBody: {
     flexDirection: "row",
     borderBottomWidth: 1,
-    borderBottomColor: "#e5e7eb",
+    borderBottomColor: "#e2e8f0",
     borderBottomStyle: "solid",
+    alignItems: "stretch",
+    backgroundColor: "#ffffff",
   },
   lineBodyLast: {
     borderBottomWidth: 0,
   },
+  lineBodyAlt: {
+    backgroundColor: "#f8fafc",
+  },
   lineSku: {
-    width: "16%",
+    width: "15%",
   },
   lineProduct: {
     width: "34%",
   },
   lineQty: {
-    width: "11%",
+    width: "10%",
     textAlign: "right",
   },
   lineUnit: {
-    width: "9%",
+    width: "8%",
     textAlign: "center",
   },
   lineMoney: {
-    width: "15%",
+    width: "16.5%",
     textAlign: "right",
   },
-  totals: {
-    marginTop: 8,
-    width: "100%",
-    alignItems: "flex-end",
+  lineHeaderText: {
+    fontSize: 8.2,
+    fontWeight: 700,
+    color: "#0f172a",
+    lineHeight: 1.1,
+  },
+  lineQtyHeaderText: {
+    fontSize: 7.4,
+    fontWeight: 700,
+    color: "#0f172a",
+    lineHeight: 1,
+  },
+  lineSkuText: {
+    fontFamily: "Courier",
+    fontSize: 5.8,
+    lineHeight: 0.98,
+    color: "#0f172a",
+  },
+  lineProductText: {
+    fontSize: 7.8,
+    lineHeight: 1.0,
+    color: "#0f172a",
+  },
+  lineQtyText: {
+    fontSize: 7.8,
+    lineHeight: 1,
+    color: "#0f172a",
+  },
+  lineUnitText: {
+    fontSize: 7.6,
+    lineHeight: 1,
+    color: "#0f172a",
+  },
+  lineMoneyText: {
+    fontSize: 7.6,
+    lineHeight: 1,
+    color: "#0f172a",
   },
   totalsBox: {
     width: 170,
     borderWidth: 1,
-    borderColor: "#d1d5db",
+    borderColor: "#cbd5e1",
     borderStyle: "solid",
-    padding: 8,
+    borderRadius: 4,
+    padding: 9,
+    backgroundColor: "#ffffff",
   },
   totalsRow: {
     flexDirection: "row",
     justifyContent: "space-between",
-    marginBottom: 3,
+    marginBottom: 4,
+    color: "#0f172a",
   },
-  notes: {
-    minHeight: 34,
+  signatureSection: {
+    marginTop: 22,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 20,
+  },
+  signatureBlock: {
+    flexGrow: 1,
+    flexBasis: 0,
+    alignItems: "center",
+    paddingTop: 34,
+  },
+  signatureLine: {
+    width: "100%",
+    borderTopWidth: 1,
+    borderTopColor: "#475569",
+    borderTopStyle: "solid",
+    marginBottom: 7,
+  },
+  signatureLabel: {
+    fontSize: 8.6,
+    fontWeight: 700,
+    color: "#0f172a",
+    textAlign: "center",
+    textTransform: "uppercase",
+    letterSpacing: 0.35,
   },
   footer: {
     position: "absolute",
@@ -160,37 +304,88 @@ const styles = StyleSheet.create({
     bottom: 18,
     flexDirection: "row",
     justifyContent: "space-between",
-    color: "#6b7280",
-    fontSize: 8,
+    color: "#64748b",
+    fontSize: 7.8,
   },
-  documentMetaGrid: {
+  documentInfoBand: {
     flexDirection: "row",
-    gap: 10,
-    marginTop: 8,
+    alignItems: "stretch",
+    marginTop: 10,
+    marginBottom: 4,
+    borderWidth: 1,
+    borderColor: "#cbd5e1",
+    borderStyle: "solid",
+    borderRadius: 4,
+    overflow: "hidden",
+    backgroundColor: "#ffffff",
   },
-  metaCard: {
+  documentInfoItem: {
     flexGrow: 1,
     flexBasis: 0,
-    borderWidth: 1,
-    borderColor: "#d1d5db",
-    borderStyle: "solid",
-    borderRadius: 3,
-    padding: 8,
+    paddingVertical: 8.5,
+    paddingHorizontal: 10,
   },
-  metaLabel: {
-    fontSize: 8,
-    color: "#6b7280",
+  documentInfoDivider: {
+    width: 1,
+    backgroundColor: "#dbe3ea",
+  },
+  documentInfoLabel: {
+    fontSize: 6.7,
+    fontWeight: 700,
+    color: "#475569",
     textTransform: "uppercase",
+    letterSpacing: 0.5,
     marginBottom: 3,
   },
-  metaValue: {
-    fontSize: 9.5,
-    color: "#111827",
+  documentInfoValue: {
+    fontSize: 8.7,
+    color: "#0f172a",
+    lineHeight: 1.05,
+  },
+  documentBottomBand: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    marginTop: 10,
+    marginBottom: 2,
+    gap: 18,
+  },
+  documentNotesSection: {
+    flexGrow: 1,
+    flexBasis: 0,
+  },
+  documentNotesCard: {
+    minHeight: 58,
+  },
+  documentTotalsSection: {
+    flexGrow: 0,
+    flexShrink: 0,
+    width: 170,
+    alignItems: "flex-end",
+  },
+  documentTotalsRowLast: {
+    marginBottom: 0,
+  },
+  documentTotalsEmphasis: {
+    paddingTop: 3,
+    marginTop: 1,
+    borderTopWidth: 1,
+    borderTopColor: "#cbd5e1",
+    borderTopStyle: "solid",
+    backgroundColor: "#eff6ff",
+  },
+  documentTotalsLabel: {
+    fontSize: 8,
+    color: "#0f172a",
+  },
+  documentTotalsValue: {
+    fontSize: 8,
+    color: "#0f172a",
+    fontWeight: 700,
   },
   supplierPrimary: {
     fontSize: 10,
     fontWeight: 700,
-    color: "#111827",
+    color: "#0f172a",
   },
 });
 
@@ -211,38 +406,25 @@ function formatDate(value: string | null) {
 
 export function PurchaseOrderPdfDocument({ snapshot }: { snapshot: PurchaseOrderDocumentSnapshot }) {
   const supplierLines = getSupplierDisplayLines(snapshot.supplier);
+  const subtotal = snapshot.totals.subtotal;
+  const iva = Number((subtotal * 0.16).toFixed(2));
+  const total = Number((subtotal + iva).toFixed(2));
   return (
     <Document>
-      <Page size="A4" orientation="landscape" style={styles.page}>
+      <Page size="LETTER" orientation="portrait" style={styles.page}>
         <View style={styles.header}>
-          <Text style={styles.title}>Orden de Compra</Text>
-          <Text style={styles.subtitle}>WMS Mangueras y Conexiones</Text>
-          <View style={styles.metaRow}>
-            <Text>Folio: {snapshot.purchaseOrder.folio}</Text>
-            <Text>Versión documento: v{snapshot.documentVersion}</Text>
+          <View style={styles.headerAccent} />
+          <View style={styles.headerTop}>
+            <View style={styles.headerTitleBlock}>
+              <Text style={styles.title}>Orden de Compra</Text>
+            </View>
+            <View style={styles.headerTitleRight}>
+              <Text style={styles.headerFolio}>Folio: {snapshot.purchaseOrder.folio}</Text>
+            </View>
           </View>
           <View style={styles.metaRow}>
             <Text>Fecha de emisión: {new Date(snapshot.generatedAt).toLocaleString("es-MX")}</Text>
-            <Text>Estado: {snapshot.purchaseOrder.status}</Text>
-          </View>
-        </View>
-
-        <View style={styles.documentMetaGrid}>
-          <View style={styles.metaCard}>
-            <Text style={styles.metaLabel}>Fecha esperada / entrega solicitada</Text>
-            <Text style={styles.metaValue}>{formatDate(snapshot.purchaseOrder.expectedDate)}</Text>
-          </View>
-          <View style={styles.metaCard}>
-            <Text style={styles.metaLabel}>Compra</Text>
-            <Text style={styles.metaValue}>Orden congelada para uso oficial</Text>
-          </View>
-          <View style={styles.metaCard}>
-            <Text style={styles.metaLabel}>Moneda</Text>
-            <Text style={styles.metaValue}>{snapshot.totals.currency}</Text>
-          </View>
-          <View style={styles.metaCard}>
-            <Text style={styles.metaLabel}>Versión documento</Text>
-            <Text style={styles.metaValue}>v{snapshot.documentVersion}</Text>
+            <Text>Versión documento: v{snapshot.documentVersion}</Text>
           </View>
         </View>
 
@@ -270,20 +452,25 @@ export function PurchaseOrderPdfDocument({ snapshot }: { snapshot: PurchaseOrder
           </View>
         </View>
 
-        <View style={[styles.row, { marginTop: 10 }]}>
-          <View style={[styles.section, styles.column]}>
-            <Text style={styles.sectionTitle}>Entrega y términos</Text>
-            <View style={styles.card}>
-              <Text>Dirección de entrega: Por definir</Text>
-              <Text>Términos de pago: Por definir</Text>
-              <Text>Moneda: {snapshot.totals.currency}</Text>
-            </View>
+        <View style={styles.documentInfoBand}>
+          <View style={styles.documentInfoItem}>
+            <Text style={styles.documentInfoLabel}>Fecha esperada</Text>
+            <Text style={styles.documentInfoValue}>{formatDate(snapshot.purchaseOrder.expectedDate)}</Text>
           </View>
-          <View style={[styles.section, styles.column]}>
-            <Text style={styles.sectionTitle}>Notas</Text>
-            <View style={[styles.card, styles.notes]}>
-              <Text>{snapshot.purchaseOrder.notes ?? "—"}</Text>
-            </View>
+          <View style={styles.documentInfoDivider} />
+          <View style={styles.documentInfoItem}>
+            <Text style={styles.documentInfoLabel}>Moneda</Text>
+            <Text style={styles.documentInfoValue}>{snapshot.totals.currency}</Text>
+          </View>
+          <View style={styles.documentInfoDivider} />
+          <View style={styles.documentInfoItem}>
+            <Text style={styles.documentInfoLabel}>Dirección de entrega</Text>
+            <Text style={styles.documentInfoValue}>{snapshot.purchaseOrder.deliveryAddressSnapshot ?? "—"}</Text>
+          </View>
+          <View style={styles.documentInfoDivider} />
+          <View style={styles.documentInfoItem}>
+            <Text style={styles.documentInfoLabel}>Términos de pago</Text>
+            <Text style={styles.documentInfoValue}>{snapshot.supplier.paymentTerms ?? "—"}</Text>
           </View>
         </View>
 
@@ -291,39 +478,91 @@ export function PurchaseOrderPdfDocument({ snapshot }: { snapshot: PurchaseOrder
           <Text style={styles.sectionTitle}>Líneas</Text>
           <View style={styles.lineTable}>
             <View style={styles.lineHeader}>
-              <Text style={[styles.lineCell, styles.lineSku]}>SKU</Text>
-              <Text style={[styles.lineCell, styles.lineProduct]}>Producto</Text>
-              <Text style={[styles.lineCell, styles.lineQty]}>Cantidad</Text>
-              <Text style={[styles.lineCell, styles.lineUnit]}>Unidad</Text>
-              <Text style={[styles.lineCell, styles.lineMoney]}>Precio unitario</Text>
-              <Text style={[styles.lineCell, styles.lineMoney]}>Importe</Text>
+              <Text style={[styles.lineCell, styles.lineSku, styles.lineHeaderText]}>SKU</Text>
+              <Text style={[styles.lineCell, styles.lineProduct, styles.lineHeaderText]}>Producto</Text>
+              <Text style={[styles.lineCell, styles.lineQty, styles.lineQtyHeaderText]}>Cantidad</Text>
+              <Text style={[styles.lineCell, styles.lineUnit, styles.lineHeaderText]}>Unidad</Text>
+              <Text style={[styles.lineCell, styles.lineMoney, styles.lineHeaderText]}>Precio unitario</Text>
+              <Text style={[styles.lineCell, styles.lineMoney, styles.lineHeaderText]}>Importe</Text>
             </View>
             {snapshot.lines.map((line, index) => (
-              <View
-                key={`${line.productId}-${index}`}
-                style={index === snapshot.lines.length - 1 ? [styles.lineBody, styles.lineBodyLast] : styles.lineBody}
-              >
-                <Text style={[styles.lineCell, styles.lineSku]}>{line.sku}</Text>
-                <Text style={[styles.lineCell, styles.lineProduct]}>{line.name}</Text>
-                <Text style={[styles.lineCell, styles.lineQty]}>{line.qtyOrdered}</Text>
-                <Text style={[styles.lineCell, styles.lineUnit]}>{line.unitLabel}</Text>
-                <Text style={[styles.lineCell, styles.lineMoney]}>{money(line.unitPrice, line.currency)}</Text>
-                <Text style={[styles.lineCell, styles.lineMoney]}>{money(line.subtotal, line.currency)}</Text>
-              </View>
+              (() => {
+                const typography = getPurchaseOrderPdfLineTypography(line);
+                return (
+                  <View
+                    key={`${line.productId}-${index}`}
+                    wrap={false}
+                    style={[
+                      styles.lineBody,
+                      ...(index % 2 === 1 ? [styles.lineBodyAlt] : []),
+                      ...(index === snapshot.lines.length - 1 ? [styles.lineBodyLast] : []),
+                      { minHeight: typography.rowMinHeight },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.lineCell,
+                        styles.lineSku,
+                        styles.lineSkuText,
+                        { fontSize: typography.skuFontSize, lineHeight: typography.skuLineHeight },
+                      ]}
+                    >
+                      {formatSingleLineText(line.sku)}
+                    </Text>
+                    <Text
+                      style={[
+                        styles.lineCell,
+                        styles.lineProduct,
+                        styles.lineProductText,
+                        { fontSize: typography.productFontSize, lineHeight: typography.productLineHeight },
+                      ]}
+                    >
+                      {injectSoftBreaks(line.name)}
+                    </Text>
+                    <Text style={[styles.lineCell, styles.lineQty, styles.lineQtyText]}>{line.qtyOrdered}</Text>
+                    <Text style={[styles.lineCell, styles.lineUnit, styles.lineUnitText]}>{formatSingleLineText(line.unitLabel)}</Text>
+                    <Text style={[styles.lineCell, styles.lineMoney, styles.lineMoneyText]}>{money(line.unitPrice, line.currency)}</Text>
+                    <Text style={[styles.lineCell, styles.lineMoney, styles.lineMoneyText]}>{money(line.subtotal, line.currency)}</Text>
+                  </View>
+                );
+              })()
             ))}
           </View>
         </View>
 
-        <View style={styles.totals}>
-          <View style={styles.totalsBox}>
-            <View style={styles.totalsRow}>
-              <Text>Subtotal</Text>
-              <Text>{money(snapshot.totals.subtotal, snapshot.totals.currency)}</Text>
+        <View style={styles.documentBottomBand}>
+          <View style={styles.documentNotesSection}>
+            <Text style={styles.sectionTitle}>Notas</Text>
+            <View style={[styles.card, styles.documentNotesCard]}>
+              <Text>{snapshot.purchaseOrder.notes ?? "—"}</Text>
             </View>
-            <View style={styles.totalsRow}>
-              <Text>Total</Text>
-              <Text>{money(snapshot.totals.total, snapshot.totals.currency)}</Text>
+          </View>
+          <View style={styles.documentTotalsSection}>
+            <View style={styles.totalsBox}>
+              <View style={styles.totalsRow}>
+                <Text style={styles.documentTotalsLabel}>Subtotal</Text>
+                <Text style={styles.documentTotalsValue}>{money(subtotal, snapshot.totals.currency)}</Text>
+              </View>
+              <View style={styles.totalsRow}>
+                <Text style={styles.documentTotalsLabel}>IVA</Text>
+                <Text style={styles.documentTotalsValue}>{money(iva, snapshot.totals.currency)}</Text>
+              </View>
+              <View style={[styles.totalsRow, styles.documentTotalsEmphasis, styles.documentTotalsRowLast]}>
+                <Text style={styles.documentTotalsLabel}>Total</Text>
+                <Text style={styles.documentTotalsValue}>{money(total, snapshot.totals.currency)}</Text>
+              </View>
             </View>
+          </View>
+        </View>
+
+        <View style={styles.signatureSection}>
+          <View style={styles.signatureBlock}>
+            <View style={styles.signatureLine} />
+            <Text style={styles.signatureLabel}>Director general</Text>
+          </View>
+          <View style={styles.signatureBlock}>
+            <View style={styles.signatureLine} />
+            <Text style={styles.signatureLabel}>Encargado de almacén</Text>
           </View>
         </View>
 

--- a/lib/schemas/wms.ts
+++ b/lib/schemas/wms.ts
@@ -149,6 +149,11 @@ export const supplierCreateSchema = z.object({
   email: z.union([z.string().trim().email("Email inválido"), z.literal("")]).optional(),
   phone: z.string().trim().max(20).optional(),
   address: z.string().trim().max(500).optional(),
+  paymentTerms: z.string().trim().max(500).optional(),
+});
+
+export const supplierUpdateSchema = z.object({
+  paymentTerms: z.string().trim().max(500).optional(),
 });
 
 export const customerCreateSchema = z.object({
@@ -221,6 +226,13 @@ export const supplierBrandSchema = z.object({
 
 export const purchaseOrderCreateSchema = z.object({
   supplierId: requiredText("Proveedor"),
+  deliveryWarehouseId: requiredText("Almacen destino"),
+  expectedDate: z.string().trim().optional(),
+  notes: z.string().trim().max(1000).optional(),
+});
+
+export const purchaseOrderUpdateSchema = z.object({
+  deliveryWarehouseId: requiredText("Almacen destino"),
   expectedDate: z.string().trim().optional(),
   notes: z.string().trim().max(1000).optional(),
 });

--- a/prisma/migrations/20260605190000_kan110_purchase_order_delivery_payment_terms/migration.sql
+++ b/prisma/migrations/20260605190000_kan110_purchase_order_delivery_payment_terms/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "Supplier" ADD COLUMN "paymentTerms" TEXT;
+
+ALTER TABLE "PurchaseOrder" ADD COLUMN "deliveryWarehouseId" TEXT;
+ALTER TABLE "PurchaseOrder" ADD COLUMN "deliveryAddressSnapshot" TEXT;
+ALTER TABLE "PurchaseOrder" ADD COLUMN "paymentTermsSnapshot" TEXT;
+
+CREATE INDEX IF NOT EXISTS "PurchaseOrder_deliveryWarehouseId_idx"
+ON "PurchaseOrder"("deliveryWarehouseId");

--- a/prisma/postgresql/migrations/20260605190000_kan110_purchase_order_delivery_payment_terms/migration.sql
+++ b/prisma/postgresql/migrations/20260605190000_kan110_purchase_order_delivery_payment_terms/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "Supplier" ADD COLUMN IF NOT EXISTS "paymentTerms" TEXT;
+
+ALTER TABLE "PurchaseOrder" ADD COLUMN IF NOT EXISTS "deliveryWarehouseId" TEXT;
+ALTER TABLE "PurchaseOrder" ADD COLUMN IF NOT EXISTS "deliveryAddressSnapshot" TEXT;
+ALTER TABLE "PurchaseOrder" ADD COLUMN IF NOT EXISTS "paymentTermsSnapshot" TEXT;
+
+CREATE INDEX IF NOT EXISTS "PurchaseOrder_deliveryWarehouseId_idx"
+ON "PurchaseOrder"("deliveryWarehouseId");

--- a/prisma/postgresql/schema.prisma
+++ b/prisma/postgresql/schema.prisma
@@ -28,6 +28,7 @@ model User {
   inventoryMovements InventoryMovement[] @relation("MovementOperatorUser")
   traceRecords       TraceRecord[]       @relation("TraceOperatorUser")
   auditLogs          AuditLog[]          @relation("AuditActorUser")
+  purchaseOrderEmailAttempts PurchaseOrderEmailAttempt[] @relation("PurchaseOrderEmailTriggeredByUser")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -224,6 +225,7 @@ model Warehouse {
   productionOrders ProductionOrder[]
   salesInternalOrders SalesInternalOrder[]
   assemblyWorkOrders AssemblyWorkOrder[]
+  purchaseOrders PurchaseOrder[]
   traceRecords TraceRecord[]
   
   createdAt   DateTime   @default(now())
@@ -906,6 +908,13 @@ enum PurchaseOrderStatus {
   CANCELADA
 }
 
+enum PurchaseOrderEmailSendState {
+  NOT_SENT
+  SENT
+  RESENT
+  FAILED
+}
+
 model Supplier {
   id           String   @id @default(uuid())
   code         String   @unique   // PROV-001
@@ -916,6 +925,7 @@ model Supplier {
   email        String?
   phone        String?
   address      String?
+  paymentTerms String?
   isActive     Boolean  @default(true)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
@@ -964,19 +974,35 @@ model PurchaseOrder {
   id           String              @id @default(uuid())
   folio        String              @unique   // OC-2026-0001
   supplierId   String
+  deliveryWarehouseId String?
   status       PurchaseOrderStatus @default(BORRADOR)
+  emailSendState PurchaseOrderEmailSendState @default(NOT_SENT)
+  emailRecipientSnapshot String?
+  emailSubjectSnapshot String?
+  emailBodySnapshot String?
+  emailDocumentVersionSnapshot Int?
+  emailLastAttemptAt DateTime?
+  emailLastSentAt DateTime?
+  emailLastErrorCode String?
+  emailLastErrorMessage String?
   expectedDate DateTime?
   notes        String?
+  deliveryAddressSnapshot String?
+  paymentTermsSnapshot String?
   createdAt    DateTime            @default(now())
   updatedAt    DateTime            @updatedAt
 
   supplier Supplier           @relation(fields: [supplierId], references: [id], onDelete: Restrict)
+  deliveryWarehouse Warehouse? @relation(fields: [deliveryWarehouseId], references: [id], onDelete: Restrict)
   lines    PurchaseOrderLine[]
   receipts PurchaseReceipt[]
   documents PurchaseOrderDocument[]
+  emailAttempts PurchaseOrderEmailAttempt[]
 
   @@index([supplierId])
+  @@index([deliveryWarehouseId])
   @@index([status])
+  @@index([emailSendState])
   @@index([createdAt])
 }
 
@@ -1008,9 +1034,38 @@ model PurchaseOrderDocument {
   createdAt       DateTime @default(now())
 
   purchaseOrder PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  emailAttempts PurchaseOrderEmailAttempt[]
 
   @@unique([purchaseOrderId, versionNumber])
   @@index([purchaseOrderId, createdAt])
+}
+
+model PurchaseOrderEmailAttempt {
+  id              String   @id @default(uuid())
+  purchaseOrderId String
+  attemptNumber   Int
+  sendState       PurchaseOrderEmailSendState
+  recipientEmail  String
+  subject         String
+  body            String
+  purchaseOrderDocumentId String?
+  documentVersion Int?
+  snapshotHash    String?
+  errorCode       String?
+  errorMessage    String?
+  triggeredByUserId String?
+  triggerSource   String
+  createdAt       DateTime @default(now())
+
+  purchaseOrder PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  purchaseOrderDocument PurchaseOrderDocument? @relation(fields: [purchaseOrderDocumentId], references: [id], onDelete: SetNull)
+  triggeredByUser User? @relation("PurchaseOrderEmailTriggeredByUser", fields: [triggeredByUserId], references: [id], onDelete: SetNull)
+
+  @@unique([purchaseOrderId, attemptNumber])
+  @@index([purchaseOrderId, createdAt])
+  @@index([sendState])
+  @@index([triggeredByUserId])
+  @@index([purchaseOrderDocumentId])
 }
 
 model PurchaseReceipt {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   inventoryMovements InventoryMovement[] @relation("MovementOperatorUser")
   traceRecords       TraceRecord[]       @relation("TraceOperatorUser")
   auditLogs          AuditLog[]          @relation("AuditActorUser")
+  purchaseOrderEmailAttempts PurchaseOrderEmailAttempt[] @relation("PurchaseOrderEmailTriggeredByUser")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -201,6 +202,7 @@ model Warehouse {
   productionOrders ProductionOrder[]
   salesInternalOrders SalesInternalOrder[]
   assemblyWorkOrders AssemblyWorkOrder[]
+  purchaseOrders PurchaseOrder[]
   traceRecords TraceRecord[]
   
   createdAt   DateTime   @default(now())
@@ -877,6 +879,13 @@ enum PurchaseOrderStatus {
   CANCELADA
 }
 
+enum PurchaseOrderEmailSendState {
+  NOT_SENT
+  SENT
+  RESENT
+  FAILED
+}
+
 model Supplier {
   id           String   @id @default(uuid())
   code         String   @unique   // PROV-001
@@ -887,6 +896,7 @@ model Supplier {
   email        String?
   phone        String?
   address      String?
+  paymentTerms String?
   isActive     Boolean  @default(true)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
@@ -935,19 +945,35 @@ model PurchaseOrder {
   id           String              @id @default(uuid())
   folio        String              @unique   // OC-2026-0001
   supplierId   String
+  deliveryWarehouseId String?
   status       PurchaseOrderStatus @default(BORRADOR)
+  emailSendState PurchaseOrderEmailSendState @default(NOT_SENT)
+  emailRecipientSnapshot String?
+  emailSubjectSnapshot String?
+  emailBodySnapshot String?
+  emailDocumentVersionSnapshot Int?
+  emailLastAttemptAt DateTime?
+  emailLastSentAt DateTime?
+  emailLastErrorCode String?
+  emailLastErrorMessage String?
   expectedDate DateTime?
   notes        String?
+  deliveryAddressSnapshot String?
+  paymentTermsSnapshot String?
   createdAt    DateTime            @default(now())
   updatedAt    DateTime            @updatedAt
 
   supplier Supplier           @relation(fields: [supplierId], references: [id], onDelete: Restrict)
+  deliveryWarehouse Warehouse? @relation(fields: [deliveryWarehouseId], references: [id], onDelete: Restrict)
   lines    PurchaseOrderLine[]
   receipts PurchaseReceipt[]
   documents PurchaseOrderDocument[]
+  emailAttempts PurchaseOrderEmailAttempt[]
 
   @@index([supplierId])
+  @@index([deliveryWarehouseId])
   @@index([status])
+  @@index([emailSendState])
   @@index([createdAt])
 }
 
@@ -979,9 +1005,38 @@ model PurchaseOrderDocument {
   createdAt       DateTime @default(now())
 
   purchaseOrder PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  emailAttempts PurchaseOrderEmailAttempt[]
 
   @@unique([purchaseOrderId, versionNumber])
   @@index([purchaseOrderId, createdAt])
+}
+
+model PurchaseOrderEmailAttempt {
+  id              String   @id @default(uuid())
+  purchaseOrderId String
+  attemptNumber   Int
+  sendState       PurchaseOrderEmailSendState
+  recipientEmail  String
+  subject         String
+  body            String
+  purchaseOrderDocumentId String?
+  documentVersion Int?
+  snapshotHash    String?
+  errorCode       String?
+  errorMessage    String?
+  triggeredByUserId String?
+  triggerSource   String
+  createdAt       DateTime @default(now())
+
+  purchaseOrder PurchaseOrder @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  purchaseOrderDocument PurchaseOrderDocument? @relation(fields: [purchaseOrderDocumentId], references: [id], onDelete: SetNull)
+  triggeredByUser User? @relation("PurchaseOrderEmailTriggeredByUser", fields: [triggeredByUserId], references: [id], onDelete: SetNull)
+
+  @@unique([purchaseOrderId, attemptNumber])
+  @@index([purchaseOrderId, createdAt])
+  @@index([sendState])
+  @@index([triggeredByUserId])
+  @@index([purchaseOrderDocumentId])
 }
 
 model PurchaseReceipt {

--- a/tests/purchasing/purchase-order-document-route.integration.test.ts
+++ b/tests/purchasing/purchase-order-document-route.integration.test.ts
@@ -91,7 +91,7 @@ describePostgres("purchase order document pdf route integration", () => {
 
     const bytes = new Uint8Array(await response.arrayBuffer());
     expect(Buffer.from(bytes).subarray(0, 4).toString("utf8")).toBe("%PDF");
-  });
+  }, 120000);
 
   it("sanitizes unsafe file names without duplicating prefixes", () => {
     expect(buildPurchaseOrderPdfFilename("OC-2026-0004")).toBe("OC-2026-0004.pdf");
@@ -154,5 +154,5 @@ describePostgres("purchase order document pdf route integration", () => {
 
     const count = await prisma.purchaseOrderDocument.count({ where: { purchaseOrderId: order.id } });
     expect(count).toBe(1);
-  });
+  }, 120000);
 });

--- a/tests/purchasing/purchase-order-document-service.integration.test.ts
+++ b/tests/purchasing/purchase-order-document-service.integration.test.ts
@@ -24,6 +24,7 @@ describePostgres("purchase order document service integration", () => {
     await prisma.purchaseOrderLine.deleteMany();
     await prisma.purchaseOrder.deleteMany();
     await prisma.supplierProduct.deleteMany();
+    await prisma.warehouse.deleteMany();
     await prisma.supplier.deleteMany();
     await prisma.product.deleteMany();
   }
@@ -39,6 +40,15 @@ describePostgres("purchase order document service integration", () => {
         email: "compras@proveedor.test",
         phone: "555-111-2222",
         address: "Calle 1",
+        paymentTerms: "30 días",
+      },
+    });
+
+    const warehouse = await prisma.warehouse.create({
+      data: {
+        code: `WH-${unique()}`,
+        name: "Almacén Documento",
+        address: "Carretera 1 Km 10",
       },
     });
 
@@ -63,8 +73,11 @@ describePostgres("purchase order document service integration", () => {
       data: {
         folio: `OC-${unique()}`,
         supplierId: supplier.id,
+        deliveryWarehouseId: warehouse.id,
         status: "BORRADOR",
         notes: "OC para snapshot",
+        deliveryAddressSnapshot: warehouse.address,
+        paymentTermsSnapshot: supplier.paymentTerms,
         lines: {
           create: [
             {
@@ -84,7 +97,7 @@ describePostgres("purchase order document service integration", () => {
       },
     });
 
-    return { supplier, productA, productB, order };
+    return { supplier, warehouse, productA, productB, order };
   }
 
   beforeEach(async () => {
@@ -133,6 +146,10 @@ describePostgres("purchase order document service integration", () => {
     expect(snapshot.purchaseOrder.folio).toBe(order.folio);
     expect(snapshot.purchaseOrder.status).toBe("BORRADOR");
     expect(snapshot.supplier.businessName).toBe("Proveedor Documento SA");
+    expect(snapshot.supplier.paymentTerms).toBe("30 días");
+    expect(snapshot.purchaseOrder.deliveryWarehouseId).toBeTruthy();
+    expect(snapshot.purchaseOrder.deliveryAddressSnapshot).toBe("Carretera 1 Km 10");
+    expect(snapshot.purchaseOrder.paymentTermsSnapshot).toBe("30 días");
     expect(snapshot.lines).toHaveLength(2);
     expect(snapshot.lines[0].pendingQty).toBe(3);
     expect(snapshot.lines[0].currency).toBe("MXN");
@@ -168,8 +185,8 @@ describePostgres("purchase order document service integration", () => {
     expect(count).toBe(1);
   });
 
-  it("freezes supplier and product data after live relations change", async () => {
-    const { supplier, productA, order } = await createFixture({ unitPrice: 15 });
+  it("freezes supplier, warehouse and product data after live relations change", async () => {
+    const { supplier, warehouse, productA, order } = await createFixture({ unitPrice: 15 });
 
     await ensurePurchaseOrderDocumentVersion({
       purchaseOrderId: order.id,
@@ -179,7 +196,11 @@ describePostgres("purchase order document service integration", () => {
 
     await prisma.supplier.update({
       where: { id: supplier.id },
-      data: { businessName: "Proveedor Mutado" },
+      data: { businessName: "Proveedor Mutado", paymentTerms: "Contado" },
+    });
+    await prisma.warehouse.update({
+      where: { id: warehouse.id },
+      data: { address: "Dirección Mutada" },
     });
     await prisma.product.update({
       where: { id: productA.id },
@@ -190,8 +211,11 @@ describePostgres("purchase order document service integration", () => {
     expect(persisted).toBeTruthy();
     const snapshot = parsePurchaseOrderDocumentSnapshot(persisted?.snapshotJson ?? "");
     expect(snapshot.supplier.businessName).toBe("Proveedor Documento SA");
+    expect(snapshot.supplier.paymentTerms).toBe("30 días");
     expect(snapshot.lines[0].name).toBe("Manguera A");
     expect(snapshot.lines[0].subtotal).toBeCloseTo(60);
+    expect(snapshot.purchaseOrder.deliveryAddressSnapshot).toBe("Carretera 1 Km 10");
+    expect(snapshot.purchaseOrder.paymentTermsSnapshot).toBe("30 días");
   });
 
   it("confirms BORRADOR to CONFIRMADA creates one document v1", async () => {

--- a/tests/purchasing/purchase-order-document.contract.test.ts
+++ b/tests/purchasing/purchase-order-document.contract.test.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { buildPurchaseOrderPdfFilename, getSupplierDisplayLines } from "@/lib/purchasing/purchase-order-pdf";
+import {
+  buildPurchaseOrderPdfFilename,
+  getPurchaseOrderPdfLineTypography,
+  getSupplierDisplayLines,
+  injectSoftBreaks,
+} from "@/lib/purchasing/purchase-order-pdf";
 
 function readWorkspaceFile(relativePath: string) {
   return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
@@ -23,6 +28,8 @@ describe("purchase order document contracts", () => {
     expect(content).toContain('pageGuard("purchasing.manage")');
     expect(content).toContain("PurchaseOrderDocumentPrintButton");
     expect(buttonContent).toContain("Imprimir / Guardar PDF");
+    expect(content).toContain("snapshot.purchaseOrder.deliveryAddressSnapshot");
+    expect(content).toContain("snapshot.supplier.paymentTerms");
   });
 
   it("pdf route returns application/pdf with attachment disposition", () => {
@@ -50,6 +57,7 @@ describe("purchase order document contracts", () => {
       email: null,
       phone: null,
       address: null,
+      paymentTerms: null,
     });
 
     expect(identical.primary).toBe("Parker");
@@ -64,6 +72,7 @@ describe("purchase order document contracts", () => {
       email: null,
       phone: null,
       address: null,
+      paymentTerms: null,
     });
 
     expect(distinct.primary).toBe("Parker Industrial");
@@ -72,12 +81,104 @@ describe("purchase order document contracts", () => {
 
   it("exposes supplier-facing labels and hides internal receiving headers in the PDF source", () => {
     const content = readWorkspaceFile("lib/purchasing/purchase-order-pdf.tsx");
+    expect(content).toContain('size="LETTER"');
+    expect(content).toContain('orientation="portrait"');
+    expect(content).toContain("wrap={false}");
+    expect(content).toContain("getPurchaseOrderPdfLineTypography");
+    expect(content).toContain("Folio:");
+    expect(content).toContain("formatSingleLineText(line.sku)");
+    expect(content).toContain("injectSoftBreaks(line.name)");
+    expect(content).toContain("lineSku:");
+    expect(content).toContain("width: \"15%\"");
+    expect(content).toContain("lineProduct:");
+    expect(content).toContain("width: \"34%\"");
+    expect(content).toContain("lineQty:");
+    expect(content).toContain("width: \"10%\"");
+    expect(content).toContain("lineQtyHeaderText");
+    expect(content).toContain("productLineHeight: 1.0");
+    expect(content).toContain("Director general");
+    expect(content).toContain("Encargado de almacén");
+    expect(content).toContain("headerAccent");
+    expect(content).toContain("documentInfoBand");
+    expect(content).toContain("documentInfoDivider");
+    expect(content).toContain("documentInfoLabel");
+    expect(content).toContain("documentInfoValue");
+    expect(content).toContain("documentInfoLabel:");
+    expect(content).not.toContain('documentInfoValue: {\n    fontSize: 8.7,\n    fontWeight: 700,');
+    expect(content).toContain("documentBottomBand");
+    expect(content).toContain("lineBodyAlt");
+    expect(content).toContain("documentNotesSection");
+    expect(content).toContain("documentTotalsSection");
+    expect(content).toContain("documentTotalsEmphasis");
+    expect(content).toContain("documentTotalsLabel");
+    expect(content).toContain("documentTotalsValue");
+    expect(content).toContain("Fecha esperada");
+    expect(content).toContain("Moneda");
+    expect(content).toContain("Dirección de entrega");
+    expect(content).toContain("Términos de pago");
     expect(content).toContain("Cantidad");
     expect(content).toContain("Unidad");
     expect(content).toContain("Precio unitario");
     expect(content).toContain("Importe");
+    expect(content).not.toContain('<Text style={styles.subtitle}>WMS Mangueras y Conexiones</Text>');
+    expect(content).not.toContain('<Text style={styles.metaLabel}>Compra</Text>');
+    expect(content).not.toContain('<Text style={styles.metaLabel}>Versión documento</Text>');
+    expect(content).not.toContain("Gerente general");
+    expect(content).not.toContain("documentMetaStrip");
+    expect(content).not.toContain("documentMetaItem");
+    expect(content).not.toContain("metaLabel");
+    expect(content).not.toContain("metaValue");
     expect(content).not.toContain("Ped.");
     expect(content).not.toContain("Rec.");
     expect(content).not.toContain("Pend.");
+    expect(content).not.toContain("injectSoftBreaks(line.sku)");
+
+    const bandIndex = content.indexOf('<View style={styles.documentInfoBand}>');
+    const linesIndex = content.indexOf('<Text style={styles.sectionTitle}>Líneas</Text>');
+    const notesIndex = content.indexOf('<Text style={styles.sectionTitle}>Notas</Text>');
+    const subtotalIndex = content.indexOf('<Text style={styles.documentTotalsLabel}>Subtotal</Text>');
+    const ivaIndex = content.indexOf('<Text style={styles.documentTotalsLabel}>IVA</Text>');
+    const totalIndex = content.indexOf('<Text style={styles.documentTotalsLabel}>Total</Text>');
+
+    expect(bandIndex).toBeGreaterThan(-1);
+    expect(linesIndex).toBeGreaterThan(-1);
+    expect(notesIndex).toBeGreaterThan(-1);
+    expect(bandIndex).toBeGreaterThan(-1);
+    expect(bandIndex).toBeLessThan(linesIndex);
+    expect(subtotalIndex).toBeGreaterThan(notesIndex);
+    expect(ivaIndex).toBeGreaterThan(subtotalIndex);
+    expect(totalIndex).toBeGreaterThan(ivaIndex);
+    expect(notesIndex).toBeGreaterThan(linesIndex);
+  });
+
+  it("adapts line typography for long SKU and product names", () => {
+    const short = getPurchaseOrderPdfLineTypography({
+      sku: "SKU-01",
+      name: "Manguera industrial",
+    });
+    const long = getPurchaseOrderPdfLineTypography({
+      sku: "SKU-2026-VERY-LONG-CODE-1234567890",
+      name: "Manguera industrial de alta presión con especificación extendida para proveedor externo",
+    });
+
+    expect(long.skuFontSize).toBeLessThan(short.skuFontSize);
+    expect(long.productFontSize).toBeLessThan(short.productFontSize);
+    expect(long.rowMinHeight).toBeGreaterThan(short.rowMinHeight);
+    expect(injectSoftBreaks("SKU-2026/0004-LOREM")).toContain("\u200B");
+    expect(injectSoftBreaks("Manguera industrial")).toContain("Manguera");
+  });
+
+  it("wires delivery warehouse selection and supplier payment terms into purchasing forms", () => {
+    const orderCreateContent = readWorkspaceFile("app/(shell)/purchasing/orders/new/page.tsx");
+    const supplierCreateContent = readWorkspaceFile("app/(shell)/purchasing/suppliers/new/page.tsx");
+    const supplierDetailContent = readWorkspaceFile("app/(shell)/purchasing/suppliers/[id]/page.tsx");
+    const orderDetailContent = readWorkspaceFile("app/(shell)/purchasing/orders/[id]/page.tsx");
+
+    expect(orderCreateContent).toContain("deliveryWarehouseId");
+    expect(orderCreateContent).toContain("Almacén destino");
+    expect(supplierCreateContent).toContain("paymentTerms");
+    expect(supplierDetailContent).toContain("Términos de pago");
+    expect(orderDetailContent).toContain("updateDraftMetadata");
+    expect(orderDetailContent).toContain("Entrega y términos oficiales");
   });
 });


### PR DESCRIPTION
Adds destination warehouse delivery-address snapshot to purchase orders.
Adds supplier payment-terms snapshot to purchase orders.
Uses frozen PO fields for official document/PDF rendering.
Keeps document fallback safe with `—`.
Includes schema, migrations, UI, document service/PDF, and purchasing tests.
Validation passed:
- `npm run prisma:validate`
- `npm run typecheck`
- `npm run test -- tests/purchasing/purchase-order-document.contract.test.ts`
- `npm run test:postgres`
- `npm run build`
