### PR TITLE
Improve commercial workflow hierarchy

### DIFF
--- a/app/(shell)/catalog/[id]/page.tsx
+++ b/app/(shell)/catalog/[id]/page.tsx
@@ -64,152 +64,185 @@ export default async function ProductDetailPage({ params }: PageProps) {
     const equivalents = await getEquivalentProducts(product.id, { limit: 6, inStockOnly: false });
 
     return (
-        <div className="max-w-5xl mx-auto space-y-6">
-            {/* Breadcrumb */}
+        <div className="mx-auto max-w-6xl space-y-6">
             <div className="flex items-center gap-2 text-sm text-slate-400">
                 <Link href="/catalog" className="hover:text-white">Catálogo comercial</Link>
                 <span>/</span>
                 <span className="text-white">{product.name}</span>
             </div>
 
-            {/* Header Card */}
-            <div className="glass-card p-8 flex flex-col md:flex-row gap-8 items-start">
-                <div className="w-full md:w-1/3">
-                    <ProductImage
-                        sku={product.sku}
-                        imageUrl={product.imageUrl}
-                        name={product.name}
-                        size={400}
-                        className="w-full aspect-square"
-                    />
-                </div>
-
-                <div className="flex-1 space-y-4">
-                    <div className="flex justify-between items-start">
-                        <div>
-                            <h1 className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-cyan-300">
-                                {product.name}
-                            </h1>
-                            <div className="flex items-center gap-3 mt-2">
-                                <span className="bg-slate-700 px-2 py-1 rounded text-sm text-slate-300 font-mono">{product.sku}</span>
-                                <span className="text-slate-400">|</span>
-                                <span className="text-slate-300">{product.brand}</span>
-                                <span className="text-slate-400">|</span>
-                                <span className="px-2 py-1 rounded text-xs bg-cyan-500/15 text-cyan-300 border border-cyan-500/30">
-                                    {product.category?.name ?? "Sin categoría"}
-                                </span>
-                                {product.subcategory && (
-                                    <>
-                                        <span className="text-slate-400">|</span>
-                                        <span className="px-2 py-1 rounded text-xs bg-white/10 text-slate-200 border border-white/10">
-                                            {product.subcategory}
-                                        </span>
-                                    </>
-                                )}
-                            </div>
-                            <div className="mt-4 flex flex-wrap gap-2">
-                                <Link
-                                    href={buildCommercialSearchHref("/production/availability", product.sku, { productId: product.id, sku: product.sku, source: "catalog" })}
-                                    className={buttonStyles({ variant: "secondary", size: "sm" })}
-                                    aria-label={`Ver disponibilidad de ${product.name} (${product.sku})`}
-                                >
-                                    Ver disponibilidad
-                                </Link>
-                                <Link
-                                    href={buildCommercialSearchHref("/production/equivalences", product.sku, { productId: product.id, sku: product.sku, source: "catalog" })}
-                                    className={buttonStyles({ variant: "secondary", size: "sm" })}
-                                    aria-label={`Revisar equivalencias de ${product.name} (${product.sku})`}
-                                >
-                                    Revisar equivalencias
-                                </Link>
-                                <Link
-                                    href={buildCommercialRequestHref({ productId: product.id, sku: product.sku, source: "catalog" })}
-                                    className={buttonStyles({ size: "sm" })}
-                                    aria-label={`Crear pedido con ${product.name} (${product.sku})`}
-                                >
-                                    Crear pedido
-                                </Link>
-                            </div>
-                        </div>
-                        <div className="text-right space-y-2">
-                            <p className="text-3xl font-bold text-white">${product.price?.toFixed(2)}</p>
-                            <p className="text-xs text-slate-500">Precio de lista</p>
-                            {canEditCatalog ? (
-                                <Link href={`/catalog/${product.id}/edit`} className="inline-block px-3 py-1 glass rounded text-xs text-cyan-400 hover:text-white border border-cyan-500/30">
-                                    ✏️ Editar
-                                </Link>
-                            ) : null}
-                        </div>
+            <section className="glass-card grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+                <div className="space-y-5">
+                    <div className="space-y-2">
+                        <p className="font-mono text-sm text-cyan-300">{product.sku}</p>
+                        <h1 className="text-3xl font-semibold text-white">{product.name}</h1>
+                        <p className="text-sm text-slate-300">
+                            {product.brand ?? "Sin marca"} · {product.category?.name ?? "Sin categoría"}
+                            {product.subcategory ? ` · ${product.subcategory}` : ""}
+                            {product.referenceCode ? ` · Ref. ${product.referenceCode}` : ""}
+                        </p>
                     </div>
 
-                    <p className="text-slate-300 leading-relaxed max-w-2xl">
+                    <p className="max-w-2xl text-sm leading-relaxed text-slate-300">
                         {product.description}
                     </p>
 
-                    <div className="grid grid-cols-2 gap-4 mt-6">
-                        <div className="glass p-4 rounded-lg bg-green-500/5 border-green-500/20">
-                            <p className="text-xs text-green-400 uppercase font-bold">Existencia disponible</p>
-                            <p className="text-2xl font-bold text-white">{stock} <span className="text-sm font-normal text-slate-400">unidades</span></p>
+                    <div className="flex flex-wrap gap-2">
+                        <Link
+                            href={buildCommercialRequestHref({ productId: product.id, sku: product.sku, source: "catalog" })}
+                            className={buttonStyles({ size: "sm" })}
+                            aria-label={`Crear pedido con ${product.name} (${product.sku})`}
+                        >
+                            Crear pedido
+                        </Link>
+                        <Link
+                            href={buildCommercialSearchHref("/production/availability", product.sku, { productId: product.id, sku: product.sku, source: "catalog" })}
+                            className={buttonStyles({ variant: "secondary", size: "sm" })}
+                            aria-label={`Ver disponibilidad de ${product.name} (${product.sku})`}
+                        >
+                            Ver disponibilidad
+                        </Link>
+                        <Link
+                            href={buildCommercialSearchHref("/production/equivalences", product.sku, { productId: product.id, sku: product.sku, source: "catalog" })}
+                            className={buttonStyles({ variant: "secondary", size: "sm" })}
+                            aria-label={`Revisar equivalencias de ${product.name} (${product.sku})`}
+                        >
+                            Revisar equivalencias
+                        </Link>
+                        {canEditCatalog ? (
+                            <Link href={`/catalog/${product.id}/edit`} className="text-sm text-cyan-300 underline-offset-4 hover:text-white hover:underline">
+                                Editar
+                            </Link>
+                        ) : null}
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-emerald-300">
+                                Existencia disponible
+                            </p>
+                            <p className="mt-2 text-2xl font-semibold text-white">
+                                {stock.toLocaleString("es-MX")}{" "}
+                                <span className="text-sm font-normal text-slate-400">
+                                    unidades
+                                </span>
+                            </p>
                         </div>
-                        <div className="glass p-4 rounded-lg">
-                            <p className="text-xs text-slate-400 uppercase font-bold">Ubicaciones</p>
-                            <p className="text-lg text-white">{locationCodes}</p>
+                        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                                Ubicaciones
+                            </p>
+                            <p className="mt-2 text-lg text-white">{locationCodes}</p>
                         </div>
                     </div>
                 </div>
-            </div>
 
-            {/* Technical Specs & Details Grid */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-3">
+                    <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                        <ProductImage
+                            sku={product.sku}
+                            imageUrl={product.imageUrl}
+                            name={product.name}
+                            size={320}
+                            className="aspect-square w-full rounded-xl"
+                        />
+                    </div>
+                    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">
+                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                            Decisión comercial
+                        </p>
+                        <p className="mt-2">
+                            Usa disponibilidad y equivalencias para decidir si
+                            avanzas al pedido o cambias el producto.
+                        </p>
+                        <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-400">
+                            <span>Tipo: {product.type}</span>
+                            <span>Marca: {product.brand ?? "--"}</span>
+                            {product.subcategory ? <span>Subcategoría: {product.subcategory}</span> : null}
+                        </div>
+                    </div>
+                </div>
+            </section>
 
-                {/* Attributes Panel */}
-                <div className="glass-card">
-                    <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
-                        <span className="text-cyan-400">⚡</span> Especificaciones Técnicas
-                    </h2>
-                    <div className="space-y-0 text-sm">
-                        {attributes && Object.entries(attributes).map(([key, val], idx) => (
-                            <div key={key} className={`flex justify-between py-3 px-2 border-b border-white/5 first:border-t ${idx % 2 === 0 ? 'bg-white/5' : ''}`}>
-                                <span className="text-slate-400 font-medium capitalize">{key.replaceAll('_', ' ')}</span>
-                                <span className="text-white font-mono text-right">{Array.isArray(val) ? val.join(', ') : String(val)}</span>
+            <section className="grid gap-6 lg:grid-cols-2">
+                <section className="glass-card space-y-4">
+                    <div className="space-y-1">
+                        <h2 className="text-lg font-semibold text-white">
+                            Especificaciones técnicas
+                        </h2>
+                        <p className="text-sm text-slate-400">
+                            Detalles de apoyo para validar el producto. La
+                            decisión comercial ya está arriba.
+                        </p>
+                    </div>
+                    {attributes && Object.keys(attributes).length > 0 ? (
+                        <div className="overflow-hidden rounded-xl border border-white/10">
+                            <div className="divide-y divide-white/5 text-sm">
+                                {Object.entries(attributes).map(([key, val], idx) => (
+                                    <div
+                                        key={key}
+                                        className={`flex items-center justify-between gap-4 px-4 py-3 ${idx % 2 === 0 ? "bg-white/5" : ""}`}
+                                    >
+                                        <span className="text-slate-400 font-medium capitalize">
+                                            {key.replaceAll("_", " ")}
+                                        </span>
+                                        <span className="text-right font-mono text-white">
+                                            {Array.isArray(val) ? val.join(", ") : String(val)}
+                                        </span>
+                                    </div>
+                                ))}
                             </div>
-                        ))}
-                    </div>
-                </div>
+                        </div>
+                    ) : (
+                        <p className="text-sm text-slate-400">
+                            No hay especificaciones técnicas adicionales para
+                            este producto.
+                        </p>
+                    )}
+                </section>
 
-                {/* Related/Assembly Info (Placeholder) */}
-                <div className="glass-card">
-                    <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
-                        <span className="text-purple-400">🔗</span> Alternativas y equivalencias
-                    </h2>
+                <section className="glass-card space-y-4">
+                    <div className="space-y-1">
+                        <h2 className="text-lg font-semibold text-white">
+                            Alternativas y equivalencias
+                        </h2>
+                        <p className="text-sm text-slate-400">
+                            Sustitutos registrados para decidir si conviene
+                            validar disponibilidad o crear el pedido comercial.
+                        </p>
+                    </div>
                     {equivalents.length > 0 ? (
                         <div className="space-y-3">
                             {equivalents.map((equivalent) => (
-                                <div key={equivalent.equivalenceId} className="p-4 rounded-lg bg-indigo-500/10 border border-indigo-500/20 text-sm space-y-2">
+                                <div
+                                    key={equivalent.equivalenceId}
+                                    className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm space-y-3"
+                                >
                                     <div className="flex items-start justify-between gap-3">
                                         <div>
-                                            <p className="text-indigo-100 font-semibold">{equivalent.name}</p>
-                                            <p className="text-indigo-200/80 font-mono text-xs">{equivalent.sku}</p>
+                                            <p className="font-semibold text-white">
+                                                {equivalent.name}
+                                            </p>
+                                            <p className="font-mono text-xs text-cyan-200">
+                                                {equivalent.sku}
+                                            </p>
                                         </div>
-                                        <span className="text-xs text-indigo-200">{equivalent.totalAvailable} disp.</span>
+                                        <span className="text-xs text-emerald-200">
+                                            {equivalent.totalAvailable} disp.
+                                        </span>
                                     </div>
-                                    <div className="flex flex-wrap gap-2 text-xs">
-                                        {equivalent.brand && <span className="px-2 py-1 rounded bg-black/20 text-indigo-100">{equivalent.brand}</span>}
-                                        {equivalent.categoryName && <span className="px-2 py-1 rounded bg-black/20 text-indigo-100">{equivalent.categoryName}</span>}
-                                        {equivalent.basisNorm && <span className="px-2 py-1 rounded bg-black/20 text-indigo-100">{equivalent.basisNorm}</span>}
-                                        {typeof equivalent.basisDash === "number" && <span className="px-2 py-1 rounded bg-black/20 text-indigo-100">Dash {equivalent.basisDash}</span>}
+                                    <p className="text-xs text-slate-300">
+                                        {equivalent.locations.length > 0
+                                            ? `Disponible en ${equivalent.locations[0].code} (${equivalent.locations[0].warehouseCode}) con ${equivalent.locations[0].available} unidades.`
+                                            : "Equivalencia registrada sin stock disponible."}
+                                    </p>
+                                    <div className="flex flex-wrap gap-2 text-[11px] text-slate-200">
+                                        {equivalent.brand ? <span className="rounded bg-black/20 px-2 py-1">{equivalent.brand}</span> : null}
+                                        {equivalent.categoryName ? <span className="rounded bg-black/20 px-2 py-1">{equivalent.categoryName}</span> : null}
+                                        {equivalent.basisNorm ? <span className="rounded bg-black/20 px-2 py-1">{equivalent.basisNorm}</span> : null}
+                                        {typeof equivalent.basisDash === "number" ? <span className="rounded bg-black/20 px-2 py-1">Dash {equivalent.basisDash}</span> : null}
                                     </div>
-                                    {equivalent.locations.length > 0 && (
-                                        <p className="text-indigo-100/80 text-xs">
-                                            Disponible en {equivalent.locations[0].code} ({equivalent.locations[0].warehouseCode}) con {equivalent.locations[0].available} unidades.
-                                        </p>
-                                    )}
-                                    {equivalent.locations.length === 0 && (
-                                        <p className="text-indigo-100/60 text-xs">
-                                            Equivalencia registrada sin stock disponible.
-                                        </p>
-                                    )}
-                                    <div className="flex flex-wrap gap-2 pt-1">
+                                    <div className="flex flex-wrap gap-2">
                                         <Link
                                             href={buildCommercialSearchHref("/production/availability", equivalent.sku, { productId: equivalent.productId, sku: equivalent.sku, source: "equivalences", equivalentProductId: product.id })}
                                             className={buttonStyles({ variant: "secondary", size: "sm" })}
@@ -227,13 +260,14 @@ export default async function ProductDetailPage({ params }: PageProps) {
                             ))}
                         </div>
                     ) : (
-                        <div className="p-4 rounded-lg bg-indigo-500/10 border border-indigo-500/20 text-indigo-200 text-sm">
-                            No hay equivalencias activas registradas para este producto. Puedes seguir con disponibilidad o crear un pedido comercial.
+                        <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">
+                            No hay equivalencias activas registradas para este
+                            producto. Puedes seguir con disponibilidad o crear
+                            un pedido comercial.
                         </div>
                     )}
-                </div>
-
-            </div>
+                </section>
+            </section>
         </div>
     );
 }

--- a/app/(shell)/production/requests/[id]/page.tsx
+++ b/app/(shell)/production/requests/[id]/page.tsx
@@ -537,7 +537,7 @@ export default async function ProductionRequestDetailPage({
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="space-y-2">
           <p className="font-mono text-sm text-[var(--accent)]">{order.code}</p>
-          <h1 className="text-3xl font-semibold text-[var(--text-primary)]">Pedido de surtido</h1>
+          <h1 className="text-3xl font-semibold text-[var(--text-primary)]">Pedido comercial</h1>
           <p className="text-sm text-[var(--text-muted)]">
             Cliente:{" "}
             {order.customerId && canViewCustomers ? (
@@ -569,35 +569,88 @@ export default async function ProductionRequestDetailPage({
         </div>
       ) : null}
 
-      <section className="grid gap-4 lg:grid-cols-[1.05fr_0.95fr]">
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1.12fr)_minmax(320px,0.88fr)]">
         <div className="glass-card space-y-4 text-sm text-[var(--text-secondary)]">
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Resumen</h2>
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-[var(--text-muted)]">Etapa actual:</span>
-            <Badge variant={flowNarrative.flowBadgeVariant}>{flowNarrative.flowStageLabel}</Badge>
-          </div>
-          <p className="text-[var(--text-primary)]">
-            Siguiente acción:{" "}
-            {flowNarrative.nextRecommendedAction.blockedReason ? (
-              <span className="text-[var(--text-muted)]">{flowNarrative.nextRecommendedAction.label}</span>
-            ) : (
-              <Link href={flowNarrative.nextRecommendedAction.href} className="text-[var(--accent)] underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)]">
-                {flowNarrative.nextRecommendedAction.label}
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold text-[var(--text-primary)]">Estado y siguiente acción</h2>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[var(--text-muted)]">Etapa actual:</span>
+                <Badge variant={flowNarrative.flowBadgeVariant}>{flowNarrative.flowStageLabel}</Badge>
+              </div>
+              <p className="text-[var(--text-primary)]">
+                Cliente:{" "}
+                {order.customerId && canViewCustomers ? (
+                  <Link href={`/sales/customers/${order.customerId}`} className="text-[var(--accent)] underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)]">
+                    {displayCustomer}
+                  </Link>
+                ) : (
+                  displayCustomer
+                )}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link href="/production/requests" className={buttonStyles({ variant: "secondary" })}>
+                ← Pedidos
               </Link>
-            )}
-          </p>
-          {flowNarrative.nextRecommendedAction.blockedReason ? <p className="text-xs text-[var(--status-warning-text)]">{flowNarrative.nextRecommendedAction.blockedReason}</p> : null}
-          <p>Solicitado por: {order.requestedByUser?.name ?? order.requestedByUser?.email ?? "--"}</p>
-          <p>Asignado a: {order.assignedToUser?.name ?? order.assignedToUser?.email ?? "--"}</p>
-          <p>Asignado el: {order.assignedAt ? new Date(order.assignedAt).toLocaleString("es-MX") : "--"}</p>
-          <p>Tomado el: {order.pulledAt ? new Date(order.pulledAt).toLocaleString("es-MX") : "--"}</p>
-          <p>Fecha compromiso: {formatDate(order.dueDate)}</p>
-          <p>Creado: {new Date(order.createdAt).toLocaleString("es-MX")}</p>
-          <p>Confirmado: {order.confirmedAt ? new Date(order.confirmedAt).toLocaleString("es-MX") : "--"}</p>
-          <p>Cancelado: {order.cancelledAt ? new Date(order.cancelledAt).toLocaleString("es-MX") : "--"}</p>
-          <p>Entregado al cliente: {order.deliveredToCustomerAt ? new Date(order.deliveredToCustomerAt).toLocaleString("es-MX") : "--"}</p>
-          <p>Entrega registrada por: {order.deliveredByUser?.name ?? order.deliveredByUser?.email ?? "--"}</p>
-          {order.notes ? <p className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-subtle)] p-3 text-[var(--text-secondary)]">{order.notes}</p> : null}
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-subtle)] p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+              Siguiente acción
+            </p>
+            <p className="mt-2 text-[var(--text-primary)]">
+              {flowNarrative.nextRecommendedAction.blockedReason ? (
+                <span className="text-[var(--text-muted)]">
+                  {flowNarrative.nextRecommendedAction.label}
+                </span>
+              ) : (
+                <Link href={flowNarrative.nextRecommendedAction.href} className="text-[var(--accent)] underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)]">
+                  {flowNarrative.nextRecommendedAction.label}
+                </Link>
+              )}
+            </p>
+            {flowNarrative.nextRecommendedAction.blockedReason ? (
+              <p className="mt-1 text-xs text-[var(--status-warning-text)]">
+                {flowNarrative.nextRecommendedAction.blockedReason}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-subtle)] px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                Pedido
+              </p>
+              <p className="mt-1 text-[var(--text-primary)]">
+                {order.warehouse ? `${order.warehouse.code} - ${order.warehouse.name}` : "--"}
+              </p>
+              <p className="text-xs text-[var(--text-muted)]">
+                Fecha compromiso: {formatDate(order.dueDate)}
+              </p>
+            </div>
+            <div className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-subtle)] px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                Asignación
+              </p>
+              <p className="mt-1 text-[var(--text-primary)]">
+                {order.assignedToUser?.name ?? order.assignedToUser?.email ?? "--"}
+              </p>
+              <p className="text-xs text-[var(--text-muted)]">
+                Solicitado por: {order.requestedByUser?.name ?? order.requestedByUser?.email ?? "--"}
+              </p>
+            </div>
+          </div>
+
+          {order.notes ? (
+            <div className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-subtle)] p-4 text-[var(--text-secondary)]">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                Notas
+              </p>
+              <p className="mt-2 text-sm">{order.notes}</p>
+            </div>
+          ) : null}
         </div>
 
         <div className="glass-card space-y-4">
