### PR TITLE
Align customer service with current schema

### DIFF
--- a/app/(shell)/sales/customers/[id]/page.tsx
+++ b/app/(shell)/sales/customers/[id]/page.tsx
@@ -42,7 +42,6 @@ export default async function CustomerDetailPage({
         phone: true,
         address: true,
         isActive: true,
-        createdAt: true,
         updatedAt: true,
       },
     }),

--- a/lib/customers/customer-service.ts
+++ b/lib/customers/customer-service.ts
@@ -15,7 +15,6 @@ type CustomerRow = {
   phone: string | null;
   address: string | null;
   isActive: boolean;
-  createdAt: Date;
   updatedAt: Date;
 };
 
@@ -108,7 +107,6 @@ export type CustomerDetail = {
   phone: string | null;
   address: string | null;
   isActive: boolean;
-  createdAt: Date;
   updatedAt: Date;
 };
 
@@ -191,7 +189,6 @@ function toCustomerDetail(row: CustomerRow): CustomerDetail {
     phone: row.phone,
     address: row.address,
     isActive: row.isActive,
-    createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
 }
@@ -303,7 +300,6 @@ export async function createCustomer(prisma: PrismaClient, input: CreateCustomer
             phone: true,
             address: true,
             isActive: true,
-            createdAt: true,
             updatedAt: true,
           },
         });
@@ -366,7 +362,6 @@ export async function updateCustomer(prisma: PrismaClient, input: UpdateCustomer
         phone: true,
         address: true,
         isActive: true,
-        createdAt: true,
         updatedAt: true,
       },
     });
@@ -428,7 +423,6 @@ export async function updateCustomer(prisma: PrismaClient, input: UpdateCustomer
           phone: true,
           address: true,
           isActive: true,
-          createdAt: true,
           updatedAt: true,
         },
       });
@@ -540,7 +534,6 @@ export async function searchCustomers(prisma: DbClient, options: SearchCustomers
         phone: true,
         address: true,
         isActive: true,
-        createdAt: true,
         updatedAt: true,
       },
     }),
@@ -565,21 +558,20 @@ export async function getCustomerById(prisma: DbClient, id: string): Promise<Cus
   const customer = getCustomerModel(prisma);
   const row = await customer.findUnique({
     where: { id: customerId },
-    select: {
-      id: true,
-      code: true,
+      select: {
+        id: true,
+        code: true,
       name: true,
       legalName: true,
       businessName: true,
       taxId: true,
-      email: true,
-      phone: true,
-      address: true,
-      isActive: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  });
+        email: true,
+        phone: true,
+        address: true,
+        isActive: true,
+        updatedAt: true,
+      },
+    });
 
   if (!row) {
     throw new CustomerServiceError("CUSTOMER_NOT_FOUND", "Cliente no encontrado");

--- a/tests/customers/customer-service.test.ts
+++ b/tests/customers/customer-service.test.ts
@@ -36,7 +36,6 @@ function makePrismaMock(options: {
 }
 
 function row(overrides: AnyRecord = {}) {
-  const now = new Date("2026-04-21T00:00:00.000Z");
   return {
     id: "cust-1",
     code: "CLI-2026-0001",
@@ -48,8 +47,7 @@ function row(overrides: AnyRecord = {}) {
     phone: null,
     address: null,
     isActive: true,
-    createdAt: now,
-    updatedAt: now,
+    updatedAt: new Date("2026-04-21T00:00:00.000Z"),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

This PR fixes a PostgreSQL regression caused by customer-service code selecting Customer.createdAt even though the active Prisma Customer model does not expose that field.

## Key changes

* Removes unsupported createdAt selections from customer-service paths.
* Aligns customer DTO/test expectations with the current schema.
* Preserves customer create/update/search/detail behavior.
* Restores PostgreSQL regression coverage.

## Validation

* 
pm run lint: pass
* 
pm run typecheck: pass
* 
pm run test:postgres: pass
* 
px vitest run tests/customers/customer-service.test.ts: pass
* 
px playwright test tests/e2e/kan48-customer-quick-create.spec.ts --project=chromium: pass

## Caveats

* No schema changes.
* No migrations.
* No RBAC widening.
* No commercial UI changes.
* No Batch 4B or Batch 4C changes included.

## Verdict

Customer service schema drift fixed.