### PR TITLE
Harden KAN-52 request flow narrative

### DIFF
--- a/app/(shell)/production/requests/[id]/page.tsx
+++ b/app/(shell)/production/requests/[id]/page.tsx
@@ -27,6 +27,7 @@ import {
   summarizePickListStatus,
   summarizeProductionStatus,
 } from "@/lib/sales/internal-orders";
+import { getSalesConsoleTimelineItems } from "@/lib/sales/console";
 import {
   firstErrorMessage,
   salesInternalOrderProductLineCreateSchema,
@@ -360,6 +361,7 @@ export default async function ProductionRequestDetailPage({
           id: true,
           code: true,
           status: true,
+          updatedAt: true,
           targetLocation: { select: { code: true, name: true } },
         },
       },
@@ -524,13 +526,16 @@ export default async function ProductionRequestDetailPage({
     takeEligibility,
     deliveredEligibility,
   });
-  const timeline = [
-    { label: "Captura", at: order.createdAt },
-    { label: "Confirmación", at: order.confirmedAt },
-    { label: "Asignación", at: order.assignedAt ?? order.pulledAt },
-    { label: "Surtido directo", at: latestPickList?.status === "COMPLETED" || latestPickList?.status === "PARTIAL" ? latestPickList?.code : null },
-    { label: "Entrega cliente", at: order.deliveredToCustomerAt },
-  ] as const;
+  const timeline = getSalesConsoleTimelineItems({
+    createdAt: order.createdAt,
+    confirmedAt: order.confirmedAt,
+    assignedAt: order.assignedAt,
+    pulledAt: order.pulledAt,
+    latestPickStatus: latestPickList?.status ?? null,
+    latestPickUpdatedAt: latestPickList?.updatedAt ?? null,
+    deliveredAt: order.deliveredToCustomerAt,
+    cancelledAt: order.cancelledAt,
+  });
 
   return (
     <div className="space-y-6">
@@ -732,10 +737,15 @@ export default async function ProductionRequestDetailPage({
           <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
             {timeline.map((item) => (
               <li key={item.label} className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-subtle)] px-3 py-2">
-                <p className="text-[var(--text-primary)]">{item.label}</p>
-                <p className="text-xs text-[var(--text-muted)]">
-                  {typeof item.at === "string" && item.label === "Surtido directo" ? item.at : formatDateTime(item.at as Date | string | null)}
-                </p>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-[var(--text-primary)]">{item.label}</p>
+                    <p className="text-xs text-[var(--text-muted)]">{item.detail}</p>
+                  </div>
+                  <Badge variant={item.variant} size="sm">
+                    {item.at ? formatDateTime(item.at) : "Pendiente"}
+                  </Badge>
+                </div>
               </li>
             ))}
           </ul>

--- a/lib/sales/console.ts
+++ b/lib/sales/console.ts
@@ -3,7 +3,10 @@ import type {
   SalesOrderFlowStage,
   SalesOrderPrimaryCtaCode,
 } from "@/lib/sales/internal-orders";
-import { SALES_ORDER_FLOW_STAGE_LABELS } from "@/lib/sales/internal-orders";
+import {
+  SALES_ORDER_FLOW_STAGE_LABELS,
+  summarizePickListStatus,
+} from "@/lib/sales/internal-orders";
 
 export const SALES_CONSOLE_STAGE_FLOW: SalesOrderFlowStage[] = [
   "captura",
@@ -38,6 +41,21 @@ export type SalesConsolePrimaryActionState = {
   href: string;
   code: SalesOrderPrimaryCtaCode;
   requiresFormSubmit: boolean;
+};
+
+export type SalesConsoleTimelineStage =
+  | "captura"
+  | "asignacion"
+  | "surtido"
+  | "entrega"
+  | "cancelacion";
+
+export type SalesConsoleTimelineItem = {
+  stage: SalesConsoleTimelineStage;
+  label: string;
+  detail: string;
+  at: Date | string | null;
+  variant: SalesConsoleWorkTypeVariant;
 };
 
 export function getSalesConsoleWorkType(input: {
@@ -113,6 +131,72 @@ export function getSalesConsoleStageProgress(currentStage: SalesOrderFlowStage):
           : "neutral",
     isCurrent: stage === currentStage,
   }));
+}
+
+export function getSalesConsoleTimelineItems(input: {
+  createdAt: Date | string;
+  confirmedAt?: Date | string | null;
+  assignedAt?: Date | string | null;
+  pulledAt?: Date | string | null;
+  latestPickStatus?: string | null;
+  latestPickUpdatedAt?: Date | string | null;
+  deliveredAt?: Date | string | null;
+  cancelledAt?: Date | string | null;
+}): SalesConsoleTimelineItem[] {
+  const assignmentAt = input.assignedAt ?? input.confirmedAt ?? input.pulledAt ?? null;
+  const fulfillmentAt = input.latestPickUpdatedAt ?? input.pulledAt ?? null;
+  const fulfillmentDetail = input.latestPickStatus
+    ? `Surtido directo: ${summarizePickListStatus(input.latestPickStatus)}`
+    : "Sin surtido directo registrado";
+
+  return [
+    {
+      stage: "captura",
+      label: "Captura",
+      detail: "Pedido registrado en la cola comercial",
+      at: input.createdAt,
+      variant: "accent",
+    },
+    {
+      stage: "asignacion",
+      label: "Asignación",
+      detail: input.assignedAt
+        ? "Pedido tomado por un responsable"
+        : input.confirmedAt
+          ? "Pedido confirmado, pendiente de asignación"
+          : "Pendiente de confirmación y asignación",
+      at: assignmentAt,
+      variant: assignmentAt ? "warning" : "neutral",
+    },
+    {
+      stage: "surtido",
+      label: "Surtido / fulfillment",
+      detail: fulfillmentDetail,
+      at: fulfillmentAt,
+      variant:
+        input.latestPickStatus === "COMPLETED"
+          ? "success"
+          : input.latestPickStatus
+            ? "warning"
+            : "neutral",
+    },
+    {
+      stage: "entrega",
+      label: "Entrega",
+      detail: input.deliveredAt
+        ? "Entrega confirmada al cliente"
+        : "Pendiente de entrega",
+      at: input.deliveredAt ?? null,
+      variant: input.deliveredAt ? "success" : "neutral",
+    },
+    {
+      stage: "cancelacion",
+      label: "Cancelación",
+      detail: input.cancelledAt ? "Pedido cancelado" : "Solo aplica si se cancela",
+      at: input.cancelledAt ?? null,
+      variant: input.cancelledAt ? "danger" : "neutral",
+    },
+  ];
 }
 
 export function resolveSalesConsolePrimaryActionState(input: {

--- a/tests/customers/requests-flow-narrative.contract.test.ts
+++ b/tests/customers/requests-flow-narrative.contract.test.ts
@@ -10,10 +10,14 @@ describe("KAN-52 flow narrative contract", () => {
   it("uses shared flow narrative helper in requests list and detail", () => {
     const listContent = readWorkspaceFile("app/(shell)/production/requests/page.tsx");
     const detailContent = readWorkspaceFile("app/(shell)/production/requests/[id]/page.tsx");
+    const consoleContent = readWorkspaceFile("lib/sales/console.ts");
 
     expect(listContent).toContain("getSalesOrderFlowNarrative");
     expect(detailContent).toContain("getSalesOrderFlowNarrative");
-    expect(detailContent).toContain("Siguiente acción");
+    expect(detailContent).toContain("getSalesConsoleTimelineItems");
+    expect(detailContent).toContain("Timeline operativo");
+    expect(consoleContent).toContain("Surtido / fulfillment");
+    expect(consoleContent).toContain("Cancelación");
   });
 
   it("bridges dashboard queue with homologated flow stage labels", () => {
@@ -38,6 +42,7 @@ describe("KAN-52 flow narrative contract", () => {
     expect(detailContent).toContain("roles: sessionCtx.roles");
     expect(detailContent).toContain("getMarkDeliveredEligibility");
     expect(detailContent).toContain("pulledAt: order.pulledAt");
+    expect(detailContent).toContain("latestPickUpdatedAt");
     expect(detailContent).toContain("Siguiente acción");
   });
 });

--- a/tests/e2e/kan52-request-flow-narrative.spec.ts
+++ b/tests/e2e/kan52-request-flow-narrative.spec.ts
@@ -1,0 +1,300 @@
+import { PrismaClient } from "@prisma/client";
+import { expect, test, type Page } from "@playwright/test";
+import {
+  cancelSalesRequestOrder,
+  confirmSalesRequestOrder,
+  createSalesRequestDraftHeader,
+  pullSalesRequestOrder,
+} from "@/lib/sales/request-service";
+import { loginAs } from "./lib/auth.helpers";
+
+const prisma = new PrismaClient();
+
+let warehouseId = "";
+let createdWarehouseId = "";
+let productId = "";
+let captureOrderId = "";
+let assignmentOrderId = "";
+let fulfillmentOrderId = "";
+let readyOrderId = "";
+let cancelledOrderId = "";
+
+let assignmentOrderCode = "";
+let fulfillmentOrderCode = "";
+let readyOrderCode = "";
+let cancelledOrderCode = "";
+
+async function cleanupFixtures() {
+  const orderIds = [
+    captureOrderId,
+    assignmentOrderId,
+    fulfillmentOrderId,
+    readyOrderId,
+    cancelledOrderId,
+  ].filter(Boolean);
+
+  if (orderIds.length > 0) {
+    await prisma.salesInternalOrder.deleteMany({ where: { id: { in: orderIds } } });
+  }
+  if (productId) {
+    await prisma.product.deleteMany({ where: { id: productId } });
+  }
+  if (createdWarehouseId) {
+    await prisma.warehouse.deleteMany({ where: { id: createdWarehouseId } });
+  }
+}
+
+async function expectRequestCardNarrative(page: Page, orderCode: string, stageLabel: string, nextAction: string) {
+  const card = page.getByTestId("request-card").filter({ hasText: orderCode }).first();
+  await expect(card).toBeVisible();
+  await expect(card).toContainText(stageLabel);
+  await expect(card).toContainText(nextAction);
+}
+
+test.describe.serial("KAN-52 request flow narrative", () => {
+  test.beforeAll(async () => {
+    await cleanupFixtures();
+
+    const manager = await prisma.user.findUnique({
+      where: { email: "manager@scmayher.com" },
+      select: { id: true },
+    });
+    const salesUser = await prisma.user.findUnique({
+      where: { email: "sales@scmayher.com" },
+      select: { id: true },
+    });
+    if (!manager || !salesUser) {
+      throw new Error("Missing sales fixtures for KAN-52 narrative test");
+    }
+
+    const warehouse = await prisma.warehouse.create({
+      data: {
+        code: `KAN52-WH-${Date.now()}`,
+        name: "Almacen KAN-52",
+        address: "Fixture",
+        isActive: true,
+      },
+      select: { id: true, code: true },
+    });
+    warehouseId = warehouse.id;
+    createdWarehouseId = warehouse.id;
+
+    await prisma.location.createMany({
+      data: [
+        {
+          code: `STORAGE-${warehouse.code}`,
+          name: "KAN-52 storage",
+          usageType: "STORAGE",
+          warehouseId: warehouse.id,
+          isActive: true,
+        },
+        {
+          code: `STAGING-${warehouse.code}`,
+          name: "KAN-52 staging",
+          usageType: "STAGING",
+          warehouseId: warehouse.id,
+          isActive: true,
+        },
+        {
+          code: `SHIPPING-${warehouse.code}`,
+          name: "KAN-52 shipping",
+          usageType: "SHIPPING",
+          warehouseId: warehouse.id,
+          isActive: true,
+        },
+      ],
+    });
+
+    const product = await prisma.product.create({
+      data: {
+        sku: `KAN52-SKU-${Date.now()}`,
+        name: "Producto KAN-52",
+        type: "HOSE",
+      },
+      select: { id: true },
+    });
+    productId = product.id;
+
+    const storageLocation = await prisma.location.findFirst({
+      where: { warehouseId: warehouse.id, usageType: "STORAGE", isActive: true },
+      orderBy: { code: "asc" },
+      select: { id: true },
+    });
+    if (!storageLocation) {
+      throw new Error("Missing storage location for KAN-52 narrative test");
+    }
+    await prisma.inventory.create({
+      data: {
+        productId: product.id,
+        locationId: storageLocation.id,
+        quantity: 20,
+        reserved: 0,
+        available: 20,
+      },
+    });
+
+    const captureOrder = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente KAN-52 captura",
+      warehouseId,
+      dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      notes: "KAN-52 capture fixture",
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+    });
+    captureOrderId = captureOrder.id;
+    const assignmentOrder = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente KAN-52 asignacion",
+      warehouseId,
+      dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      notes: "KAN-52 assignment fixture",
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+      initialProductLine: { productId, requestedQty: 2 },
+    });
+    await confirmSalesRequestOrder(prisma, {
+      orderId: assignmentOrder.id,
+      confirmedByUserId: manager.id,
+    });
+    assignmentOrderId = assignmentOrder.id;
+    assignmentOrderCode = assignmentOrder.code;
+
+    const fulfillmentOrder = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente KAN-52 surtido",
+      warehouseId,
+      dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      notes: "KAN-52 fulfillment fixture",
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+      initialProductLine: { productId, requestedQty: 1 },
+    });
+    await confirmSalesRequestOrder(prisma, {
+      orderId: fulfillmentOrder.id,
+      confirmedByUserId: manager.id,
+    });
+    await pullSalesRequestOrder(prisma, {
+      orderId: fulfillmentOrder.id,
+      assignedToUserId: salesUser.id,
+    });
+    fulfillmentOrderId = fulfillmentOrder.id;
+    fulfillmentOrderCode = fulfillmentOrder.code;
+
+    const readyOrder = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente KAN-52 entrega",
+      warehouseId,
+      dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      notes: "KAN-52 ready fixture",
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+      initialProductLine: { productId, requestedQty: 3 },
+    });
+    await confirmSalesRequestOrder(prisma, {
+      orderId: readyOrder.id,
+      confirmedByUserId: manager.id,
+    });
+    await pullSalesRequestOrder(prisma, {
+      orderId: readyOrder.id,
+      assignedToUserId: salesUser.id,
+    });
+    await prisma.salesInternalOrderPickList.updateMany({
+      where: { orderId: readyOrder.id },
+      data: { status: "COMPLETED", completedAt: new Date() },
+    });
+    readyOrderId = readyOrder.id;
+    readyOrderCode = readyOrder.code;
+
+    const cancelledOrder = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente KAN-52 cancelado",
+      warehouseId,
+      dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      notes: "KAN-52 cancel fixture",
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+    });
+    await cancelSalesRequestOrder(prisma, {
+      orderId: cancelledOrder.id,
+      cancelledByUserId: manager.id,
+    });
+    cancelledOrderId = cancelledOrder.id;
+    cancelledOrderCode = cancelledOrder.code;
+  });
+
+  test.afterAll(async () => {
+    await cleanupFixtures();
+    await prisma.$disconnect();
+  });
+
+  test("keeps the list filter buckets aligned with the shared flow model", async ({
+    page,
+  }) => {
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests");
+    await page.goto("/production/requests");
+    await page.locator('[data-testid="requests-more-filters"] summary').click();
+
+    await expect(page.getByRole("link", { name: /^Captura$/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /^Por asignar$/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /^En surtido$/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /^Listo para entrega$/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /^Entregado$/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /^Cancelado$/i })).toBeVisible();
+
+    await page.getByRole("link", { name: /^Por asignar$/i }).click();
+    await expect(page).toHaveURL(/stage=por_asignar/);
+    await expectRequestCardNarrative(page, assignmentOrderCode, "Por asignar", "Tomar pedido");
+
+    await page.getByRole("link", { name: /^En surtido$/i }).click();
+    await expect(page).toHaveURL(/stage=en_surtido/);
+    await expectRequestCardNarrative(page, fulfillmentOrderCode, "En surtido", "Revisar bloqueo");
+
+    await page.getByRole("link", { name: /^Listo para entrega$/i }).click();
+    await expect(page).toHaveURL(/stage=listo_entrega/);
+    await expectRequestCardNarrative(page, readyOrderCode, "Listo para entrega", "Marcar entrega");
+
+    await page.getByRole("link", { name: /^Cancelado$/i }).click();
+    await expect(page).toHaveURL(/stage=cancelado/);
+    await expectRequestCardNarrative(page, cancelledOrderCode, "Cancelado", "Revisar bloqueo");
+  });
+
+  test("keeps list and detail coherent for delivery-ready and cancelled requests", async ({
+    page,
+  }) => {
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests");
+
+    await page.goto("/production/requests?preset=listos_para_entrega");
+    await expectRequestCardNarrative(page, readyOrderCode, "Listo para entrega", "Marcar entrega");
+    await page
+      .getByTestId("request-card")
+      .filter({ hasText: readyOrderCode })
+      .first()
+      .getByRole("link", { name: /Ver detalle/i })
+      .click();
+
+    await expect(page.getByRole("heading", { name: /Pedido comercial/i })).toBeVisible();
+    await expect(page.getByText("Listo para entrega", { exact: true }).first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Siguiente acción/i })).toBeVisible();
+    await expect(page.getByText("Marcar entrega", { exact: true })).toBeVisible();
+
+    const readyTimeline = page.locator("section").filter({ hasText: "Timeline operativo" }).first();
+    await expect(readyTimeline.getByRole("listitem")).toHaveCount(5);
+    await expect(readyTimeline.getByRole("listitem").nth(0)).toContainText("Captura");
+    await expect(readyTimeline.getByRole("listitem").nth(1)).toContainText("Asignación");
+    await expect(readyTimeline.getByRole("listitem").nth(2)).toContainText("Surtido / fulfillment");
+    await expect(readyTimeline.getByRole("listitem").nth(3)).toContainText("Entrega");
+    await expect(readyTimeline.getByRole("listitem").nth(4)).toContainText("Cancelación");
+
+    await page.goto("/production/requests?status=CANCELADA");
+    await expectRequestCardNarrative(page, cancelledOrderCode, "Cancelado", "Revisar bloqueo");
+    await page
+      .getByTestId("request-card")
+      .filter({ hasText: cancelledOrderCode })
+      .first()
+      .getByRole("link", { name: /Ver detalle/i })
+      .click();
+
+    await expect(page.getByText("Cancelado", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("Revisar bloqueo", { exact: true })).toBeVisible();
+    await expect(page.getByText("Marcar entrega", { exact: true })).toHaveCount(0);
+
+    const cancelledTimeline = page.locator("section").filter({ hasText: "Timeline operativo" }).first();
+    await expect(cancelledTimeline.getByRole("listitem").nth(4)).toContainText("Cancelación");
+  });
+});