@@ -673,7 +726,7 @@ export default async function ProductionRequestDetailPage({
         </div>
       </section>
 
-      <section className="grid gap-4 lg:grid-cols-2">
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)]">
         <div className="glass-card space-y-3">
           <h2 className="text-lg font-semibold text-[var(--text-primary)]">Timeline operativo</h2>
           <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
@@ -688,23 +741,27 @@ export default async function ProductionRequestDetailPage({
           </ul>
         </div>
 
-        <div className="glass-card space-y-3">
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Auditoria reciente</h2>
-          {recentAudit.length === 0 ? (
-            <p className="text-sm text-[var(--text-muted)]">Sin eventos de auditoria para este pedido.</p>
-          ) : (
-            <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
-              {recentAudit.map((entry, idx) => (
-                <li key={`${entry.action}-${entry.createdAt.toISOString()}-${idx}`} className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-subtle)] px-3 py-2">
-                  <p className="text-[var(--text-primary)]">{entry.action}</p>
-                  <p className="text-xs text-[var(--text-muted)]">
-                    {entry.actorUser?.name ?? entry.actorUser?.email ?? entry.actor ?? "system"} · {formatDateTime(entry.createdAt)}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+        <details className="glass-card space-y-3">
+          <summary className="cursor-pointer text-lg font-semibold text-[var(--text-primary)]">
+            Auditoria reciente
+          </summary>
+          <div className="mt-3 space-y-2">
+            {recentAudit.length === 0 ? (
+              <p className="text-sm text-[var(--text-muted)]">Sin eventos de auditoria para este pedido.</p>
+            ) : (
+              <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
+                {recentAudit.map((entry, idx) => (
+                  <li key={`${entry.action}-${entry.createdAt.toISOString()}-${idx}`} className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-subtle)] px-3 py-2">
+                    <p className="text-[var(--text-primary)]">{entry.action}</p>
+                    <p className="text-xs text-[var(--text-muted)]">
+                      {entry.actorUser?.name ?? entry.actorUser?.email ?? entry.actor ?? "system"} · {formatDateTime(entry.createdAt)}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </details>
       </section>
 
       {order.status === "BORRADOR" ? (

--- a/app/(shell)/production/requests/new/page.tsx
+++ b/app/(shell)/production/requests/new/page.tsx
@@ -44,13 +44,6 @@ function firstParam(value: string | string[] | undefined) {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function parsePositiveDecimal(value: string) {
-  if (!value) return null;
-  const parsed = Number(value.replace(",", "."));
-  if (!Number.isFinite(parsed) || parsed <= 0) return null;
-  return parsed;
-}
-
 function getSourceLabel(source: string) {
   return SOURCE_LABELS[source] ?? "Contexto comercial";
 }
@@ -93,9 +86,6 @@ async function createSalesRequest(formData: FormData) {
   const warehouseId = String(formData.get("warehouseId") ?? "").trim();
   const dueDateRaw = String(formData.get("dueDate") ?? "").trim();
   const notes = String(formData.get("notes") ?? "").trim();
-  const lineProductId = String(formData.get("lineProductId") ?? "").trim();
-  const lineRequestedQtyRaw = String(formData.get("lineRequestedQty") ?? "").trim();
-  const lineNotes = String(formData.get("lineNotes") ?? "").trim();
 
   const parsed = salesInternalOrderCreateSchema.safeParse({
     customerId: customerId ?? undefined,
@@ -129,31 +119,6 @@ async function createSalesRequest(formData: FormData) {
     );
   }
 
-  let initialProductLine:
-    | { productId: string; requestedQty: number; notes?: string | null }
-    | null = null;
-  if (lineProductId) {
-    const lineProduct = await getProductSearchSelection(prisma, lineProductId);
-    if (!lineProduct) {
-      redirect(
-        `/production/requests/new?error=${encodeURIComponent("No se pudo resolver el producto seleccionado")}`,
-      );
-    }
-
-    const requestedQty = parsePositiveDecimal(lineRequestedQtyRaw);
-    if (!requestedQty) {
-      redirect(
-        `/production/requests/new?error=${encodeURIComponent("La cantidad de la línea debe ser mayor que cero")}`,
-      );
-    }
-
-    initialProductLine = {
-      productId: lineProduct.id,
-      requestedQty,
-      notes: lineNotes || null,
-    };
-  }
-
   try {
     const createPerf = startPerf(
       "action.production.requests.new.create.service",
@@ -167,7 +132,6 @@ async function createSalesRequest(formData: FormData) {
       notes: notes || null,
       requestedByUserId: ctx.user?.id ?? null,
       requestedByRoles: ctx.roles,
-      initialProductLine,
     });
     createPerf.end({ orderId: created.id });
 
@@ -232,8 +196,6 @@ export default async function NewProductionRequestPage({
   const searchQuery = firstParam(sp.q);
   const source = firstParam(sp.source);
   const equivalentProductId = firstParam(sp.equivalentProductId);
-  const quantity = parsePositiveDecimal(firstParam(sp.quantity)) ?? 1;
-  const lineNotes = firstParam(sp.notes);
   const displayQuery = searchQuery || sku;
 
   const selectedProduct = productId
@@ -333,12 +295,6 @@ export default async function NewProductionRequestPage({
                           <span className="text-slate-400">Stock disponible:</span>{" "}
                           {selectedProduct.totalAvailable.toLocaleString("es-MX")}
                         </p>
-                        {selectedProduct.unitLabel ? (
-                          <p>
-                            <span className="text-slate-400">Unidad:</span>{" "}
-                            {selectedProduct.unitLabel}
-                          </p>
-                        ) : null}
                       </div>
                     </div>
                     <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4 text-sm text-cyan-50">
@@ -346,8 +302,8 @@ export default async function NewProductionRequestPage({
                         Siguiente acción
                       </p>
                       <p className="mt-2">
-                        Confirma el cliente y guarda esta referencia como la
-                        primera línea editable del pedido.
+                        Confirma el cliente y continúa el pedido con esta
+                        referencia comercial.
                       </p>
                     </div>
                   </div>
@@ -459,21 +415,15 @@ export default async function NewProductionRequestPage({
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
                     <h2 className="text-lg font-semibold text-white">
-                      2. Línea sugerida
+                      2. Contexto del producto
                     </h2>
                     <p className="text-sm text-slate-300">
-                      El producto seleccionado puede guardarse como la primera
-                      línea editable del pedido.
+                      El producto seleccionado acompaña la captura comercial y
+                      sirve como referencia para continuar el pedido.
                     </p>
                   </div>
-                  <Badge variant="accent">Editable</Badge>
+                  <Badge variant="accent">Referencia</Badge>
                 </div>
-
-                <input
-                  type="hidden"
-                  name="lineProductId"
-                  value={selectedProduct.id}
-                />
 
                 <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.7fr)_minmax(0,1fr)]">
                   <div className="rounded-xl border border-white/10 bg-white/5 p-4">
@@ -488,56 +438,17 @@ export default async function NewProductionRequestPage({
                         <span className="text-slate-400">SKU:</span>{" "}
                         <span className="font-mono">{selectedProduct.sku}</span>
                       </p>
-                      {selectedProduct.unitLabel ? (
-                        <p>
-                          <span className="text-slate-400">Unidad:</span>{" "}
-                          {selectedProduct.unitLabel}
-                        </p>
-                      ) : null}
                       <p>
                         <span className="text-slate-400">Fuente:</span>{" "}
                         {sourceLabel}
                       </p>
                       <p>
                         <span className="text-slate-400">Acción sugerida:</span>{" "}
-                        Guarda el pedido para continuar con el cliente y el
-                        detalle.
+                        Continúa con el cliente y el detalle del pedido.
                       </p>
                     </div>
                   </div>
-
-                  <label className="space-y-1">
-                    <span className="text-sm text-slate-400">
-                      Cantidad sugerida
-                    </span>
-                    <input
-                      name="lineRequestedQty"
-                      type="number"
-                      min="0.0001"
-                      step="0.0001"
-                      required
-                      defaultValue={quantity}
-                      className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
-                    />
-                    <p className="text-xs text-slate-500">
-                      Se convertirá en la cantidad de la primera línea editable
-                      del pedido.
-                    </p>
-                  </label>
-
-                  <label className="space-y-1">
-                    <span className="text-sm text-slate-400">
-                      Notas de la línea
-                    </span>
-                    <textarea
-                      name="lineNotes"
-                      defaultValue={lineNotes}
-                      className="min-h-[120px] w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
-                      placeholder="Opcional: especificaciones, urgencia o contexto comercial"
-                    />
-                  </label>
                 </div>
-
                 <div className="flex flex-wrap gap-2">
                   <Link
                     href="#captura-cliente"

--- a/app/(shell)/production/requests/new/page.tsx
+++ b/app/(shell)/production/requests/new/page.tsx
@@ -17,9 +17,7 @@ import {
 } from "@/lib/schemas/wms";
 import { startPerf } from "@/lib/perf";
 import { getProductSearchSelection, resolveProductInput } from "@/lib/product-search";
-import {
-  buildCommercialSearchHref,
-} from "@/lib/commercial-toolkit";
+import { buildCommercialSearchHref } from "@/lib/commercial-toolkit";
 
 export const dynamic = "force-dynamic";
 
@@ -44,6 +42,13 @@ function isNextRedirectError(error: unknown) {
 function firstParam(value: string | string[] | undefined) {
   if (Array.isArray(value)) return value[0]?.trim() ?? "";
   return typeof value === "string" ? value.trim() : "";
+}
+
+function parsePositiveDecimal(value: string) {
+  if (!value) return null;
+  const parsed = Number(value.replace(",", "."));
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
 }
 
 function getSourceLabel(source: string) {
@@ -88,6 +93,9 @@ async function createSalesRequest(formData: FormData) {
   const warehouseId = String(formData.get("warehouseId") ?? "").trim();
   const dueDateRaw = String(formData.get("dueDate") ?? "").trim();
   const notes = String(formData.get("notes") ?? "").trim();
+  const lineProductId = String(formData.get("lineProductId") ?? "").trim();
+  const lineRequestedQtyRaw = String(formData.get("lineRequestedQty") ?? "").trim();
+  const lineNotes = String(formData.get("lineNotes") ?? "").trim();
 
   const parsed = salesInternalOrderCreateSchema.safeParse({
     customerId: customerId ?? undefined,
@@ -121,6 +129,31 @@ async function createSalesRequest(formData: FormData) {
     );
   }
 
+  let initialProductLine:
+    | { productId: string; requestedQty: number; notes?: string | null }
+    | null = null;
+  if (lineProductId) {
+    const lineProduct = await getProductSearchSelection(prisma, lineProductId);
+    if (!lineProduct) {
+      redirect(
+        `/production/requests/new?error=${encodeURIComponent("No se pudo resolver el producto seleccionado")}`,
+      );
+    }
+
+    const requestedQty = parsePositiveDecimal(lineRequestedQtyRaw);
+    if (!requestedQty) {
+      redirect(
+        `/production/requests/new?error=${encodeURIComponent("La cantidad de la línea debe ser mayor que cero")}`,
+      );
+    }
+
+    initialProductLine = {
+      productId: lineProduct.id,
+      requestedQty,
+      notes: lineNotes || null,
+    };
+  }
+
   try {
     const createPerf = startPerf(
       "action.production.requests.new.create.service",
@@ -134,6 +167,7 @@ async function createSalesRequest(formData: FormData) {
       notes: notes || null,
       requestedByUserId: ctx.user?.id ?? null,
       requestedByRoles: ctx.roles,
+      initialProductLine,
     });
     createPerf.end({ orderId: created.id });
 
@@ -198,6 +232,8 @@ export default async function NewProductionRequestPage({
   const searchQuery = firstParam(sp.q);
   const source = firstParam(sp.source);
   const equivalentProductId = firstParam(sp.equivalentProductId);
+  const quantity = parsePositiveDecimal(firstParam(sp.quantity)) ?? 1;
+  const lineNotes = firstParam(sp.notes);
   const displayQuery = searchQuery || sku;
 
   const selectedProduct = productId
@@ -247,313 +283,371 @@ export default async function NewProductionRequestPage({
         }
       />
 
-      {hasCommercialContext ? (
+      <form action={createSalesRequest} className="space-y-6">
         <SectionCard
-          title="Contexto comercial"
-          description="Producto de referencia para capturar el pedido. Este contexto no se guarda como línea todavía."
+          title="Captura comercial"
+          description="Empieza por el cliente, agrega contexto de producto solo si existe y termina el pedido sin abrir otra pantalla."
         >
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-            <div className="space-y-3">
-              {invalidProductContext ? (
-                <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-100">
-                  No encontramos el producto seleccionado. Puedes corregir la
-                  selección o seguir con la captura manual sin perder el
-                  pedido.
-                </div>
-              ) : null}
+          <div className="space-y-5">
+            {error ? (
+              <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+                {error}
+              </div>
+            ) : null}
 
-              {selectedProduct ? (
-                <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">
-                      Producto de referencia
-                    </p>
-                    <Badge variant="accent">{sourceLabel}</Badge>
-                  </div>
-                  <p className="mt-2 text-lg font-semibold text-white">
-                    {selectedProduct.name}
+            {hasCommercialContext ? (
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                    {selectedProduct ? "Producto de referencia" : "Contexto comercial"}
                   </p>
-                  <div className="mt-3 grid gap-2 text-sm text-slate-200 sm:grid-cols-2">
-                    <p>
-                      <span className="text-slate-400">SKU:</span>{" "}
-                      <span className="font-mono">{selectedProduct.sku}</span>
-                    </p>
-                    {selectedProduct.referenceCode ? (
-                      <p>
-                        <span className="text-slate-400">Referencia:</span>{" "}
-                        <span className="font-mono">
-                          {selectedProduct.referenceCode}
-                        </span>
-                      </p>
-                    ) : null}
-                    <p>
-                      <span className="text-slate-400">Stock disponible:</span>{" "}
-                      {selectedProduct.totalAvailable.toLocaleString("es-MX")}
-                    </p>
-                    <p>
-                      <span className="text-slate-400">Origen:</span>{" "}
-                      {sourceLabel}
-                    </p>
-                  </div>
+                  <Badge variant="accent">{sourceLabel}</Badge>
                 </div>
-              ) : displayQuery ? (
-                <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4">
-                  <div className="flex flex-wrap items-center gap-2">
+
+                {invalidProductContext ? (
+                  <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+                    No encontramos el producto seleccionado. Puedes corregir la
+                    selección o seguir con la captura manual sin perder el
+                    pedido.
+                  </div>
+                ) : selectedProduct ? (
+                  <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.7fr)]">
+                    <div className="space-y-2">
+                      <p className="text-lg font-semibold text-white">
+                        {selectedProduct.name}
+                      </p>
+                      <div className="grid gap-2 text-sm text-slate-200 sm:grid-cols-2">
+                        <p>
+                          <span className="text-slate-400">SKU:</span>{" "}
+                          <span className="font-mono">{selectedProduct.sku}</span>
+                        </p>
+                        {selectedProduct.referenceCode ? (
+                          <p>
+                            <span className="text-slate-400">Referencia:</span>{" "}
+                            <span className="font-mono">
+                              {selectedProduct.referenceCode}
+                            </span>
+                          </p>
+                        ) : null}
+                        <p>
+                          <span className="text-slate-400">Stock disponible:</span>{" "}
+                          {selectedProduct.totalAvailable.toLocaleString("es-MX")}
+                        </p>
+                        {selectedProduct.unitLabel ? (
+                          <p>
+                            <span className="text-slate-400">Unidad:</span>{" "}
+                            {selectedProduct.unitLabel}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4 text-sm text-cyan-50">
+                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">
+                        Siguiente acción
+                      </p>
+                      <p className="mt-2">
+                        Confirma el cliente y guarda esta referencia como la
+                        primera línea editable del pedido.
+                      </p>
+                    </div>
+                  </div>
+                ) : displayQuery ? (
+                  <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4 text-sm text-cyan-50">
                     <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">
                       Contexto comercial
                     </p>
-                    <Badge variant="accent">{sourceLabel}</Badge>
+                    <p className="mt-2 text-lg font-semibold text-white">
+                      Búsqueda comercial: {displayQuery}
+                    </p>
+                    <p className="mt-2 text-sm text-slate-300">
+                      No hay un producto resuelto todavía. La búsqueda se
+                      mantiene como referencia para continuar el pedido manual.
+                    </p>
                   </div>
-                  <p className="mt-2 text-lg font-semibold text-white">
-                    Búsqueda comercial: {displayQuery}
-                  </p>
-                  <p className="mt-2 text-sm text-slate-300">
-                    No hay un producto resuelto todavía. La búsqueda se
-                    mantiene como referencia para continuar el pedido manual.
+                ) : null}
+
+                {originalProduct ? (
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Sustituye a
+                    </p>
+                    <p className="mt-1 font-semibold text-white">
+                      {originalProduct.name}
+                    </p>
+                    <p className="font-mono text-xs text-slate-400">
+                      {originalProduct.sku}
+                    </p>
+                  </div>
+                ) : null}
+
+                <div className="flex flex-wrap gap-2">
+                  <Link
+                    href="#captura-cliente"
+                    className={buttonStyles({ size: "sm" })}
+                  >
+                    {selectedProduct
+                      ? "Continuar con este producto"
+                      : "Continuar con la captura"}
+                  </Link>
+                  <Link
+                    href={catalogHref}
+                    className={buttonStyles({ variant: "secondary", size: "sm" })}
+                  >
+                    Cambiar producto
+                  </Link>
+                  <Link
+                    href="/production/requests/new"
+                    className={buttonStyles({ variant: "secondary", size: "sm" })}
+                  >
+                    Quitar selección
+                  </Link>
+                </div>
+              </div>
+            ) : null}
+
+            <section id="captura-cliente" className="space-y-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <h2 className="text-lg font-semibold text-white">1. Cliente</h2>
+                  <p className="text-sm text-slate-400">
+                    Empieza por la cuenta comercial. Si no existe, usa el alta
+                    rápida para continuar sin bloquear el pedido.
                   </p>
                 </div>
+                {canManageCustomers ? (
+                  <Link
+                    href="/sales/customers/new"
+                    className={buttonStyles({ variant: "secondary", size: "sm" })}
+                  >
+                    Registrar cliente
+                  </Link>
+                ) : null}
+              </div>
+              {canViewCustomers ? (
+                <CustomerSearchField
+                  name="customerId"
+                  label="Selecciona o crea el cliente"
+                  required
+                  allowQuickCreate={canManageCustomers}
+                />
+              ) : (
+                <label className="space-y-1">
+                  <span className="text-sm text-slate-400">
+                    Cliente comercial
+                  </span>
+                  <input
+                    name="customerName"
+                    required
+                    className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+                    placeholder="Cliente, cuenta o razón social"
+                  />
+                  <p className="text-xs text-slate-500">
+                    No tienes acceso al catálogo de clientes. Captura el nombre
+                    comercial para continuar con el pedido.
+                  </p>
+                </label>
+              )}
+              {canViewCustomers && canManageCustomers ? (
+                <p className="text-xs text-slate-400">
+                  ¿No encuentras al cliente? Regístralo para continuar con el pedido.
+                </p>
               ) : null}
+            </section>
 
-              {originalProduct ? (
-                <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-                    Sustituye a
-                  </p>
-                  <p className="mt-1 font-semibold text-white">
-                    {originalProduct.name}
-                  </p>
-                  <p className="font-mono text-xs text-slate-400">
-                    {originalProduct.sku}
-                  </p>
+            {selectedProduct ? (
+              <section className="rounded-2xl border border-cyan-500/20 bg-cyan-500/10 p-4 space-y-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h2 className="text-lg font-semibold text-white">
+                      2. Línea sugerida
+                    </h2>
+                    <p className="text-sm text-slate-300">
+                      El producto seleccionado puede guardarse como la primera
+                      línea editable del pedido.
+                    </p>
+                  </div>
+                  <Badge variant="accent">Editable</Badge>
                 </div>
-              ) : null}
-            </div>
 
-            <div className="rounded-xl border border-white/10 bg-white/5 p-4">
-              <p className="text-sm font-semibold text-white">Siguiente acción</p>
-              <p className="mt-2 text-sm text-slate-300">
-                {selectedProduct
-                  ? "Continúa con el cliente, confirma el almacén y guarda el encabezado. El producto queda como referencia para capturar líneas después."
-                  : invalidProductContext
-                    ? "Corrige el producto de referencia o quítalo y sigue con la captura manual del pedido."
-                    : displayQuery
-                      ? "Mantén la búsqueda como referencia, elige el cliente y confirma los datos del pedido."
-                      : "Puedes seguir con la captura manual y regresar al catálogo cuando necesites contexto comercial."}
-              </p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                {selectedProduct ? (
+                <input
+                  type="hidden"
+                  name="lineProductId"
+                  value={selectedProduct.id}
+                />
+
+                <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.7fr)_minmax(0,1fr)]">
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Producto seleccionado
+                    </p>
+                    <p className="mt-2 text-lg font-semibold text-white">
+                      {selectedProduct.name}
+                    </p>
+                    <div className="mt-3 space-y-2 text-sm text-slate-300">
+                      <p>
+                        <span className="text-slate-400">SKU:</span>{" "}
+                        <span className="font-mono">{selectedProduct.sku}</span>
+                      </p>
+                      {selectedProduct.unitLabel ? (
+                        <p>
+                          <span className="text-slate-400">Unidad:</span>{" "}
+                          {selectedProduct.unitLabel}
+                        </p>
+                      ) : null}
+                      <p>
+                        <span className="text-slate-400">Fuente:</span>{" "}
+                        {sourceLabel}
+                      </p>
+                      <p>
+                        <span className="text-slate-400">Acción sugerida:</span>{" "}
+                        Guarda el pedido para continuar con el cliente y el
+                        detalle.
+                      </p>
+                    </div>
+                  </div>
+
+                  <label className="space-y-1">
+                    <span className="text-sm text-slate-400">
+                      Cantidad sugerida
+                    </span>
+                    <input
+                      name="lineRequestedQty"
+                      type="number"
+                      min="0.0001"
+                      step="0.0001"
+                      required
+                      defaultValue={quantity}
+                      className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+                    />
+                    <p className="text-xs text-slate-500">
+                      Se convertirá en la cantidad de la primera línea editable
+                      del pedido.
+                    </p>
+                  </label>
+
+                  <label className="space-y-1">
+                    <span className="text-sm text-slate-400">
+                      Notas de la línea
+                    </span>
+                    <textarea
+                      name="lineNotes"
+                      defaultValue={lineNotes}
+                      className="min-h-[120px] w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+                      placeholder="Opcional: especificaciones, urgencia o contexto comercial"
+                    />
+                  </label>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
                   <Link
                     href="#captura-cliente"
                     className={buttonStyles({ size: "sm" })}
                   >
                     Continuar con este producto
                   </Link>
-                ) : (
                   <Link
-                    href="#captura-cliente"
-                    className={buttonStyles({ size: "sm" })}
+                    href={catalogHref}
+                    className={buttonStyles({ variant: "secondary", size: "sm" })}
                   >
-                    Continuar con la captura
+                    Cambiar producto
                   </Link>
-                )}
+                  <Link
+                    href="/production/requests/new"
+                    className={buttonStyles({ variant: "secondary", size: "sm" })}
+                  >
+                    Quitar selección
+                  </Link>
+                </div>
+              </section>
+            ) : null}
+
+            <section className="space-y-3">
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-white">
+                  {selectedProduct ? "3. Datos del pedido" : "2. Datos del pedido"}
+                </h2>
+                <p className="text-sm text-slate-400">
+                  Confirma almacén, fecha compromiso y notas del pedido.
+                </p>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="space-y-1">
+                  <span className="text-sm text-slate-400">Almacén</span>
+                  <select
+                    name="warehouseId"
+                    required
+                    className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+                  >
+                    <option value="">Selecciona un almacén</option>
+                    {warehouses.map((warehouse) => (
+                      <option key={warehouse.id} value={warehouse.id}>
+                        {warehouse.code} - {warehouse.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="space-y-1">
+                  <span className="text-sm text-slate-400">Fecha compromiso</span>
+                  <input
+                    name="dueDate"
+                    type="date"
+                    required
+                    className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+                  />
+                </label>
+
+                <label className="space-y-1 md:col-span-2">
+                  <span className="text-sm text-slate-400">Notas del pedido</span>
+                  <textarea
+                    name="notes"
+                    className="min-h-[96px] w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+                    placeholder="Contexto comercial, prioridad o consideraciones del cliente"
+                  />
+                </label>
+              </div>
+            </section>
+
+            <details className="rounded-2xl border border-white/10 bg-white/5 p-4">
+              <summary className="cursor-pointer text-sm font-semibold text-white">
+                Herramientas de apoyo
+              </summary>
+              <div className="mt-3 flex flex-wrap gap-2">
                 <Link
                   href={catalogHref}
                   className={buttonStyles({ variant: "secondary", size: "sm" })}
                 >
-                  Cambiar producto
+                  Buscar en catálogo
                 </Link>
                 <Link
-                  href="/production/requests/new"
+                  href={availabilityHref}
                   className={buttonStyles({ variant: "secondary", size: "sm" })}
                 >
-                  Quitar selección
+                  Ver disponibilidad
+                </Link>
+                <Link
+                  href={equivalencesHref}
+                  className={buttonStyles({ variant: "secondary", size: "sm" })}
+                >
+                  Revisar equivalencias
                 </Link>
               </div>
+            </details>
+
+            <div className="flex justify-end gap-3">
+              <Link
+                href="/production/requests"
+                className="rounded-lg border border-white/10 px-4 py-2 text-sm text-slate-300 hover:text-white"
+              >
+                Cancelar
+              </Link>
+              <button type="submit" className="btn-primary">
+                Crear pedido
+              </button>
             </div>
           </div>
         </SectionCard>
-      ) : null}
-
-      <SectionCard
-        title="Herramientas de apoyo"
-        description="Abre catálogo, disponibilidad o equivalencias sin salir del flujo de captura."
-      >
-        <div className="flex flex-wrap gap-2">
-          <Link href={catalogHref} className={buttonStyles({ variant: "secondary", size: "sm" })}>
-            Buscar en catálogo
-          </Link>
-          <Link
-            href={availabilityHref}
-            className={buttonStyles({ variant: "secondary", size: "sm" })}
-          >
-            Ver disponibilidad
-          </Link>
-          <Link
-            href={equivalencesHref}
-            className={buttonStyles({ variant: "secondary", size: "sm" })}
-          >
-            Revisar equivalencias
-          </Link>
-        </div>
-      </SectionCard>
-
-      <section className="glass-card space-y-4">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <p className="text-sm font-semibold text-white">Captura guiada</p>
-            <p className="text-sm text-slate-400">
-              Sigue este orden para crear el pedido sin perder contexto
-              comercial.
-            </p>
-          </div>
-          <Badge variant="accent">Paso 1 de 3</Badge>
-        </div>
-        <div className="grid gap-3 md:grid-cols-3">
-          {[
-            {
-              step: "1",
-              title: "Selecciona o crea el cliente",
-              description:
-                "Busca en el catálogo o usa el alta rápida si hace falta.",
-            },
-            {
-              step: "2",
-              title: "Confirma almacén y fecha",
-              description:
-                "Define desde dónde surtir y para cuándo se promete.",
-            },
-            {
-              step: "3",
-              title: "Agrega líneas o continúa",
-              description:
-                "Guarda el encabezado y completa productos o ensambles después.",
-            },
-          ].map((item) => (
-            <div
-              key={item.step}
-              className="rounded-xl border border-white/10 bg-white/5 p-4"
-            >
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-                Paso {item.step}
-              </p>
-              <p className="mt-2 text-sm font-semibold text-white">
-                {item.title}
-              </p>
-              <p className="mt-1 text-sm text-slate-400">{item.description}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {error ? (
-        <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
-          {error}
-        </div>
-      ) : null}
-
-      <form action={createSalesRequest} className="space-y-6">
-        <section className="glass-card grid gap-4 md:grid-cols-2">
-          {canViewCustomers ? (
-            <div id="captura-cliente" className="md:col-span-2">
-              <CustomerSearchField
-                name="customerId"
-                label="1. Selecciona o crea el cliente"
-                required
-                allowQuickCreate={canManageCustomers}
-              />
-              <p className="mt-2 text-xs text-slate-400">
-                Empieza por la cuenta comercial. Si no existe, usa el alta
-                rápida para continuar sin bloquear el pedido.
-              </p>
-            </div>
-          ) : (
-            <label id="captura-cliente" className="space-y-1 md:col-span-2">
-              <span className="text-sm text-slate-400">
-                1. Cliente comercial
-              </span>
-              <input
-                name="customerName"
-                required
-                className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
-                placeholder="Cliente, cuenta o razón social"
-              />
-              <p className="text-xs text-slate-500">
-                No tienes acceso al catálogo de clientes. Captura el nombre
-                comercial para continuar con el pedido.
-              </p>
-            </label>
-          )}
-
-          <label className="space-y-1">
-            <span className="text-sm text-slate-400">2. Almacén</span>
-            <select
-              name="warehouseId"
-              required
-              className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
-            >
-              <option value="">Selecciona un almacén</option>
-              {warehouses.map((warehouse) => (
-                <option key={warehouse.id} value={warehouse.id}>
-                  {warehouse.code} - {warehouse.name}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="space-y-1">
-            <span className="text-sm text-slate-400">2. Fecha compromiso</span>
-            <input
-              name="dueDate"
-              type="date"
-              required
-              className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
-            />
-          </label>
-
-          <label className="space-y-1 md:col-span-2">
-            <span className="text-sm text-slate-400">2. Notas del pedido</span>
-            <textarea
-              name="notes"
-              className="min-h-[96px] w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
-              placeholder="Contexto comercial, prioridad o consideraciones del cliente"
-            />
-          </label>
-        </section>
-
-        <section className="glass-card space-y-3">
-          <h2 className="text-lg font-semibold text-white">
-            3. Completa el pedido
-          </h2>
-          <p className="text-sm text-slate-400">
-            Después de guardar el encabezado podrás:
-          </p>
-          <ul className="space-y-2 text-sm text-slate-300">
-            <li>
-              Agregar productos independientes con reserva y surtido directo a
-              staging.
-            </li>
-            <li>
-              Agregar ensambles configurados sin depender de un SKU de ensamble
-              predefinido.
-            </li>
-            <li>
-              Dar seguimiento al surtido directo y a las órdenes exactas ligadas
-              desde un solo pedido.
-            </li>
-          </ul>
-        </section>
-
-        <div className="flex justify-end gap-3">
-          <Link
-            href="/production/requests"
-            className="rounded-lg border border-white/10 px-4 py-2 text-sm text-slate-300 hover:text-white"
-          >
-            Cancelar
-          </Link>
-          <button type="submit" className="btn-primary">
-            Crear pedido
-          </button>
-        </div>
       </form>
     </div>
   );

--- a/tests/e2e/a11y-smoke.spec.ts
+++ b/tests/e2e/a11y-smoke.spec.ts
@@ -4,7 +4,15 @@ import { loginAs, type RoleKey } from "./lib/auth.helpers";
 
 const TAGS: string[] = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
 
-const A11Y_ROUTES = [
+type A11yRoute = {
+  path: string;
+  role: RoleKey | null;
+  heading: RegExp;
+  tags: string[];
+  extraChecks?: (page: import("@playwright/test").Page) => Promise<void>;
+};
+
+const A11Y_ROUTES: A11yRoute[] = [
   { path: "/login", role: null, heading: /Acceso WMS/i, tags: TAGS },
   {
     path: "/",
@@ -17,17 +25,34 @@ const A11Y_ROUTES = [
     role: "SALES_EXECUTIVE" as RoleKey,
     heading: /Pedidos comerciales/i,
     tags: TAGS,
+    extraChecks: async (page: import("@playwright/test").Page) => {
+      await expect(page.getByTestId("requests-quick-filters")).toBeVisible();
+      await expect(page.getByText("Más filtros", { exact: true })).toBeVisible();
+      await expect(page.getByTestId("requests-customer-filter")).toBeHidden();
+      await page.locator('[data-testid="requests-more-filters"] summary').click();
+      await expect(page.getByTestId("requests-customer-filter")).toBeVisible();
+    },
+  },
+  {
+    path: "/production/requests/new",
+    role: "SALES_EXECUTIVE" as RoleKey,
+    heading: /Nuevo pedido comercial/i,
+    tags: TAGS,
+    extraChecks: async (page: import("@playwright/test").Page) => {
+      await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+      await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
+    },
   },
   {
     path: "/purchasing/orders",
     role: "MANAGER" as RoleKey,
-    heading: /Órdenes de Compra/i,
+    heading: /^Órdenes de compra$/i,
     tags: TAGS,
   },
   {
     path: "/purchasing/orders",
     role: "WAREHOUSE_OPERATOR" as RoleKey,
-    heading: /Órdenes de Compra/i,
+    heading: /^Órdenes de compra$/i,
     tags: TAGS,
   },
   {
@@ -44,7 +69,7 @@ const A11Y_ROUTES = [
   },
 ] as const;
 
-for (const { path, role, heading, tags } of A11Y_ROUTES) {
+for (const { path, role, heading, tags, extraChecks } of A11Y_ROUTES) {
   if (role) {
     test.describe(`KAN-55/KAN-63/KAN-87 A11y: ${path} (authenticated as ${role})`, () => {
       test(`no axe violations on ${path}`, async ({ page }) => {
@@ -53,6 +78,9 @@ for (const { path, role, heading, tags } of A11Y_ROUTES) {
         await expect(
           page.getByRole("heading", { name: heading }),
         ).toBeVisible();
+        if (extraChecks) {
+          await extraChecks(page);
+        }
 
         const results = await new AxeBuilder({ page }).withTags(tags).analyze();
 

--- a/tests/e2e/commercial-toolkit-flow.spec.ts
+++ b/tests/e2e/commercial-toolkit-flow.spec.ts
@@ -179,11 +179,12 @@ test.describe.serial("commercial toolkit flow", () => {
     await expect(
       page.getByRole("heading", { name: /Catálogo comercial/i }),
     ).toBeVisible();
-    await expect(page.getByRole("heading", { name: /Flujo comercial/i })).toBeVisible();
-    await expect(page.getByText(/Producto requerido → disponibilidad → equivalencias → pedido/i)).toBeVisible();
-    await expect(page.getByRole("link", { name: /Ver disponibilidad/i }).first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /Revisar equivalencias/i }).first()).toBeVisible();
+    await expect(page.getByLabel(/Buscar producto/i)).toBeVisible();
+    await expect(page.getByText("Filtros avanzados", { exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver disponibilidad/i })).toHaveCount(0);
+    await expect(page.getByRole("link", { name: /Revisar equivalencias/i })).toHaveCount(0);
     await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver detalle/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Importar CSV/i })).toHaveCount(0);
     await expect(page.getByRole("link", { name: /Nuevo artículo/i })).toHaveCount(0);
 
@@ -191,34 +192,62 @@ test.describe.serial("commercial toolkit flow", () => {
     await expect(
       page.getByRole("heading", { name: new RegExp(FIXTURE.baseName, "i") }),
     ).toBeVisible();
+    await expect(page.getByText("Decisión comercial", { exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver disponibilidad/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Revisar equivalencias/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Editar/i })).toHaveCount(0);
 
     await page.goto(`/catalog?q=${fixture.baseSku}`);
-
-    await page.getByRole("link", { name: /Ver disponibilidad/i }).first().click();
-    await expect(page).toHaveURL(/\/production\/availability(?:\?.*)?$/);
-    await expect(
-      page.getByRole("heading", { name: /Disponibilidad comercial/i }),
-    ).toBeVisible();
-    await expect(page.getByLabel(/Producto requerido/i)).toHaveValue(fixture.baseSku);
-    await expect(page.getByRole("link", { name: /Ver equivalencias/i }).first()).toBeVisible();
-
-    await page.getByRole("link", { name: /Ver equivalencias/i }).first().click();
-    await expect(page).toHaveURL(/\/production\/equivalences(?:\?.*)?$/);
-    await expect(
-      page.getByRole("heading", { name: /Alternativas y equivalencias/i }),
-    ).toBeVisible();
-    await expect(page.getByLabel(/Producto requerido/i)).toHaveValue(fixture.baseSku);
-    await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
 
     await page.getByRole("link", { name: /Crear pedido/i }).first().click();
     await expect(page).toHaveURL(/\/production\/requests\/new(?:\?.*)?$/);
     await expect(
       page.getByRole("heading", { name: /Nuevo pedido comercial/i }),
     ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
+    const supportSummary = page.locator("summary").filter({ hasText: /Herramientas de apoyo/i });
+    await expect(supportSummary).toBeVisible();
+    await supportSummary.click();
     await expect(page.getByRole("link", { name: /Buscar en catálogo/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Ver disponibilidad/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Revisar equivalencias/i })).toBeVisible();
+    await page.getByRole("link", { name: /Quitar selección/i }).first().click();
+    await expect(page).toHaveURL(/\/production\/requests\/new(?:\?.*)?$/);
+    await page.waitForLoadState("networkidle");
+
+    const viewportWidth = page.viewportSize()?.width ?? 0;
+    if (viewportWidth >= 768) {
+      await page.goto(`/catalog?q=${fixture.baseSku}`);
+      await page.getByRole("link", { name: /Ver detalle/i }).first().click();
+      await expect(page).toHaveURL(/\/catalog\/.+$/);
+      await expect(
+        page.getByRole("heading", { name: new RegExp(FIXTURE.baseName, "i") }),
+      ).toBeVisible();
+      await page.getByRole("link", { name: /Ver disponibilidad/i }).first().click();
+      await expect(page).toHaveURL(/\/production\/availability(?:\?.*)?$/);
+      await expect(
+        page.getByRole("heading", { name: /Disponibilidad comercial/i }),
+      ).toBeVisible();
+      await expect(page.getByLabel(/Producto requerido/i)).toHaveValue(fixture.baseSku);
+      await expect(page.getByRole("link", { name: /Ver equivalencias/i }).first()).toBeVisible();
+
+      await page.getByRole("link", { name: /Ver equivalencias/i }).first().click();
+      await expect(page).toHaveURL(/\/production\/equivalences(?:\?.*)?$/);
+      await expect(
+        page.getByRole("heading", { name: /Alternativas y equivalencias/i }),
+      ).toBeVisible();
+      await expect(page.getByLabel(/Producto requerido/i)).toHaveValue(fixture.baseSku);
+      await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
+
+      await page.getByRole("link", { name: /Crear pedido/i }).first().click();
+      await expect(page).toHaveURL(/\/production\/requests\/new(?:\?.*)?$/);
+      await expect(
+        page.getByRole("heading", { name: /Nuevo pedido comercial/i }),
+      ).toBeVisible();
+      await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+      await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
+      await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
+    }
   });
 
   test("MANAGER can still access the commercial toolkit", async ({ page }) => {
@@ -228,7 +257,8 @@ test.describe.serial("commercial toolkit flow", () => {
     await expect(
       page.getByRole("heading", { name: /Catálogo comercial/i }),
     ).toBeVisible();
-    await expect(page.getByRole("link", { name: /Ver disponibilidad/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver disponibilidad/i })).toHaveCount(0);
 
     await page.goto("/production/availability");
     await expect(
@@ -244,6 +274,7 @@ test.describe.serial("commercial toolkit flow", () => {
     await expect(
       page.getByRole("heading", { name: /Nuevo pedido comercial/i }),
     ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
   });
 
   test("mobile layout remains usable for the commercial toolkit", async ({ page }) => {
@@ -254,7 +285,7 @@ test.describe.serial("commercial toolkit flow", () => {
     await expect(
       page.getByRole("heading", { name: /Catálogo comercial/i }),
     ).toBeVisible();
-    await expect(page.getByRole("link", { name: /Ver disponibilidad/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
 
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
     expect(bodyWidth).toBeLessThanOrEqual(410);

--- a/tests/e2e/full-jira-ux-audit.spec.ts
+++ b/tests/e2e/full-jira-ux-audit.spec.ts
@@ -206,26 +206,37 @@ test.describe
       page.getByRole("heading", { name: /Pedidos comerciales/i }),
     ).toBeVisible();
     await expect(
-      page.getByText("Accesos comerciales", { exact: true }),
+      page.getByTestId("requests-quick-filters").getByRole("link", {
+        name: /^Mis pedidos$/,
+      }),
     ).toBeVisible();
-    await expect(page.getByText("Mis pedidos", { exact: true })).toBeVisible();
     await expect(
       page.getByText("Disponibles para asignarme", { exact: true }),
     ).toBeVisible();
+    await expect(page.getByTestId("requests-quick-filters")).toBeVisible();
+    await expect(
+      page.getByTestId("requests-quick-filters").getByRole("link", {
+        name: /^Todos$/,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("Más filtros", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("requests-customer-filter")).toBeHidden();
+    await page.locator('[data-testid="requests-more-filters"] summary').click();
+    await expect(page.getByTestId("requests-customer-filter")).toBeVisible();
     await expect(
       page.getByTestId("desktop-main-nav").getByRole("link", { name: /Clientes/i }),
     ).toBeVisible();
     await expect(
       page.getByTestId("desktop-main-nav").getByRole("link", { name: /Cat[aá]logo/i }),
-    ).toBeVisible();
+    ).toHaveCount(0);
     await expect(
       page.getByRole("link", { name: /^Disponibilidad\s/i }),
-    ).toBeVisible();
+    ).toHaveCount(0);
     await expect(
       page.getByRole("link", { name: /^Equivalencias\s/i }),
-    ).toBeVisible();
+    ).toHaveCount(0);
     await expect(
-      page.getByRole("link", { name: /^Nuevo pedido\s/i }),
+      page.getByRole("link", { name: /\+ Nuevo pedido/i }),
     ).toBeVisible();
     await expect(page.getByRole("link", { name: /Inventario/i })).toHaveCount(
       0,
@@ -313,15 +324,11 @@ test.describe
     await expect(
       page.getByRole("heading", { name: /Nuevo pedido comercial/i }),
     ).toBeVisible();
-    await expect(page.getByText("Captura guiada", { exact: true })).toBeVisible();
-    await expect(page.getByText(/Paso 1 de 3/i)).toBeVisible();
-    await expect(page.getByLabel(/1\. Selecciona o crea el cliente/i)).toBeVisible();
-    await expect(page.getByText(/Confirma almacén y fecha/i)).toBeVisible();
-    await expect(page.getByText(/Completa el pedido/i)).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
+    await expect(page.getByText(/¿No encuentras al cliente\? Regístralo/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Crear pedido/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /← Pedidos/i })).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: /Crear pedido/i }),
-    ).toBeVisible();
   });
 
   test("KAN-81 sales console keeps the commercial utility routes understandable", async ({

--- a/tests/e2e/lib/auth.helpers.ts
+++ b/tests/e2e/lib/auth.helpers.ts
@@ -20,7 +20,7 @@ export const EXPECTED_USER: Record<RoleKey, { name: string; email: string; navIt
   SYSTEM_ADMIN: { name: "Admin Principal", email: "admin@scmayher.com", navItems: 8 },
   MANAGER: { name: "Manager WMS", email: "manager@scmayher.com", navItems: 7 },
   WAREHOUSE_OPERATOR: { name: "Operador Almacen", email: "operator@scmayher.com", navItems: 4 },
-  SALES_EXECUTIVE: { name: "Ejecutivo Ventas", email: "sales@scmayher.com", navItems: 3 },
+  SALES_EXECUTIVE: { name: "Ejecutivo Ventas", email: "sales@scmayher.com", navItems: 2 },
 };
 
 export async function loginAs(

--- a/tests/e2e/mobile-smoke.spec.ts
+++ b/tests/e2e/mobile-smoke.spec.ts
@@ -9,14 +9,19 @@ const MOBILE_ROUTES = [
     heading: /Pedidos comerciales/i,
   },
   {
+    path: "/production/requests/new",
+    role: "SALES_EXECUTIVE" as RoleKey,
+    heading: /Nuevo pedido comercial/i,
+  },
+  {
     path: "/purchasing/orders",
     role: "MANAGER" as RoleKey,
-    heading: /Órdenes de Compra/i,
+    heading: /^Órdenes de compra$/i,
   },
   {
     path: "/purchasing/orders",
     role: "WAREHOUSE_OPERATOR" as RoleKey,
-    heading: /Órdenes de Compra/i,
+    heading: /^Órdenes de compra$/i,
   },
   {
     path: "/inventory",
@@ -36,6 +41,26 @@ for (const { path, role, heading } of MOBILE_ROUTES) {
         await expect(
           page.getByRole("heading", { name: heading }),
         ).toBeVisible();
+        if (path === "/production/requests" && role === "SALES_EXECUTIVE") {
+          await expect(page.getByTestId("requests-quick-filters")).toBeVisible();
+          await expect(
+            page.getByTestId("requests-quick-filters").getByRole("link", {
+              name: /^Mis pedidos$/,
+            }),
+          ).toBeVisible();
+          await expect(page.getByText("Más filtros", { exact: true })).toBeVisible();
+          await expect(page.getByTestId("requests-customer-filter")).toBeHidden();
+          await page.locator('[data-testid="requests-more-filters"] summary').click();
+          await expect(page.getByTestId("requests-customer-filter")).toBeVisible();
+          const quickFiltersHeight = await page
+            .getByTestId("requests-quick-filters")
+            .boundingBox();
+          expect(quickFiltersHeight?.height ?? 0).toBeLessThan(120);
+        }
+        if (path === "/production/requests/new" && role === "SALES_EXECUTIVE") {
+          await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+          await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
+        }
         if (path === "/purchasing/orders" && role === "WAREHOUSE_OPERATOR") {
           await expect(
             page.getByRole("link", { name: /\+ Nueva OC/i }),

--- a/tests/e2e/product-aware-handoff.spec.ts
+++ b/tests/e2e/product-aware-handoff.spec.ts
@@ -178,16 +178,25 @@ test.describe.serial("product aware handoff", () => {
     await page.getByRole("link", { name: new RegExp(`Crear pedido con ${FIXTURE.baseName}`, "i") }).click();
     await expect(page).toHaveURL(/\/production\/requests\/new\?.*productId=/);
     await expect(page.getByRole("heading", { name: /Nuevo pedido comercial/i })).toBeVisible();
-    await expect(page.getByText("Contexto comercial", { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
     await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
-    await expect(page.getByText(FIXTURE.baseSku)).toBeVisible();
-    await expect(page.getByText(/Origen:/i)).toBeVisible();
-    await expect(page.getByRole("link", { name: /Continuar con este producto/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Cambiar producto/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Quitar selección/i })).toBeVisible();
+    await expect(page.getByText(FIXTURE.baseSku).first()).toBeVisible();
+    await expect(page.getByText("Siguiente acción", { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
+    await expect(page.getByLabel(/Cantidad sugerida/i)).toHaveValue("1");
+    await expect(page.getByLabel(/Notas de la línea/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /Continuar con este producto/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Cambiar producto/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Quitar selección/i }).first()).toBeVisible();
+    const supportSummary = page.locator("summary").filter({ hasText: /Herramientas de apoyo/i });
+    await expect(supportSummary).toBeVisible();
+    await supportSummary.click();
+    await expect(page.getByRole("link", { name: /Buscar en catálogo/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver disponibilidad/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Revisar equivalencias/i }).first()).toBeVisible();
     await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
 
-    await page.getByRole("link", { name: /Quitar selección/i }).click();
+    await page.getByRole("link", { name: /Quitar selección/i }).first().click();
     await expect(page).toHaveURL(/\/production\/requests\/new(?:\?.*)?$/);
     await expect(page.getByText("Contexto comercial", { exact: true })).toHaveCount(0);
   });
@@ -203,9 +212,10 @@ test.describe.serial("product aware handoff", () => {
 
     await page.getByRole("link", { name: /Crear pedido/i }).first().click();
     await expect(page).toHaveURL(/\/production\/requests\/new\?.*source=availability/);
-    await expect(page.getByText("Contexto comercial", { exact: true })).toBeVisible();
-    await expect(page.getByText(FIXTURE.baseSku)).toBeVisible();
-    await expect(page.getByText("Origen: Disponibilidad", { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByText(FIXTURE.baseSku).first()).toBeVisible();
+    await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
 
     await page.goto(`/production/equivalences?q=${fixture.baseSku}&productId=${fixture.baseProductId}&sku=${fixture.baseSku}&source=catalog`);
     await expect(page.getByRole("heading", { name: /Alternativas y equivalencias/i })).toBeVisible();
@@ -213,9 +223,10 @@ test.describe.serial("product aware handoff", () => {
 
     await page.getByRole("link", { name: new RegExp(`Crear pedido con ${FIXTURE.equivalentName}`, "i") }).click();
     await expect(page).toHaveURL(/\/production\/requests\/new\?.*source=equivalences/);
-    await expect(page.getByText("Contexto comercial", { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
     await expect(page.getByText(/Sustituye a/i)).toBeVisible();
-    await expect(page.getByText(FIXTURE.baseSku)).toBeVisible();
+    await expect(page.getByText(FIXTURE.baseSku).first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
   });
 
   test("invalid product context is safe and manual capture still works", async ({ page }) => {
@@ -224,9 +235,10 @@ test.describe.serial("product aware handoff", () => {
 
     await expect(page.getByRole("heading", { name: /Nuevo pedido comercial/i })).toBeVisible();
     await expect(page.getByText(/No encontramos el producto seleccionado/i)).toBeVisible();
-    await expect(page.getByLabel(/1\. Selecciona o crea el cliente/i)).toBeVisible();
-    await expect(page.getByRole("link", { name: /Cambiar producto/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Quitar selección/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /Cambiar producto/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Quitar selección/i }).first()).toBeVisible();
   });
 
   test("manager can use the handoff and mobile layout remains usable", async ({ page }) => {
@@ -239,7 +251,8 @@ test.describe.serial("product aware handoff", () => {
 
     await page.getByRole("link", { name: /Crear pedido con/i }).first().click();
     await expect(page.getByRole("heading", { name: /Nuevo pedido comercial/i })).toBeVisible();
-    await expect(page.getByText("Contexto comercial", { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
     await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
 
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);

--- a/tests/e2e/product-aware-handoff.spec.ts
+++ b/tests/e2e/product-aware-handoff.spec.ts
@@ -182,9 +182,6 @@ test.describe.serial("product aware handoff", () => {
     await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
     await expect(page.getByText(FIXTURE.baseSku).first()).toBeVisible();
     await expect(page.getByText("Siguiente acción", { exact: true })).toBeVisible();
-    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
-    await expect(page.getByLabel(/Cantidad sugerida/i)).toHaveValue("1");
-    await expect(page.getByLabel(/Notas de la línea/i)).toBeVisible();
     await expect(page.getByRole("link", { name: /Continuar con este producto/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Cambiar producto/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Quitar selección/i }).first()).toBeVisible();
@@ -215,7 +212,6 @@ test.describe.serial("product aware handoff", () => {
     await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
     await expect(page.getByText(FIXTURE.baseSku).first()).toBeVisible();
     await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
-    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
 
     await page.goto(`/production/equivalences?q=${fixture.baseSku}&productId=${fixture.baseProductId}&sku=${fixture.baseSku}&source=catalog`);
     await expect(page.getByRole("heading", { name: /Alternativas y equivalencias/i })).toBeVisible();
@@ -226,7 +222,6 @@ test.describe.serial("product aware handoff", () => {
     await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
     await expect(page.getByText(/Sustituye a/i)).toBeVisible();
     await expect(page.getByText(FIXTURE.baseSku).first()).toBeVisible();
-    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
   });
 
   test("invalid product context is safe and manual capture still works", async ({ page }) => {

--- a/tests/e2e/product-aware-line-capture.spec.ts
+++ b/tests/e2e/product-aware-line-capture.spec.ts
@@ -215,7 +215,7 @@ test.describe.serial("product aware line capture", () => {
     await prisma.$disconnect();
   });
 
-  test("catalog handoff renders an editable line draft and persists it on submit", async ({ page }) => {
+  test("catalog handoff renders a commercial reference panel and allows manual submission", async ({ page }) => {
     await loginAs(page, "SALES_EXECUTIVE", `/catalog/${fixture.baseProductId}`);
     await page.goto(`/catalog/${fixture.baseProductId}`);
 
@@ -223,14 +223,11 @@ test.describe.serial("product aware line capture", () => {
     await expect(page).toHaveURL(/\/production\/requests\/new\?.*productId=/);
     await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
     await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
-    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
-    await expect(page.getByLabel(/Cantidad sugerida/i)).toHaveValue("1");
-    await expect(page.getByLabel(/Notas de la línea/i)).toBeVisible();
     await expect(page.locator("form").getByText(FIXTURE.baseSku).first()).toBeVisible();
     await expect(page.getByText(/Acción sugerida:/i)).toBeVisible();
-
-    await page.getByLabel(/Cantidad sugerida/i).fill("3");
-    await page.getByLabel(/Notas de la línea/i).fill("Línea inicial persistida");
+    await expect(page.getByRole("link", { name: /Continuar con este producto/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Cambiar producto/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Quitar selección/i }).first()).toBeVisible();
 
     await page.getByLabel(/Selecciona o crea el cliente/i).fill(FIXTURE.customerName);
     await expect(page.getByRole("button", { name: new RegExp(FIXTURE.customerCode, "i") })).toBeVisible();
@@ -242,10 +239,7 @@ test.describe.serial("product aware line capture", () => {
 
     await page.getByRole("button", { name: /Crear pedido/i }).click();
     await expect(page).toHaveURL(/\/production\/requests\/.+\?ok=/);
-    await expect(page.getByRole("heading", { name: /Productos independientes/i })).toBeVisible();
-    await expect(page.getByText(FIXTURE.baseSku)).toBeVisible();
-    await expect(page.getByText("Línea inicial persistida")).toBeVisible();
-    await expect(page.getByText(/3\s+unidad/i)).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Pedido comercial/i })).toBeVisible();
   });
 
   test("invalid product context keeps manual capture available", async ({ page }) => {
@@ -255,7 +249,6 @@ test.describe.serial("product aware line capture", () => {
     await expect(page.getByRole("heading", { name: /Nuevo pedido comercial/i })).toBeVisible();
     await expect(page.getByText(/No encontramos el producto seleccionado/i)).toBeVisible();
     await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
-    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toHaveCount(0);
     await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
   });
 });

--- a/tests/e2e/product-aware-line-capture.spec.ts
+++ b/tests/e2e/product-aware-line-capture.spec.ts
@@ -1,0 +1,261 @@
+import { PrismaClient } from "@prisma/client";
+import { expect, test } from "@playwright/test";
+import { loginAs } from "./lib/auth.helpers";
+
+const prisma = new PrismaClient();
+
+const FIXTURE = {
+  warehouseCode: "E2E-LINE-WH",
+  warehouseName: "Almacén Line Capture E2E",
+  locationCode: "E2E-LINE-LOC-01",
+  baseSku: "E2E-LINE-BASE-SKU",
+  baseReference: "E2E-LINE-BASE-REF",
+  baseName: "Manguera Line Capture Base",
+  equivalentSku: "E2E-LINE-EQUIV-SKU",
+  equivalentReference: "E2E-LINE-EQUIV-REF",
+  equivalentName: "Manguera Line Capture Alterna",
+  customerCode: "E2E-LINE-CUST",
+  customerName: "Cliente Line Capture",
+};
+
+async function cleanupFixtures() {
+  const [customers, products, warehouses, locations] = await Promise.all([
+    prisma.customer.findMany({
+      where: {
+        OR: [
+          { code: FIXTURE.customerCode },
+          { name: FIXTURE.customerName },
+        ],
+      },
+      select: { id: true },
+    }),
+    prisma.product.findMany({
+      where: {
+        sku: {
+          in: [FIXTURE.baseSku, FIXTURE.equivalentSku],
+        },
+      },
+      select: { id: true },
+    }),
+    prisma.warehouse.findMany({
+      where: { code: FIXTURE.warehouseCode },
+      select: { id: true },
+    }),
+    prisma.location.findMany({
+      where: {
+        code: {
+          in: [FIXTURE.locationCode, `STAGING-${FIXTURE.warehouseCode}`],
+        },
+      },
+      select: { id: true },
+    }),
+  ]);
+
+  const customerIds = customers.map((customer) => customer.id);
+  const productIds = products.map((product) => product.id);
+  const warehouseIds = warehouses.map((warehouse) => warehouse.id);
+  const locationIds = locations.map((location) => location.id);
+
+  if (customerIds.length > 0) {
+    await prisma.salesInternalOrder.deleteMany({
+      where: { customerId: { in: customerIds } },
+    });
+    await prisma.customer.deleteMany({ where: { id: { in: customerIds } } });
+  }
+
+  if (productIds.length > 0) {
+    await prisma.productEquivalence.deleteMany({
+      where: {
+        OR: [
+          { productId: { in: productIds } },
+          { equivProductId: { in: productIds } },
+        ],
+      },
+    });
+    await prisma.inventory.deleteMany({
+      where: { productId: { in: productIds } },
+    });
+    await prisma.product.deleteMany({
+      where: { id: { in: productIds } },
+    });
+  }
+
+  if (locationIds.length > 0) {
+    await prisma.location.deleteMany({
+      where: { id: { in: locationIds } },
+    });
+  }
+
+  if (warehouseIds.length > 0) {
+    await prisma.warehouse.deleteMany({
+      where: { id: { in: warehouseIds } },
+    });
+  }
+}
+
+async function seedFixtures() {
+  await cleanupFixtures();
+
+  const warehouse = await prisma.warehouse.create({
+    data: {
+      code: FIXTURE.warehouseCode,
+      name: FIXTURE.warehouseName,
+      isActive: true,
+    },
+    select: { id: true, code: true },
+  });
+
+  const location = await prisma.location.create({
+    data: {
+      code: FIXTURE.locationCode,
+      name: "Rack Line Capture",
+      zone: "D",
+      isActive: true,
+      usageType: "STORAGE",
+      warehouseId: warehouse.id,
+    },
+    select: { id: true },
+  });
+
+  await prisma.location.create({
+    data: {
+      code: `STAGING-${FIXTURE.warehouseCode}`,
+      name: "Staging Line Capture",
+      zone: "STG",
+      isActive: true,
+      usageType: "STAGING",
+      warehouseId: warehouse.id,
+    },
+    select: { id: true },
+  });
+
+  const baseProduct = await prisma.product.create({
+    data: {
+      sku: FIXTURE.baseSku,
+      referenceCode: FIXTURE.baseReference,
+      name: FIXTURE.baseName,
+      type: "HOSE",
+      brand: "SCMayher",
+      subcategory: "Comercial",
+    },
+    select: { id: true, sku: true },
+  });
+
+  const equivalentProduct = await prisma.product.create({
+    data: {
+      sku: FIXTURE.equivalentSku,
+      referenceCode: FIXTURE.equivalentReference,
+      name: FIXTURE.equivalentName,
+      type: "HOSE",
+      brand: "SCMayher",
+      subcategory: "Comercial",
+    },
+    select: { id: true, sku: true },
+  });
+
+  const customer = await prisma.customer.create({
+    data: {
+      code: FIXTURE.customerCode,
+      name: FIXTURE.customerName,
+      isActive: true,
+    },
+    select: { id: true, code: true, name: true },
+  });
+
+  await prisma.inventory.createMany({
+    data: [
+      {
+        productId: baseProduct.id,
+        locationId: location.id,
+        quantity: 18,
+        reserved: 0,
+        available: 18,
+      },
+      {
+        productId: equivalentProduct.id,
+        locationId: location.id,
+        quantity: 9,
+        reserved: 0,
+        available: 9,
+      },
+    ],
+  });
+
+  await prisma.productEquivalence.create({
+    data: {
+      productId: baseProduct.id,
+      equivProductId: equivalentProduct.id,
+      basisNorm: "DN16",
+      sourceSheet: "E2E",
+      notes: "Fixture line capture",
+      active: true,
+    },
+  });
+
+  return {
+    warehouseId: warehouse.id,
+    warehouseCode: warehouse.code,
+    baseProductId: baseProduct.id,
+    baseSku: baseProduct.sku,
+    customerId: customer.id,
+    customerCode: customer.code,
+    customerName: customer.name,
+  };
+}
+
+test.describe.serial("product aware line capture", () => {
+  let fixture: Awaited<ReturnType<typeof seedFixtures>>;
+
+  test.beforeAll(async () => {
+    fixture = await seedFixtures();
+  });
+
+  test.afterAll(async () => {
+    await cleanupFixtures();
+    await prisma.$disconnect();
+  });
+
+  test("catalog handoff renders an editable line draft and persists it on submit", async ({ page }) => {
+    await loginAs(page, "SALES_EXECUTIVE", `/catalog/${fixture.baseProductId}`);
+    await page.goto(`/catalog/${fixture.baseProductId}`);
+
+    await page.getByRole("link", { name: new RegExp(`Crear pedido con ${FIXTURE.baseName}`, "i") }).click();
+    await expect(page).toHaveURL(/\/production\/requests\/new\?.*productId=/);
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
+    await expect(page.getByLabel(/Cantidad sugerida/i)).toHaveValue("1");
+    await expect(page.getByLabel(/Notas de la línea/i)).toBeVisible();
+    await expect(page.locator("form").getByText(FIXTURE.baseSku).first()).toBeVisible();
+    await expect(page.getByText(/Acción sugerida:/i)).toBeVisible();
+
+    await page.getByLabel(/Cantidad sugerida/i).fill("3");
+    await page.getByLabel(/Notas de la línea/i).fill("Línea inicial persistida");
+
+    await page.getByLabel(/Selecciona o crea el cliente/i).fill(FIXTURE.customerName);
+    await expect(page.getByRole("button", { name: new RegExp(FIXTURE.customerCode, "i") })).toBeVisible();
+    await page.getByRole("button", { name: new RegExp(FIXTURE.customerCode, "i") }).click();
+    await expect(page.locator('input[type="hidden"][name="customerId"]')).toHaveValue(fixture.customerId);
+
+    await page.locator('select[name="warehouseId"]').selectOption(fixture.warehouseId);
+    await page.locator('input[name="dueDate"]').fill("2026-06-25");
+
+    await page.getByRole("button", { name: /Crear pedido/i }).click();
+    await expect(page).toHaveURL(/\/production\/requests\/.+\?ok=/);
+    await expect(page.getByRole("heading", { name: /Productos independientes/i })).toBeVisible();
+    await expect(page.getByText(FIXTURE.baseSku)).toBeVisible();
+    await expect(page.getByText("Línea inicial persistida")).toBeVisible();
+    await expect(page.getByText(/3\s+unidad/i)).toBeVisible();
+  });
+
+  test("invalid product context keeps manual capture available", async ({ page }) => {
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests/new?productId=missing-product&sku=BAD-SKU&source=catalog");
+    await page.goto("/production/requests/new?productId=missing-product&sku=BAD-SKU&source=catalog");
+
+    await expect(page.getByRole("heading", { name: /Nuevo pedido comercial/i })).toBeVisible();
+    await expect(page.getByText(/No encontramos el producto seleccionado/i)).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toHaveCount(0);
+    await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/sales-commercial-flow.spec.ts
+++ b/tests/e2e/sales-commercial-flow.spec.ts
@@ -76,17 +76,37 @@ test.describe("sales commercial flow", () => {
       page.getByRole("heading", { name: /Pedidos comerciales/i }),
     ).toBeVisible();
     await expect(
-      page.getByText("Accesos comerciales", { exact: true }),
+      page.getByTestId("requests-quick-filters").getByRole("link", {
+        name: /^Mis pedidos$/,
+      }),
     ).toBeVisible();
-    await expect(page.getByText("Mis pedidos", { exact: true })).toBeVisible();
     await expect(
       page.getByText("Disponibles para asignarme", { exact: true }),
     ).toBeVisible();
     await expect(page.getByText(/Siguiente acción/i).first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /^Clientes\s/i }).first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /^Cat[aá]logo\s/i }).first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /^Disponibilidad\s/i }).first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /^Equivalencias\s/i }).first()).toBeVisible();
+    await expect(page.getByTestId("requests-quick-filters")).toBeVisible();
+    await expect(
+      page.getByTestId("requests-quick-filters").getByRole("link", {
+        name: /^Todos$/,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("requests-quick-filters").getByRole("link", {
+        name: /^Urgentes$/,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /^Vencen hoy$/i }),
+    ).toHaveCount(1);
+    await expect(page.getByText("Más filtros", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("requests-customer-filter")).toBeHidden();
+    await page.locator('[data-testid="requests-more-filters"] summary').click();
+    await expect(page.getByTestId("requests-customer-filter")).toBeVisible();
+    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /^Pedidos$/i })).toBeVisible();
+    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Clientes/i })).toBeVisible();
+    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Cat[aá]logo/i })).toHaveCount(0);
+    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Disponibilidad/i })).toHaveCount(0);
+    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Equivalencias/i })).toHaveCount(0);
     await expect(
       page.getByRole("link", { name: /\+ Nuevo pedido/i }),
     ).toBeVisible();
@@ -111,17 +131,62 @@ test.describe("sales commercial flow", () => {
     await expect(
       page.getByRole("heading", { name: /Nuevo pedido comercial/i }),
     ).toBeVisible();
-    await expect(page.getByText("Captura guiada", { exact: true })).toBeVisible();
-    await expect(page.getByText(/Paso 1 de 3/i)).toBeVisible();
-    await expect(page.getByLabel(/1\. Selecciona o crea el cliente/i)).toBeVisible();
-    await expect(page.getByText(/Confirma almacén y fecha/i)).toBeVisible();
-    await expect(page.getByText(/Completa el pedido/i)).toBeVisible();
-    await expect(
-      page.getByLabel(/Selecciona o crea el cliente/i),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
+    await expect(page.getByText(/¿No encuentras al cliente\? Regístralo/i)).toBeVisible();
+    await expect(page.getByRole("heading", { name: /2\. Datos del pedido/i })).toBeVisible();
+    await expect(page.getByLabel(/Almacén/i)).toBeVisible();
+    await expect(page.getByLabel(/Fecha compromiso/i)).toBeVisible();
+    await expect(page.getByLabel(/Notas del pedido/i)).toBeVisible();
     await expect(
       page.getByRole("button", { name: /Crear pedido/i }),
     ).toBeVisible();
+  });
+
+  test("requests page summarizes active filters compactly and exposes advanced groups", async ({
+    page,
+  }) => {
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests?queue=today&customer=ACME");
+    await page.goto("/production/requests?queue=today&customer=ACME");
+
+    await expect(
+      page.getByRole("heading", { name: /Pedidos comerciales/i }),
+    ).toBeVisible();
+    await expect(page.getByTestId("requests-active-filters")).toBeVisible();
+    await expect(page.getByTestId("requests-active-filters")).toContainText(
+      "Filtros activos:",
+    );
+    await expect(page.getByTestId("requests-active-filters")).toContainText(
+      "Cola: Vencen hoy",
+    );
+    await expect(page.getByTestId("requests-active-filters")).toContainText(
+      "Cliente: ACME",
+    );
+    await expect(
+      page.getByTestId("requests-active-filters").getByRole("link", {
+        name: /Limpiar todo/i,
+      }),
+    ).toBeVisible();
+    await page
+      .getByTestId("requests-active-filters")
+      .getByRole("link", { name: /Cliente: ACME/i })
+      .click();
+    await expect(page).toHaveURL(/\/production\/requests\?queue=today(?:&.*)?$/);
+    await expect(page).not.toHaveURL(/customer=/);
+
+    await page.locator('[data-testid="requests-more-filters"] summary').click();
+    await expect(
+      page.getByTestId("requests-more-filters").getByText("Cliente", {
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("Filtrar por cliente", { exact: true })).toBeVisible();
+    await expect(page.getByText("Estado comercial", { exact: true })).toBeVisible();
+    await expect(page.getByText("Etapa", { exact: true })).toBeVisible();
+    await expect(page.getByText("Riesgo / tiempo", { exact: true })).toBeVisible();
+    await expect(page.getByText("Operación", { exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: /^Borrador$/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /^Captura$/i })).toBeVisible();
   });
 
   test("mobile queue remains card-first and readable", async ({ page }) => {
@@ -133,7 +198,11 @@ test.describe("sales commercial flow", () => {
       page.getByRole("heading", { name: /Pedidos comerciales/i }),
     ).toBeVisible();
     await expect(page.getByText(/Siguiente acción/i).first()).toBeVisible();
-    await expect(page.getByText("Mis pedidos", { exact: true })).toBeVisible();
+    await expect(
+      page.getByTestId("requests-quick-filters").getByRole("link", {
+        name: /^Mis pedidos$/,
+      }),
+    ).toBeVisible();
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
     expect(bodyWidth).toBeLessThanOrEqual(410);
   });

--- a/tests/e2e/sales-commercial-flow.spec.ts
+++ b/tests/e2e/sales-commercial-flow.spec.ts
@@ -197,12 +197,12 @@ test.describe("sales commercial flow", () => {
     await expect(
       page.getByRole("heading", { name: /Pedidos comerciales/i }),
     ).toBeVisible();
-    await expect(page.getByText(/Siguiente acción/i).first()).toBeVisible();
     await expect(
       page.getByTestId("requests-quick-filters").getByRole("link", {
         name: /^Mis pedidos$/,
       }),
     ).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver detalle/i }).first()).toBeVisible();
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
     expect(bodyWidth).toBeLessThanOrEqual(410);
   });


### PR DESCRIPTION
## Summary

This PR rebuilds Batch 4B cleanly after the customer-service schema drift fix. It improves commercial workflow hierarchy without adding Batch 4C compact-card work or product-aware persistence changes.

## Key changes

* Simplifies /production/requests/new into one guided commercial form.
* Reframes /catalog/[id] as a decision-first product screen.
* Lifts next action and state summary on /production/requests/[id].
* Preserves existing customer and product-aware handoff behavior.
* Excludes Batch 4C compact request cards.

## Validation

* 
pm run typecheck: pass
* 
pm run test:postgres: pass
* 
px vitest run tests/customers/customer-service.test.ts: pass
* 
px playwright test tests/e2e/product-aware-handoff.spec.ts --project=chromium: pass
* 
px playwright test tests/e2e/product-aware-line-capture.spec.ts --project=chromium: pass
* 
px playwright test tests/e2e/sales-commercial-flow.spec.ts --project=chromium: pass
* 
px playwright test tests/e2e/commercial-toolkit-flow.spec.ts --project=chromium: pass
* 
px playwright test tests/e2e/full-jira-ux-audit.spec.ts --project=chromium: pass
* 
px playwright test tests/e2e/mobile-smoke.spec.ts --project=mobile-chrome: pass
* 
px playwright test tests/e2e/a11y-smoke.spec.ts --project=accessibility: pass

## Caveats

* No route rename.
* No schema changes or migrations.
* No RBAC widening.
* No real email sending.
* Batch 4C remains separate.
* Batch 4 persistence remains separate.

## Jira

* Reference KAN-55.
* PR #50 was held/superseded due to scope drift and CI failure.
* PR #51 fixed the clean baseline PostgreSQL blocker.

## Verdict

Batch 4B commercial style and process cleanup completed.