### PR TITLE
Fix purchase MOQ lint warning

### DIFF
--- a/app/(shell)/catalog/[id]/edit/page.tsx
+++ b/app/(shell)/catalog/[id]/edit/page.tsx
@@ -47,7 +47,7 @@ async function updateProduct(id: string, formData: FormData) {
   }
 
   const base_cost = baseCostRaw ? Number(baseCostRaw.replace(",", ".")) : null;
-    const purchaseMoq = purchaseMoqRaw ? Number(purchaseMoqRaw.replace(",", ".")) : null;
+  const purchaseMoq = purchaseMoqRaw ? Number(purchaseMoqRaw.replace(",", ".")) : null;
   const price = priceRaw ? Number(priceRaw.replace(",", ".")) : null;
 
   // Resolve brand snapshot from SupplierBrand
@@ -116,6 +116,7 @@ async function updateProduct(id: string, formData: FormData) {
       imageUrl: resolvedImageUrl || null,
       subcategory,
       base_cost: Number.isFinite(base_cost ?? NaN) ? base_cost : null,
+      purchaseMoq: Number.isFinite(purchaseMoq ?? NaN) ? purchaseMoq : null,
       price: Number.isFinite(price ?? NaN) ? price : null,
       attributes: attributesRaw,
       categoryId: categoryId ?? null,


### PR DESCRIPTION
## Summary\n\nThis PR fixes the unrelated ESLint warning in pp/(shell)/catalog/[id]/edit/page.tsx by wiring purchaseMoq into the existing product update payload.\n\n## Key changes\n\n* Removes the unused purchaseMoq warning.\n* Preserves the catalog edit form and current schema.\n* Keeps the change scoped to one file.\n\n## Validation\n\n* 
pm run lint: pass\n* 
pm run typecheck: pass\n\n## Caveats\n\n* No Batch 4C files included.\n* No schema changes.\n* No RBAC changes.\n* No unrelated cleanup work included.\n\n## Verdict\n\nPurchase MOQ lint warning fixed.