### PR TITLE
Persist selected product on request creation

### DIFF
--- a/app/(shell)/production/requests/new/page.tsx
+++ b/app/(shell)/production/requests/new/page.tsx
@@ -44,6 +44,13 @@ function firstParam(value: string | string[] | undefined) {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function parsePositiveDecimal(value: string) {
+  if (!value) return null;
+  const parsed = Number(value.replace(",", "."));
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
 function getSourceLabel(source: string) {
   return SOURCE_LABELS[source] ?? "Contexto comercial";
 }
@@ -86,6 +93,9 @@ async function createSalesRequest(formData: FormData) {
   const warehouseId = String(formData.get("warehouseId") ?? "").trim();
   const dueDateRaw = String(formData.get("dueDate") ?? "").trim();
   const notes = String(formData.get("notes") ?? "").trim();
+  const lineProductId = String(formData.get("lineProductId") ?? "").trim();
+  const lineRequestedQtyRaw = String(formData.get("lineRequestedQty") ?? "").trim();
+  const lineNotes = String(formData.get("lineNotes") ?? "").trim();
 
   const parsed = salesInternalOrderCreateSchema.safeParse({
     customerId: customerId ?? undefined,
@@ -119,6 +129,29 @@ async function createSalesRequest(formData: FormData) {
     );
   }
 
+  let initialProductLine:
+    | { productId: string; requestedQty: number; notes?: string | null }
+    | null = null;
+  if (lineProductId) {
+    const lineProduct = await getProductSearchSelection(prisma, lineProductId);
+    if (lineProduct) {
+      const requestedQty = lineRequestedQtyRaw
+        ? parsePositiveDecimal(lineRequestedQtyRaw)
+        : 1;
+      if (!requestedQty) {
+        redirect(
+          `/production/requests/new?error=${encodeURIComponent("La cantidad de la línea debe ser mayor que cero")}`,
+        );
+      }
+
+      initialProductLine = {
+        productId: lineProduct.id,
+        requestedQty,
+        notes: lineNotes || null,
+      };
+    }
+  }
+
   try {
     const createPerf = startPerf(
       "action.production.requests.new.create.service",
@@ -132,6 +165,7 @@ async function createSalesRequest(formData: FormData) {
       notes: notes || null,
       requestedByUserId: ctx.user?.id ?? null,
       requestedByRoles: ctx.roles,
+      initialProductLine,
     });
     createPerf.end({ orderId: created.id });
 
@@ -196,6 +230,8 @@ export default async function NewProductionRequestPage({
   const searchQuery = firstParam(sp.q);
   const source = firstParam(sp.source);
   const equivalentProductId = firstParam(sp.equivalentProductId);
+  const quantity = parsePositiveDecimal(firstParam(sp.quantity)) ?? 1;
+  const lineNotes = firstParam(sp.notes);
   const displayQuery = searchQuery || sku;
 
   const selectedProduct = productId
@@ -295,6 +331,12 @@ export default async function NewProductionRequestPage({
                           <span className="text-slate-400">Stock disponible:</span>{" "}
                           {selectedProduct.totalAvailable.toLocaleString("es-MX")}
                         </p>
+                        {selectedProduct.unitLabel ? (
+                          <p>
+                            <span className="text-slate-400">Unidad:</span>{" "}
+                            {selectedProduct.unitLabel}
+                          </p>
+                        ) : null}
                       </div>
                     </div>
                     <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4 text-sm text-cyan-50">
@@ -302,8 +344,8 @@ export default async function NewProductionRequestPage({
                         Siguiente acción
                       </p>
                       <p className="mt-2">
-                        Confirma el cliente y continúa el pedido con esta
-                        referencia comercial.
+                        Confirma el cliente y guarda esta referencia como la
+                        primera línea editable del pedido.
                       </p>
                     </div>
                   </div>
@@ -415,15 +457,21 @@ export default async function NewProductionRequestPage({
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
                     <h2 className="text-lg font-semibold text-white">
-                      2. Contexto del producto
+                      2. Línea sugerida
                     </h2>
                     <p className="text-sm text-slate-300">
-                      El producto seleccionado acompaña la captura comercial y
-                      sirve como referencia para continuar el pedido.
+                      El producto seleccionado puede guardarse como la primera
+                      línea editable del pedido.
                     </p>
                   </div>
-                  <Badge variant="accent">Referencia</Badge>
+                  <Badge variant="accent">Editable</Badge>
                 </div>
+
+                <input
+                  type="hidden"
+                  name="lineProductId"
+                  value={selectedProduct.id}
+                />
 
                 <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.7fr)_minmax(0,1fr)]">
                   <div className="rounded-xl border border-white/10 bg-white/5 p-4">
@@ -438,17 +486,56 @@ export default async function NewProductionRequestPage({
                         <span className="text-slate-400">SKU:</span>{" "}
                         <span className="font-mono">{selectedProduct.sku}</span>
                       </p>
+                      {selectedProduct.unitLabel ? (
+                        <p>
+                          <span className="text-slate-400">Unidad:</span>{" "}
+                          {selectedProduct.unitLabel}
+                        </p>
+                      ) : null}
                       <p>
                         <span className="text-slate-400">Fuente:</span>{" "}
                         {sourceLabel}
                       </p>
                       <p>
                         <span className="text-slate-400">Acción sugerida:</span>{" "}
-                        Continúa con el cliente y el detalle del pedido.
+                        Guarda el pedido para continuar con el cliente y el
+                        detalle.
                       </p>
                     </div>
                   </div>
+
+                  <label className="space-y-1">
+                    <span className="text-sm text-slate-400">
+                      Cantidad sugerida
+                    </span>
+                    <input
+                      name="lineRequestedQty"
+                      type="number"
+                      min="0.0001"
+                      step="0.0001"
+                      required
+                      defaultValue={quantity}
+                      className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+                    />
+                    <p className="text-xs text-slate-500">
+                      Se convertirá en la cantidad de la primera línea editable
+                      del pedido.
+                    </p>
+                  </label>
+
+                  <label className="space-y-1">
+                    <span className="text-sm text-slate-400">
+                      Notas de la línea
+                    </span>
+                    <textarea
+                      name="lineNotes"
+                      defaultValue={lineNotes}
+                      className="min-h-[120px] w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+                      placeholder="Opcional: especificaciones, urgencia o contexto comercial"
+                    />
+                  </label>
                 </div>
+
                 <div className="flex flex-wrap gap-2">
                   <Link
                     href="#captura-cliente"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,8 +5,8 @@ Este repositorio usa PostgreSQL como base canónica de pruebas de backend.
 ## Prerrequisitos locales
 
 - Node.js 22+
-- PostgreSQL local o contenedor en `127.0.0.1:5432`
 - `DATABASE_URL` con formato `postgres://` o `postgresql://`
+- AWS Postgres como objetivo canónico de validación
 
 Ejemplo:
 
@@ -26,6 +26,15 @@ npm run db:push
 
 `env:postgres:check` valida formato/campos de `DATABASE_URL`.  
 `env:postgres:tcp` valida además conectividad TCP real al host/puerto.
+
+Vitest usa AWS Postgres con aislamiento por esquema como ruta canónica de prueba:
+
+```bash
+npx vitest run tests/sales-request-service.test.ts
+npm run test:postgres -- tests/sales-request-service.test.ts
+```
+
+Ambos comandos resuelven el mismo backend Postgres aislado. El wrapper `npm run test:postgres` sigue siendo la ruta preferida para baterías grandes o ejecuciones repetibles.
 
 ## Suites principales
 
@@ -96,8 +105,8 @@ Si faltan credenciales de auth, `smoke:web` reporta `SKIPPED` explícito y no de
 
 ## Evidencia mínima reproducible
 
-- Local PostgreSQL:
-  - `env:postgres:check`, `env:postgres:tcp`, `prisma:*`, `db:push`, `test:regression:postgres`, `build`.
+- AWS Postgres:
+  - `env:postgres:check`, `env:postgres:tcp`, `prisma:*`, `db:push`, `test:postgres`, `test:regression:postgres`, `build`.
 - CI:
   - `Quality Gate (required)` con el orden definido en `.github/workflows/ci.yml`.
 - Deploy DEV web:
@@ -108,13 +117,16 @@ Nota de alcance: `mobile staging` es un entorno intermedio móvil útil para su 
 ## Troubleshooting
 
 - Error `DATABASE_URL es requerido`:
-  - Define `DATABASE_URL` antes de correr pruebas.
+  - Define `DATABASE_URL` antes de correr pruebas, o usa `npm run test:postgres` para dejar que el wrapper resuelva el backend autorizado.
 - Error `DATABASE_URL debe iniciar con postgres://`:
   - Corrige el scheme.
 - Error de conexión TCP:
   - Verifica que PostgreSQL esté activo y escuchando en `host:port` del `DATABASE_URL`.
 - Error de schema mismatch:
   - Ejecuta `npm run db:push` después de `prisma:generate`.
+- Si `npx vitest run ...` parece usar un esquema viejo:
+  - Verifica que no haya una ejecución manual apuntando a una base local.
+  - El setup de Vitest ahora resuelve el backend AWS Postgres y aplica aislamiento por esquema salvo que se pida SQLite explícitamente.
 
 ### Cobertura KAN-53 (regresión PostgreSQL)
 

--- a/lib/product-search.ts
+++ b/lib/product-search.ts
@@ -5,6 +5,7 @@ export type ProductSearchCandidate = {
   sku: string;
   referenceCode: string | null;
   name: string;
+  unitLabel?: string | null;
   brand: string | null;
   description: string | null;
   type: string;
@@ -108,6 +109,7 @@ function buildDefaultProductSearchSelect(warehouseId?: string) {
     sku: true,
     referenceCode: true,
     name: true,
+    unitLabel: true,
     brand: true,
     description: true,
     type: true,

--- a/lib/sales/request-service.ts
+++ b/lib/sales/request-service.ts
@@ -17,6 +17,12 @@ type ProductLineInput = {
   notes?: string | null;
 };
 
+type InitialProductLineInput = {
+  productId: string;
+  requestedQty: number;
+  notes?: string | null;
+};
+
 type AssemblyLineInput = {
   orderId: string;
   warehouseId: string;
@@ -442,6 +448,84 @@ async function rebuildDraftProductPickList(tx: Tx, prisma: PrismaClient, orderId
   return pickList;
 }
 
+function assertValidRequestedQty(requestedQty: number) {
+  if (!Number.isFinite(requestedQty) || requestedQty <= 0) {
+    throw new InventoryServiceError("INVALID_QTY", "La cantidad solicitada debe ser mayor que cero");
+  }
+}
+
+function isInventoryServiceError(error: unknown, code: string) {
+  return error instanceof InventoryServiceError && error.code === code;
+}
+
+async function createSalesRequestProductLineInTx(
+  tx: Tx,
+  prisma: PrismaClient,
+  input: ProductLineInput,
+) {
+  const order = await ensureEditableOrder(tx, input.orderId);
+  assertValidRequestedQty(input.requestedQty);
+
+  const product = await tx.product.findUnique({
+    where: { id: input.productId },
+    select: { id: true, sku: true, name: true },
+  });
+  if (!product) {
+    throw new InventoryServiceError("PRODUCT_NOT_FOUND", "Producto no encontrado");
+  }
+
+  const line = await tx.salesInternalOrderLine.create({
+    data: {
+      orderId: order.id,
+      lineKind: "PRODUCT",
+      productId: product.id,
+      requestedQty: input.requestedQty,
+      notes: input.notes ?? null,
+    },
+    select: { id: true },
+  });
+
+  await rebuildDraftProductPickList(tx, prisma, order.id);
+
+  await createAuditLogSafeWithDb({
+    entityType: "SALES_INTERNAL_ORDER",
+    entityId: order.id,
+    action: "ADD_PRODUCT_LINE",
+    actor: "system",
+    source: "sales/request-service",
+    after: {
+      lineId: line.id,
+      productId: product.id,
+      productSku: product.sku,
+      productName: product.name,
+      requestedQty: input.requestedQty,
+    },
+  }, tx);
+
+  return line;
+}
+
+async function tryCreateInitialSalesRequestProductLineInTx(
+  tx: Tx,
+  prisma: PrismaClient,
+  orderId: string,
+  input: InitialProductLineInput,
+) {
+  try {
+    return await createSalesRequestProductLineInTx(tx, prisma, {
+      orderId,
+      productId: input.productId,
+      requestedQty: input.requestedQty,
+      notes: input.notes ?? null,
+    });
+  } catch (error) {
+    if (isInventoryServiceError(error, "PRODUCT_NOT_FOUND")) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 export async function createSalesRequestDraftHeader(
   prisma: PrismaClient,
   args: {
@@ -453,6 +537,7 @@ export async function createSalesRequestDraftHeader(
     notes?: string | null;
     requestedByUserId?: string | null;
     requestedByRoles?: string[] | null;
+    initialProductLine?: InitialProductLineInput | null;
   }
 ) {
   const perf = startPerf("sales.create_request_draft_header");
@@ -510,6 +595,14 @@ export async function createSalesRequestDraftHeader(
     });
     createPerf.end({ orderId: created.id });
 
+    if (args.initialProductLine) {
+      await tryCreateInitialSalesRequestProductLineInTx(tx, prisma, created.id, {
+        productId: args.initialProductLine.productId,
+        requestedQty: args.initialProductLine.requestedQty,
+        notes: args.initialProductLine.notes ?? null,
+      });
+    }
+
     const auditPerf = startPerf("sales.create_request_draft_header.audit");
     await createAuditLogSafeWithDb({
       entityType: "SALES_INTERNAL_ORDER",
@@ -524,6 +617,12 @@ export async function createSalesRequestDraftHeader(
         warehouseId: args.warehouseId,
         dueDate: args.dueDate.toISOString(),
         assignedToUserId: shouldAutoAssignToRequester ? args.requestedByUserId : null,
+        initialProductLine: args.initialProductLine
+          ? {
+              productId: args.initialProductLine.productId,
+              requestedQty: args.initialProductLine.requestedQty,
+            }
+          : null,
       },
     }, tx);
     auditPerf.end();
@@ -535,35 +634,7 @@ export async function createSalesRequestDraftHeader(
 
 export async function addSalesRequestProductLine(prisma: PrismaClient, input: ProductLineInput) {
   return prisma.$transaction(async (tx) => {
-    const order = await ensureEditableOrder(tx, input.orderId);
-
-    const line = await tx.salesInternalOrderLine.create({
-      data: {
-        orderId: order.id,
-        lineKind: "PRODUCT",
-        productId: input.productId,
-        requestedQty: input.requestedQty,
-        notes: input.notes ?? null,
-      },
-      select: { id: true },
-    });
-
-    await rebuildDraftProductPickList(tx, prisma, order.id);
-
-    await createAuditLogSafeWithDb({
-      entityType: "SALES_INTERNAL_ORDER",
-      entityId: order.id,
-      action: "ADD_PRODUCT_LINE",
-      actor: "system",
-      source: "sales/request-service",
-      after: {
-        lineId: line.id,
-        productId: input.productId,
-        requestedQty: input.requestedQty,
-      },
-    }, tx);
-
-    return line;
+    return createSalesRequestProductLineInTx(tx, prisma, input);
   });
 }
 

--- a/tests/e2e/product-aware-handoff.spec.ts
+++ b/tests/e2e/product-aware-handoff.spec.ts
@@ -14,10 +14,21 @@ const FIXTURE = {
   equivalentSku: "E2E-HANDOFF-EQUIV-SKU",
   equivalentReference: "E2E-HANDOFF-EQUIV-REF",
   equivalentName: "Manguera Handoff Alterna",
+  customerCode: "E2E-HANDOFF-CUST",
+  customerName: "Cliente Handoff E2E",
 };
 
 async function cleanupFixtures() {
-  const [products, warehouses, locations] = await Promise.all([
+  const [customers, products, warehouses, locations] = await Promise.all([
+    prisma.customer.findMany({
+      where: {
+        OR: [
+          { code: FIXTURE.customerCode },
+          { name: FIXTURE.customerName },
+        ],
+      },
+      select: { id: true },
+    }),
     prisma.product.findMany({
       where: {
         sku: {
@@ -36,9 +47,17 @@ async function cleanupFixtures() {
     }),
   ]);
 
+  const customerIds = customers.map((customer) => customer.id);
   const productIds = products.map((product) => product.id);
   const warehouseIds = warehouses.map((warehouse) => warehouse.id);
   const locationIds = locations.map((location) => location.id);
+
+  if (customerIds.length > 0) {
+    await prisma.salesInternalOrder.deleteMany({
+      where: { customerId: { in: customerIds } },
+    });
+    await prisma.customer.deleteMany({ where: { id: { in: customerIds } } });
+  }
 
   if (productIds.length > 0) {
     await prisma.productEquivalence.deleteMany({
@@ -118,6 +137,15 @@ async function seedFixtures() {
     select: { id: true, sku: true },
   });
 
+  const customer = await prisma.customer.create({
+    data: {
+      code: FIXTURE.customerCode,
+      name: FIXTURE.customerName,
+      isActive: true,
+    },
+    select: { id: true },
+  });
+
   await prisma.inventory.createMany({
     data: [
       {
@@ -149,10 +177,12 @@ async function seedFixtures() {
   });
 
   return {
+    warehouseId: warehouse.id,
     baseProductId: baseProduct.id,
     baseSku: baseProduct.sku,
     equivalentProductId: equivalentProduct.id,
     equivalentSku: equivalentProduct.sku,
+    customerId: customer.id,
   };
 }
 
@@ -234,6 +264,30 @@ test.describe.serial("product aware handoff", () => {
     await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
     await expect(page.getByRole("link", { name: /Cambiar producto/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Quitar selección/i }).first()).toBeVisible();
+  });
+
+  test("a selected product can be removed before submit and the request still saves", async ({ page }) => {
+    await loginAs(page, "SALES_EXECUTIVE", `/catalog/${fixture.baseProductId}`);
+    await page.goto(`/catalog/${fixture.baseProductId}`);
+
+    await page.getByRole("link", { name: new RegExp(`Crear pedido con ${FIXTURE.baseName}`, "i") }).click();
+    await expect(page).toHaveURL(/\/production\/requests\/new\?.*productId=/);
+    await page.getByRole("link", { name: /Quitar selección/i }).first().click();
+    await expect(page).toHaveURL(/\/production\/requests\/new(?:\?.*)?$/);
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toHaveCount(0);
+
+    await page.getByLabel(/Selecciona o crea el cliente/i).fill(FIXTURE.customerName);
+    await expect(page.getByRole("button", { name: new RegExp(FIXTURE.customerCode, "i") })).toBeVisible();
+    await page.getByRole("button", { name: new RegExp(FIXTURE.customerCode, "i") }).click();
+
+    await page.locator('select[name="warehouseId"]').selectOption(fixture.warehouseId);
+    await page.locator('input[name="dueDate"]').fill("2026-06-25");
+    await page.getByRole("button", { name: /Crear pedido/i }).click();
+
+    await expect(page).toHaveURL(/\/production\/requests\/.+\?ok=/);
+    await expect(page.getByRole("heading", { name: /Productos independientes/i })).toBeVisible();
+    await expect(page.getByText(FIXTURE.baseSku)).toHaveCount(0);
+    await expect(page.getByText(/Todavia no hay productos independientes en este pedido/i)).toBeVisible();
   });
 
   test("manager can use the handoff and mobile layout remains usable", async ({ page }) => {

--- a/tests/e2e/product-aware-line-capture.spec.ts
+++ b/tests/e2e/product-aware-line-capture.spec.ts
@@ -215,7 +215,7 @@ test.describe.serial("product aware line capture", () => {
     await prisma.$disconnect();
   });
 
-  test("catalog handoff renders a commercial reference panel and allows manual submission", async ({ page }) => {
+  test("catalog handoff renders an editable line draft and persists it on submit", async ({ page }) => {
     await loginAs(page, "SALES_EXECUTIVE", `/catalog/${fixture.baseProductId}`);
     await page.goto(`/catalog/${fixture.baseProductId}`);
 
@@ -223,11 +223,13 @@ test.describe.serial("product aware line capture", () => {
     await expect(page).toHaveURL(/\/production\/requests\/new\?.*productId=/);
     await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
     await expect(page.getByText("Producto de referencia", { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toBeVisible();
+    await expect(page.getByLabel(/Cantidad sugerida/i)).toHaveValue("1");
+    await expect(page.getByLabel(/Notas de la línea/i)).toBeVisible();
     await expect(page.locator("form").getByText(FIXTURE.baseSku).first()).toBeVisible();
     await expect(page.getByText(/Acción sugerida:/i)).toBeVisible();
-    await expect(page.getByRole("link", { name: /Continuar con este producto/i }).first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /Cambiar producto/i }).first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /Quitar selección/i }).first()).toBeVisible();
+
+    await page.getByLabel(/Notas de la línea/i).fill("Línea inicial persistida");
 
     await page.getByLabel(/Selecciona o crea el cliente/i).fill(FIXTURE.customerName);
     await expect(page.getByRole("button", { name: new RegExp(FIXTURE.customerCode, "i") })).toBeVisible();
@@ -239,7 +241,32 @@ test.describe.serial("product aware line capture", () => {
 
     await page.getByRole("button", { name: /Crear pedido/i }).click();
     await expect(page).toHaveURL(/\/production\/requests\/.+\?ok=/);
-    await expect(page.getByRole("heading", { name: /Pedido comercial/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Productos independientes/i })).toBeVisible();
+    await expect(page.getByText(FIXTURE.baseSku)).toBeVisible();
+    await expect(page.getByText("Línea inicial persistida")).toBeVisible();
+    await expect(page.getByText(/1\s+unidad/i)).toBeVisible();
+  });
+
+  test("manual request creation without product context still works", async ({ page }) => {
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests/new");
+    await page.goto("/production/requests/new");
+
+    await expect(page.getByRole("heading", { name: /Nuevo pedido comercial/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toHaveCount(0);
+
+    await page.getByLabel(/Selecciona o crea el cliente/i).fill(FIXTURE.customerName);
+    await expect(page.getByRole("button", { name: new RegExp(FIXTURE.customerCode, "i") })).toBeVisible();
+    await page.getByRole("button", { name: new RegExp(FIXTURE.customerCode, "i") }).click();
+    await expect(page.locator('input[type="hidden"][name="customerId"]')).toHaveValue(fixture.customerId);
+
+    await page.locator('select[name="warehouseId"]').selectOption(fixture.warehouseId);
+    await page.locator('input[name="dueDate"]').fill("2026-06-25");
+    await page.getByRole("button", { name: /Crear pedido/i }).click();
+
+    await expect(page).toHaveURL(/\/production\/requests\/.+\?ok=/);
+    await expect(page.getByRole("heading", { name: /Productos independientes/i })).toBeVisible();
+    await expect(page.getByText(FIXTURE.baseSku)).toHaveCount(0);
+    await expect(page.getByText(/Todavia no hay productos independientes en este pedido/i)).toBeVisible();
   });
 
   test("invalid product context keeps manual capture available", async ({ page }) => {
@@ -249,6 +276,7 @@ test.describe.serial("product aware line capture", () => {
     await expect(page.getByRole("heading", { name: /Nuevo pedido comercial/i })).toBeVisible();
     await expect(page.getByText(/No encontramos el producto seleccionado/i)).toBeVisible();
     await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Línea sugerida/i })).toHaveCount(0);
     await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
   });
 });

--- a/tests/sales-request-service.test.ts
+++ b/tests/sales-request-service.test.ts
@@ -220,6 +220,103 @@ describe("sales request service", () => {
     expect(inventoryB?.available).toBe(5);
   });
 
+  it("creates the request header and initial product line atomically when a product draft is provided", async () => {
+    const { warehouse, productA } = await createRequestFixture();
+
+    const created = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente con línea inicial",
+      warehouseId: warehouse.id,
+      dueDate: new Date("2026-04-30T00:00:00.000Z"),
+      notes: "Pedido con línea sugerida",
+      initialProductLine: {
+        productId: productA.id,
+        requestedQty: 2,
+        notes: "Línea comercial inicial",
+      },
+    });
+
+    const saved = await prisma.salesInternalOrder.findUnique({
+      where: { id: created.id },
+      select: {
+        id: true,
+        lines: {
+          orderBy: { createdAt: "asc" },
+          select: {
+            productId: true,
+            requestedQty: true,
+            notes: true,
+            product: { select: { sku: true } },
+          },
+        },
+      },
+    });
+
+    const pickList = await prisma.salesInternalOrderPickList.findFirst({
+      where: { orderId: created.id },
+      select: { id: true, status: true },
+    });
+
+    expect(saved?.lines).toHaveLength(1);
+    expect(saved?.lines[0]?.productId).toBe(productA.id);
+    expect(saved?.lines[0]?.requestedQty).toBe(2);
+    expect(saved?.lines[0]?.notes).toBe("Línea comercial inicial");
+    expect(saved?.lines[0]?.product?.sku).toBe("SKU-SURT-01");
+    expect(pickList?.status).toBe("DRAFT");
+  });
+
+  it("keeps header-only creation valid when no initial product is provided", async () => {
+    const { warehouse } = await createRequestFixture();
+
+    const created = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente sin línea inicial",
+      warehouseId: warehouse.id,
+      dueDate: new Date("2026-04-30T00:00:00.000Z"),
+      notes: "Pedido manual",
+    });
+
+    const saved = await prisma.salesInternalOrder.findUnique({
+      where: { id: created.id },
+      select: {
+        id: true,
+        lines: {
+          select: { id: true },
+        },
+      },
+    });
+
+    expect(saved?.id).toBe(created.id);
+    expect(saved?.lines).toHaveLength(0);
+  });
+
+  it("falls back to header-only creation when the initial product context cannot be resolved", async () => {
+    const { warehouse } = await createRequestFixture();
+
+    const created = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente con contexto inválido",
+      warehouseId: warehouse.id,
+      dueDate: new Date("2026-04-30T00:00:00.000Z"),
+      notes: "Pedido con fallback seguro",
+      initialProductLine: {
+        productId: "missing-product-id",
+        requestedQty: 1,
+        notes: "No debe bloquear la captura manual",
+      },
+    });
+
+    const saved = await prisma.salesInternalOrder.findUnique({
+      where: { id: created.id },
+      select: {
+        id: true,
+        lines: {
+          select: { id: true },
+        },
+      },
+    });
+
+    expect(saved?.id).toBe(created.id);
+    expect(saved?.lines).toHaveLength(0);
+  });
+
   it("releases reserved shortfall when a direct pick task is confirmed as partial", async () => {
     const { order, productA, storageA, staging } = await createRequestFixture();
 

--- a/tests/setup/postgres-worker-isolation.ts
+++ b/tests/setup/postgres-worker-isolation.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { PrismaClient } from "@prisma/client";
 
@@ -23,6 +24,61 @@ function withSchema(url: string, schema: string): string {
   return parsed.toString();
 }
 
+function isPostgresUrl(value: string) {
+  return /^postgres(ql)?:\/\//i.test(value);
+}
+
+function readAuthoritativeDatabaseUrl(repoRoot: string) {
+  const envFilePath = path.join(repoRoot, ".env");
+  try {
+    const contents = readFileSync(envFilePath, "utf8");
+    for (const rawLine of contents.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith("#")) continue;
+      if (!/^DATABASE_URL\s*=/.test(line)) continue;
+      const [, rawValue = ""] = line.split("=", 2);
+      const normalized = rawValue.trim().replace(/^["']|["']$/g, "");
+      if (isPostgresUrl(normalized)) {
+        return normalized;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function bootstrapPostgresTestDefaults() {
+  if (process.env.RUN_SQLITE_TESTS === "1") {
+    return false;
+  }
+
+  if (process.env.RUN_POSTGRES_TESTS !== "1") {
+    process.env.RUN_POSTGRES_TESTS = "1";
+  }
+
+  if (process.env.WMS_TEST_ISOLATION !== "worker-schema") {
+    process.env.WMS_TEST_ISOLATION = "worker-schema";
+  }
+
+  const currentDatabaseUrl = String(process.env.DATABASE_URL ?? "").trim();
+  if (isPostgresUrl(currentDatabaseUrl)) {
+    return true;
+  }
+
+  const repoRoot = path.resolve(__dirname, "..", "..");
+  const authoritativeDatabaseUrl = readAuthoritativeDatabaseUrl(repoRoot);
+  if (!authoritativeDatabaseUrl) {
+    throw new Error(
+      "No se pudo resolver una DATABASE_URL PostgreSQL autorizada. Usa npm run test:postgres o define DATABASE_URL a AWS Postgres.",
+    );
+  }
+
+  process.env.DATABASE_URL = authoritativeDatabaseUrl;
+  return true;
+}
+
 async function ensureSchemaExists(adminUrl: string, schema: string) {
   const prisma = new PrismaClient({
     datasources: { db: { url: adminUrl } },
@@ -36,6 +92,7 @@ async function ensureSchemaExists(adminUrl: string, schema: string) {
 }
 
 async function setupWorkerSchemaIsolation() {
+  if (!bootstrapPostgresTestDefaults()) return;
   if (process.env.RUN_POSTGRES_TESTS !== "1") return;
   if (process.env.WMS_TEST_ISOLATION !== "worker-schema") return;
 


### PR DESCRIPTION
## Summary
This PR includes:

1. Batch 5 product-aware request line persistence.
2. AWS-only DB validation hardening required to remove stale local/SQLite drift.

## Product-aware behavior
- Valid selected product context persists as the first editable `SalesInternalOrderLine`.
- Requested quantity defaults to `1`.
- Notes carry through when provided.
- Missing or invalid product context falls back to header-only creation.
- Manual detail-page add-line flow remains unchanged.
- Unit remains display-only.
- No schema changes.
- No migrations.

## DB validation behavior
- AWS Postgres is the canonical normal validation target.
- Bare Vitest service tests use AWS Postgres worker-schema isolation.
- `npm run test:postgres` uses the same authoritative path.
- The stale SQLite runner was removed.
- Localhost fallback was removed from Prisma helpers.
- No local PostgreSQL data was deleted.
- Install-time placeholder remains non-local and is only for no-secret `npm install` compatibility.

## Validation
- `npm run env:postgres:check` ✅
- `npm run env:postgres:tcp` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npx prisma validate` ✅
- `npx prisma generate` ✅
- `npx vitest run tests/sales-request-service.test.ts` ✅
- `npm run test:postgres` ✅
- `npx playwright test tests/e2e/product-aware-line-capture.spec.ts --project=chromium` ✅
- `npx playwright test tests/e2e/product-aware-handoff.spec.ts --project=chromium` ✅

## Caveats
- No unit persistence.
- No schema changes.
- No migrations.
- No RBAC widening.
- No route rename.
- No purchasing, inventory, PDF, or email changes.