### PR TITLE
test(rbac): cover sales write access rules

### DIFF
--- a/tests/rbac/sales-write-access.test.ts
+++ b/tests/rbac/sales-write-access.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth/session-context", () => ({
+  getSessionContext: vi.fn(),
+}));
+
+import { hasSalesWriteAccess } from "@/lib/rbac/sales";
+
+describe("sales write access", () => {
+  it("allows managers and system admins without extra permission claims", () => {
+    expect(hasSalesWriteAccess({ roles: ["MANAGER"], permissions: [] })).toBe(true);
+    expect(hasSalesWriteAccess({ roles: ["SYSTEM_ADMIN"], permissions: [] })).toBe(true);
+  });
+
+  it("requires explicit permission or privileged role for non-admin users", () => {
+    expect(hasSalesWriteAccess({ roles: ["SALES_EXECUTIVE"], permissions: [] })).toBe(false);
+    expect(hasSalesWriteAccess({ roles: ["WAREHOUSE_OPERATOR"], permissions: [] })).toBe(false);
+    expect(hasSalesWriteAccess({ roles: [], permissions: [] })).toBe(false);
+    expect(hasSalesWriteAccess({ roles: ["SALES_EXECUTIVE"], permissions: ["sales.create_order"] })).toBe(true);
+  });
+});


### PR DESCRIPTION
- Adds focused unit coverage for `hasSalesWriteAccess`.
- Confirms managers and system admins can write without extra permission claims.
- Confirms non-privileged users require explicit `sales.create_order`.
- Keeps the `session-context` mock because `lib/rbac/sales.ts` imports it and the pure helper test fails to load without the stub.

Validation:
- `npm run test -- tests/rbac/sales-write-access.test.ts`