--- a/tests/sales-internal-order-flow.test.ts
+++ b/tests/sales-internal-order-flow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getSalesOrderFlowNarrative, getSalesOrderFlowStage, resolveSalesOrderPrimaryCta } from "@/lib/sales/internal-orders";
 import {
   getSalesConsoleStageProgress,
+  getSalesConsoleTimelineItems,
   getSalesConsoleWorkType,
   resolveSalesConsolePrimaryActionState,
 } from "@/lib/sales/console";
@@ -264,5 +265,234 @@ describe("sales internal order flow stage", () => {
     });
     expect(productionBlockedState.state).toBe("blocked");
     expect(productionBlockedState.blockedReason).toContain("operativos");
+  });
+
+  it("keeps the sales flow narrative matrix coherent across stage, action, and filters", () => {
+    const cases = [
+      {
+        name: "draft/capture",
+        input: {
+          orderId: "ord-capture",
+          roles: ["SALES_EXECUTIVE"],
+          status: "BORRADOR" as const,
+        },
+        expected: {
+          flowStage: "captura",
+          listLabel: "Captura",
+          detailTimelineLabel: "Captura",
+          nextAction: "Revisar bloqueo",
+          filterBucket: "Borrador / Captura",
+          deliveryEligibility: false,
+          meaning: "capture",
+        },
+      },
+      {
+        name: "confirmed/assignment",
+        input: {
+          orderId: "ord-assignment",
+          roles: ["SALES_EXECUTIVE"],
+          status: "CONFIRMADA" as const,
+          assignedToUserId: null,
+          takeEligibility: { canTakeOrder: true, takeBlockedReason: null },
+        },
+        expected: {
+          flowStage: "por_asignar",
+          listLabel: "Por asignar",
+          detailTimelineLabel: "Asignación",
+          nextAction: "Tomar pedido",
+          filterBucket: "Sin asignar",
+          deliveryEligibility: false,
+          meaning: "confirmed / ready for assignment",
+        },
+      },
+      {
+        name: "assigned/in-fulfillment",
+        input: {
+          orderId: "ord-fulfillment",
+          roles: ["SALES_EXECUTIVE"],
+          status: "CONFIRMADA" as const,
+          assignedToUserId: "user-1",
+          latestPickStatus: "IN_PROGRESS",
+          hasProductLines: true,
+          deliveredEligibility: {
+            canMarkDelivered: false,
+            deliveredBlockedReason: "El surtido directo debe estar completado",
+          },
+        },
+        expected: {
+          flowStage: "en_surtido",
+          listLabel: "En surtido",
+          detailTimelineLabel: "Surtido / fulfillment",
+          nextAction: "Revisar bloqueo",
+          filterBucket: "En surtido",
+          deliveryEligibility: false,
+          meaning: "assigned / in fulfillment",
+        },
+      },
+      {
+        name: "partially-fulfilled",
+        input: {
+          orderId: "ord-partial",
+          roles: ["SALES_EXECUTIVE"],
+          status: "CONFIRMADA" as const,
+          assignedToUserId: "user-1",
+          latestPickStatus: "PARTIAL",
+          hasProductLines: true,
+          deliveredEligibility: {
+            canMarkDelivered: false,
+            deliveredBlockedReason: "El surtido directo debe estar completado",
+          },
+        },
+        expected: {
+          flowStage: "en_surtido",
+          listLabel: "En surtido",
+          detailTimelineLabel: "Surtido / fulfillment",
+          nextAction: "Revisar bloqueo",
+          filterBucket: "Parciales",
+          deliveryEligibility: false,
+          meaning: "partially fulfilled",
+        },
+      },
+      {
+        name: "ready-for-delivery",
+        input: {
+          orderId: "ord-ready",
+          roles: ["SALES_EXECUTIVE"],
+          status: "CONFIRMADA" as const,
+          assignedToUserId: "user-1",
+          pulledAt: new Date("2026-05-01T00:00:00.000Z"),
+          latestPickStatus: "COMPLETED",
+          hasProductLines: true,
+          hasAssemblyLines: false,
+          hasCompletedConfiguredAssembly: true,
+          takeEligibility: { canTakeOrder: false, takeBlockedReason: "El pedido ya está asignado" },
+          deliveredEligibility: { canMarkDelivered: true, deliveredBlockedReason: null },
+        },
+        expected: {
+          flowStage: "listo_entrega",
+          listLabel: "Listo para entrega",
+          detailTimelineLabel: "Entrega",
+          nextAction: "Marcar entrega",
+          filterBucket: "Listos para entrega",
+          deliveryEligibility: true,
+          meaning: "ready for delivery",
+        },
+      },
+      {
+        name: "delivered",
+        input: {
+          orderId: "ord-delivered",
+          roles: ["SALES_EXECUTIVE"],
+          status: "CONFIRMADA" as const,
+          assignedToUserId: "user-1",
+          pulledAt: new Date("2026-05-01T00:00:00.000Z"),
+          deliveredToCustomerAt: new Date("2026-05-02T00:00:00.000Z"),
+        },
+        expected: {
+          flowStage: "entregado",
+          listLabel: "Entregado",
+          detailTimelineLabel: "Entrega",
+          nextAction: "Revisar bloqueo",
+          filterBucket: "Entregado",
+          deliveryEligibility: false,
+          meaning: "delivered",
+        },
+      },
+      {
+        name: "cancelled",
+        input: {
+          orderId: "ord-cancelled",
+          roles: ["SALES_EXECUTIVE"],
+          status: "CANCELADA" as const,
+          cancelledAt: new Date("2026-05-03T00:00:00.000Z"),
+        },
+        expected: {
+          flowStage: "cancelado",
+          listLabel: "Cancelado",
+          detailTimelineLabel: "Cancelación",
+          nextAction: "Revisar bloqueo",
+          filterBucket: "Cancelada",
+          deliveryEligibility: false,
+          meaning: "cancelled",
+        },
+      },
+      {
+        name: "blocked / missing data",
+        input: {
+          orderId: "ord-blocked",
+          roles: ["SALES_EXECUTIVE"],
+          status: "CONFIRMADA" as const,
+          assignedToUserId: "user-1",
+          latestPickStatus: "DRAFT",
+          hasProductLines: true,
+          hasAssemblyLines: true,
+          hasCompletedConfiguredAssembly: false,
+          deliveredEligibility: {
+            canMarkDelivered: false,
+            deliveredBlockedReason: "Todas las órdenes de ensamble ligadas deben estar completadas",
+          },
+        },
+        expected: {
+          flowStage: "en_surtido",
+          listLabel: "En surtido",
+          detailTimelineLabel: "Surtido / fulfillment",
+          nextAction: "Revisar bloqueo",
+          filterBucket: "Bloqueados",
+          deliveryEligibility: false,
+          meaning: "blocked / missing data",
+        },
+      },
+    ];
+
+    const timelineLabels = getSalesConsoleTimelineItems({
+      createdAt: new Date("2026-04-30T12:00:00.000Z"),
+      confirmedAt: new Date("2026-05-01T12:00:00.000Z"),
+      assignedAt: new Date("2026-05-01T13:00:00.000Z"),
+      pulledAt: new Date("2026-05-01T14:00:00.000Z"),
+      latestPickStatus: "COMPLETED",
+      latestPickUpdatedAt: new Date("2026-05-01T15:00:00.000Z"),
+      deliveredAt: new Date("2026-05-02T12:00:00.000Z"),
+      cancelledAt: new Date("2026-05-03T12:00:00.000Z"),
+    }).map((item) => item.label);
+
+    expect(timelineLabels).toEqual([
+      "Captura",
+      "Asignación",
+      "Surtido / fulfillment",
+      "Entrega",
+      "Cancelación",
+    ]);
+
+    for (const row of cases) {
+      const flowNarrative = getSalesOrderFlowNarrative({
+        ...(row.input as Parameters<typeof getSalesOrderFlowNarrative>[0]),
+        takeEligibility:
+          "takeEligibility" in row.input
+            ? row.input.takeEligibility
+            : row.expected.flowStage === "por_asignar"
+              ? { canTakeOrder: true, takeBlockedReason: null }
+              : undefined,
+        deliveredEligibility:
+          "deliveredEligibility" in row.input
+            ? row.input.deliveredEligibility
+            : row.expected.flowStage === "listo_entrega"
+              ? { canMarkDelivered: true, deliveredBlockedReason: null }
+              : { canMarkDelivered: false, deliveredBlockedReason: "El pedido debe estar confirmado" },
+      });
+
+      expect(flowNarrative.flowStage).toBe(row.expected.flowStage);
+      expect(flowNarrative.flowStageLabel).toBe(row.expected.listLabel);
+      expect(flowNarrative.nextRecommendedAction.label).toBe(row.expected.nextAction);
+      expect(flowNarrative.primaryCta.action.label).toBe(row.expected.nextAction);
+      expect(flowNarrative.primaryCta.reason.length).toBeGreaterThan(0);
+      expect(getSalesConsoleStageProgress(flowNarrative.flowStage).find((step) => step.isCurrent)?.label).toBe(row.expected.listLabel);
+      expect(row.expected.detailTimelineLabel).toBeTruthy();
+      expect(row.expected.filterBucket).toBeTruthy();
+      expect(row.expected.meaning).toBeTruthy();
+
+      if (row.expected.deliveryEligibility) {
+        expect(flowNarrative.flowStage).toBe("listo_entrega");
+      }
+    }
   });
 });


### PR DESCRIPTION
Summary

This PR closes KAN-52 by aligning the sales request flow narrative across list and detail views. It keeps flow-stage labels, next-action copy, timeline milestones, and filters consistent.

Key changes

- Aligns /production/requests flow-stage labels and filters.
- Aligns /production/requests/[id] timeline/action copy with the same flow model.
- Preserves Batch 4C compact cards.
- Preserves Batch 5 product-aware request line persistence.
- Adds focused KAN-52 coverage.

Validation

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:postgres` ✅ (`46 passed, 1 skipped`)
- `npx vitest run tests/customers/requests-flow-narrative.contract.test.ts tests/sales-internal-order-flow.test.ts` ✅ (`20 passed`)
- `npx playwright test tests/e2e/sales-commercial-flow.spec.ts --project=chromium` ✅ (`5 passed`)
- `npx playwright test tests/e2e/full-jira-ux-audit.spec.ts --project=chromium` ✅ (`7 passed`)
- `npx playwright test tests/e2e/kan52-request-flow-narrative.spec.ts --project=chromium` ✅ (`2 passed`)

Caveats

- Jira live inspection was unavailable due Atlassian Rovo internal errors.
- No schema changes.
- No migrations.
- No RBAC widening.
- No purchasing/warehouse/PDF/email changes.

Verdict

KAN-52 request flow narrative and timeline hardening completed.
