### PR TITLE
feat: KAN-61 dashboard consistency & auth callback preservation

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -2,15 +2,12 @@ import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { signIn } from "@/lib/auth";
 import { getSessionContext } from "@/lib/auth/session-context";
-import { ROLE_HOME } from "@/lib/rbac/route-access-map";
-import type { RoleCode } from "@/lib/rbac/permissions";
-import { buttonStyles } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { SectionCard } from "@/components/ui/section-card";
 import ThemeToggle from "@/components/ThemeToggle";
 import { startPerf } from "@/lib/perf";
 import { getRequestId } from "@/lib/request-meta";
-import { sanitizeCallbackUrl } from "@/lib/auth/callback-url";
+import { resolvePostLoginRedirect, sanitizeCallbackUrl } from "@/lib/auth/callback-url";
+import LoginForm from "@/components/auth/LoginForm";
 
 const SESSION_COOKIE_NAMES = [
   "authjs.session-token",
@@ -55,6 +52,10 @@ export default async function LoginPage({
 }: {
   searchParams: Promise<SearchParams>;
 }) {
+  const sp = await searchParams;
+  const callbackUrl = sanitizeCallbackUrl(sp.callbackUrl);
+  const error = String(sp.error ?? "").trim();
+
   // Only check session (which hits the DB) when a session cookie is present.
   // Anonymous visitors skip auth() entirely — this removes ~200ms of overhead
   // on the initial login page load and avoids a Prisma round-trip for nothing.
@@ -63,15 +64,9 @@ export default async function LoginPage({
   if (hasCookie) {
     const ctx = await getSessionContext();
     if (ctx.isAuthenticated) {
-      const roles = ctx.roles;
-      const primaryRole = (roles[0] as RoleCode) ?? "MANAGER";
-      redirect(ROLE_HOME[primaryRole] ?? "/");
+      redirect(resolvePostLoginRedirect(callbackUrl, ctx.roles));
     }
   }
-
-  const sp = await searchParams;
-  const callbackUrl = sanitizeCallbackUrl(sp.callbackUrl);
-  const error = String(sp.error ?? "").trim();
 
   return (
     <div className="relative isolate flex min-h-screen items-center justify-center overflow-hidden px-4 py-10 sm:px-6">
@@ -90,15 +85,7 @@ export default async function LoginPage({
           <ThemeToggle compact />
         </div>
         <SectionCard title="Acceso WMS" description="Inicia sesion para operar el sistema.">
-          <form action={loginAction} className="space-y-4">
-            <input type="hidden" name="callbackUrl" value={callbackUrl} />
-            <Input name="email" type="email" label="Email" placeholder="admin@scmayher.com" required />
-            <Input name="password" type="password" label="Contrasena" required />
-            {error ? <p className="text-sm text-[var(--status-danger-text)]">{error}</p> : null}
-            <button type="submit" className={buttonStyles({ fullWidth: true })}>
-              Iniciar sesion
-            </button>
-          </form>
+          <LoginForm action={loginAction} callbackUrl={callbackUrl} error={error} />
         </SectionCard>
       </div>
     </div>

--- a/app/(shell)/labels/page.tsx
+++ b/app/(shell)/labels/page.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link";
+import prisma from "@/lib/prisma";
+import { pageGuard } from "@/components/rbac/PageGuard";
+import { PageHeader } from "@/components/ui/page-header";
+import { buttonStyles } from "@/components/ui/button";
+import { ensureDefaultLabelTemplates } from "@/lib/labeling-service";
+
+export const dynamic = "force-dynamic";
+
+export default async function LabelsPage() {
+  await pageGuard("labels.manage");
+  await ensureDefaultLabelTemplates(prisma);
+
+  const [recentJobs, templateCount] = await Promise.all([
+    prisma.labelPrintJob.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 12,
+      select: {
+        id: true,
+        status: true,
+        requestedBy: true,
+        createdAt: true,
+        traceRecord: {
+          select: {
+            traceId: true,
+            labelType: true,
+            sourceDocumentType: true,
+            sourceDocumentId: true,
+            operatorName: true,
+          },
+        },
+      },
+    }),
+    prisma.labelTemplate.count({ where: { isActive: true } }),
+  ]);
+
+  return (
+    <div className="max-w-6xl mx-auto space-y-6">
+      <PageHeader
+        title="Etiquetas"
+        description="Centro de acceso a trabajos de impresión, documentos etiquetados y trazabilidad asociada."
+        actions={
+          <>
+            <Link href="/inventory" className={buttonStyles({ variant: "secondary" })}>
+              Inventario
+            </Link>
+            <Link href="/trace" className={buttonStyles({ variant: "secondary" })}>
+              Trace
+            </Link>
+          </>
+        }
+      />
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="glass-card space-y-2">
+          <p className="text-xs uppercase tracking-[0.12em] text-slate-400">Plantillas activas</p>
+          <p className="text-3xl font-bold text-white">{templateCount.toLocaleString("es-MX")}</p>
+          <p className="text-sm text-slate-300">
+            Plantillas disponibles para movimientos, ubicaciones y documentos.
+          </p>
+        </div>
+        <div className="glass-card space-y-2">
+          <p className="text-xs uppercase tracking-[0.12em] text-slate-400">Trabajos recientes</p>
+          <p className="text-3xl font-bold text-white">{recentJobs.length.toLocaleString("es-MX")}</p>
+          <p className="text-sm text-slate-300">
+            Últimos trabajos de impresión listos para reimpresión o validación.
+          </p>
+        </div>
+        <div className="glass-card space-y-2">
+          <p className="text-xs uppercase tracking-[0.12em] text-slate-400">Accesos rápidos</p>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/inventory/receive" className={buttonStyles({ variant: "secondary", size: "sm" })}>
+              Recepciones
+            </Link>
+            <Link href="/inventory/pick" className={buttonStyles({ variant: "secondary", size: "sm" })}>
+              Picking
+            </Link>
+            <Link href="/inventory/adjust" className={buttonStyles({ variant: "secondary", size: "sm" })}>
+              Ajustes
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <section className="glass-card space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Trabajos recientes</h2>
+          <p className="text-sm text-slate-400">
+            Revisa el último render, su operador y el documento de origen cuando exista.
+          </p>
+        </div>
+
+        {recentJobs.length === 0 ? (
+          <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-8 text-center text-sm text-slate-400">
+            Aún no hay trabajos de impresión registrados.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-slate-400">
+                  <th className="py-3 text-left">Trace</th>
+                  <th className="py-3 text-left">Tipo</th>
+                  <th className="py-3 text-left">Documento</th>
+                  <th className="py-3 text-left">Operador</th>
+                  <th className="py-3 text-left">Estado</th>
+                  <th className="py-3 text-left">Creado</th>
+                  <th className="py-3 text-right">Acción</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentJobs.map((job) => {
+                  const documentLabel = job.traceRecord.sourceDocumentType && job.traceRecord.sourceDocumentId
+                    ? `${job.traceRecord.sourceDocumentType}:${job.traceRecord.sourceDocumentId}`
+                    : "--";
+
+                  return (
+                    <tr key={job.id} className="border-b border-white/5 text-slate-300 hover:bg-white/5">
+                      <td className="py-3 font-mono text-cyan-300">{job.traceRecord.traceId}</td>
+                      <td className="py-3">{job.traceRecord.labelType}</td>
+                      <td className="py-3">{documentLabel}</td>
+                      <td className="py-3">{job.requestedBy ?? job.traceRecord.operatorName ?? "--"}</td>
+                      <td className="py-3">{job.status}</td>
+                      <td className="py-3">{job.createdAt.toLocaleString("es-MX")}</td>
+                      <td className="py-3 text-right">
+                        <Link href={`/labels/jobs/${job.id}`} className="text-cyan-300 hover:text-white">
+                          Abrir
+                        </Link>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/(shell)/production/fulfillment/page.tsx
+++ b/app/(shell)/production/fulfillment/page.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import prisma from "@/lib/prisma";
+import { pageGuard } from "@/components/rbac/PageGuard";
+import { PageHeader } from "@/components/ui/page-header";
+import { buttonStyles } from "@/components/ui/button";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = {
+  blocked?: string;
+  status?: string;
+};
+
+function isTruthy(value: string | undefined) {
+  return value === "1" || value === "true" || value === "yes";
+}
+
+export default async function ProductionFulfillmentIndexPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  await pageGuard("production.execute");
+  const sp = await searchParams;
+
+  if (isTruthy(sp.blocked)) {
+    redirect("/production/requests?queue=assembly_blocked");
+  }
+
+  if (sp.status?.trim().toLowerCase() === "active") {
+    redirect("/production?ops=assembly_open");
+  }
+
+  const [blockedCount, activeAssemblyCount, activePickCount] = await Promise.all([
+    prisma.salesInternalOrder.count({
+      where: {
+        status: "CONFIRMADA",
+        deliveredToCustomerAt: null,
+        lines: { some: { lineKind: "CONFIGURED_ASSEMBLY" } },
+      },
+    }),
+    prisma.productionOrder.count({
+      where: { status: { in: ["BORRADOR", "ABIERTA", "EN_PROCESO"] } },
+    }),
+    prisma.salesInternalOrder.count({
+      where: {
+        status: { not: "CANCELADA" },
+        pickLists: {
+          some: {
+            status: { in: ["DRAFT", "RELEASED", "IN_PROGRESS", "PARTIAL"] },
+          },
+        },
+      },
+    }),
+  ]);
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      <PageHeader
+        title="Fulfillment"
+        description="Compatibilidad de rutas heredadas para surtido directo y ensambles abiertos."
+        actions={
+          <>
+            <Link href="/production/requests" className={buttonStyles({ variant: "secondary" })}>
+              Ver pedidos
+            </Link>
+            <Link href="/production" className={buttonStyles({ variant: "secondary" })}>
+              Ver ensambles
+            </Link>
+          </>
+        }
+      />
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Link href="/production/requests?queue=assembly_blocked" className="glass-card block space-y-2 hover:bg-white/5">
+          <p className="text-xs uppercase tracking-[0.12em] text-slate-400">Bloqueos activos</p>
+          <p className="text-3xl font-bold text-white">{blockedCount.toLocaleString("es-MX")}</p>
+          <p className="text-sm text-slate-300">
+            Abre la cola operativa con pedidos bloqueados por ensamble pendiente.
+          </p>
+        </Link>
+
+        <Link href="/production?ops=assembly_open" className="glass-card block space-y-2 hover:bg-white/5">
+          <p className="text-xs uppercase tracking-[0.12em] text-slate-400">Ensambles activos</p>
+          <p className="text-3xl font-bold text-white">{activeAssemblyCount.toLocaleString("es-MX")}</p>
+          <p className="text-sm text-slate-300">
+            Revisa órdenes de ensamble abiertas o en proceso desde el flujo canónico.
+          </p>
+        </Link>
+
+        <Link href="/production/requests" className="glass-card block space-y-2 hover:bg-white/5">
+          <p className="text-xs uppercase tracking-[0.12em] text-slate-400">Surtidos directos activos</p>
+          <p className="text-3xl font-bold text-white">{activePickCount.toLocaleString("es-MX")}</p>
+          <p className="text-sm text-slate-300">
+            Continúa el surtido directo desde el cockpit de pedidos compartido.
+          </p>
+        </Link>
+      </div>
+
+      <div className="glass-card space-y-3">
+        <h2 className="text-lg font-semibold text-white">Rutas heredadas soportadas</h2>
+        <p className="text-sm text-slate-400">
+          Esta vista mantiene activos los enlaces históricos usados por dashboards o marcadores antiguos.
+        </p>
+        <ul className="space-y-2 text-sm text-slate-300">
+          <li>
+            <code>/production/fulfillment?blocked=true</code> redirige a la cola canónica de bloqueos:
+            {" "}
+            <code>/production/requests?queue=assembly_blocked</code>
+          </li>
+          <li>
+            <code>/production/fulfillment?status=active</code> redirige a la vista canónica de ensambles abiertos:
+            {" "}
+            <code>/production?ops=assembly_open</code>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type LoginFormProps = {
+  action: (formData: FormData) => void;
+  callbackUrl: string;
+  error: string;
+};
+
+export default function LoginForm({
+  action,
+  callbackUrl,
+  error,
+}: LoginFormProps) {
+  return (
+    <form action={action} className="space-y-4">
+      <input type="hidden" name="callbackUrl" value={callbackUrl} />
+      <Input
+        name="email"
+        type="email"
+        label="Email"
+        placeholder="admin@scmayher.com"
+        autoComplete="email"
+        autoFocus
+        required
+      />
+      <Input
+        name="password"
+        type="password"
+        label="Contrasena"
+        autoComplete="current-password"
+        enterKeyHint="go"
+        required
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
+          event.preventDefault();
+          event.currentTarget.form?.requestSubmit();
+        }}
+      />
+      {error ? <p className="text-sm text-[var(--status-danger-text)]">{error}</p> : null}
+      <Button type="submit" fullWidth>
+        Iniciar sesion
+      </Button>
+    </form>
+  );
+}

--- a/lib/auth/callback-url.ts
+++ b/lib/auth/callback-url.ts
@@ -1,4 +1,11 @@
+import { ROLE_HOME } from "@/lib/rbac/route-access-map";
+import { RBAC_ROLES, type RoleCode } from "@/lib/rbac/permissions";
+import { getRequiredPermissionForPath } from "@/lib/rbac/route-permissions";
+import { getPermissionsForRoles } from "@/lib/rbac/role-permissions";
+
 const FALLBACK_CALLBACK_URL = "/";
+const DISALLOWED_CALLBACK_PREFIXES = ["/api/", "/_next/"];
+const DISALLOWED_CALLBACK_PATHS = new Set(["/login", "/logout", "/forbidden"]);
 
 export function sanitizeCallbackUrl(rawValue: string | null | undefined): string {
   const value = String(rawValue ?? "").trim();
@@ -15,4 +22,51 @@ export function sanitizeCallbackUrl(rawValue: string | null | undefined): string
   } catch {
     return FALLBACK_CALLBACK_URL;
   }
+}
+
+function getPrimaryRoleHome(roles: string[] | undefined) {
+  const primaryRole = Array.isArray(roles) && roles.length > 0
+    ? roles[0] as RoleCode
+    : "MANAGER";
+  return ROLE_HOME[primaryRole] ?? "/";
+}
+
+function getAllowedHomeRoutes(roles: string[] | undefined) {
+  return new Set(
+    (roles ?? [])
+      .filter((role): role is RoleCode => RBAC_ROLES.includes(role as RoleCode))
+      .map((role) => ROLE_HOME[role]),
+  );
+}
+
+export function resolvePostLoginRedirect(rawValue: string | null | undefined, roles: string[] | undefined) {
+  const fallbackUrl = getPrimaryRoleHome(roles);
+  const callbackUrl = sanitizeCallbackUrl(rawValue);
+
+  if (callbackUrl === FALLBACK_CALLBACK_URL) return fallbackUrl;
+
+  const normalized = new URL(callbackUrl, "http://localhost");
+  const pathname = normalized.pathname;
+
+  if (
+    DISALLOWED_CALLBACK_PATHS.has(pathname)
+    || DISALLOWED_CALLBACK_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  ) {
+    return fallbackUrl;
+  }
+
+  const allowedHomeRoutes = getAllowedHomeRoutes(roles);
+  if (allowedHomeRoutes.has(pathname)) {
+    return callbackUrl;
+  }
+
+  if (Array.isArray(roles) && roles.includes("SYSTEM_ADMIN")) {
+    return callbackUrl;
+  }
+
+  const requiredPermission = getRequiredPermissionForPath(pathname);
+  if (!requiredPermission) return fallbackUrl;
+
+  const grantedPermissions = getPermissionsForRoles(roles ?? []);
+  return grantedPermissions.includes(requiredPermission) ? callbackUrl : fallbackUrl;
 }

--- a/lib/rbac/route-access-map.ts
+++ b/lib/rbac/route-access-map.ts
@@ -210,6 +210,12 @@ export const ROUTE_ACCESS_MAP: RouteAccessEntry[] = [
     roles: ["SYSTEM_ADMIN", "MANAGER", "SALES_EXECUTIVE"],
   },
   {
+    route: "/production/fulfillment",
+    description: "Landing de compatibilidad para surtido directo y ensambles abiertos",
+    permission: "production.execute",
+    roles: ["SYSTEM_ADMIN", "MANAGER", "WAREHOUSE_OPERATOR"],
+  },
+  {
     route: "/production/fulfillment/[id]",
     description: "Ejecución del surtido directo del pedido hacia staging",
     permission: "production.execute",

--- a/lib/rbac/route-permissions.ts
+++ b/lib/rbac/route-permissions.ts
@@ -30,6 +30,7 @@ export const ROUTE_PERMISSION_RULES: RoutePermissionRule[] = [
   { prefix: "/production/requests", permission: "production.cockpit.view" },
   { prefix: "/production/availability", permission: "sales.view" },
   { prefix: "/production/equivalences", permission: "sales.view" },
+  { prefix: "/production/fulfillment", permission: "production.execute" },
   { prefix: "/production/fulfillment/", permission: "production.execute" },
   { prefix: "/production/orders/new", permission: "production.execute" },
   { prefix: "/production/orders/", permission: "production.view" },

--- a/proxy.ts
+++ b/proxy.ts
@@ -18,7 +18,7 @@ function isPublicPath(pathname: string) {
   );
 }
 
-function unauthorizedResponse(pathname: string, requestUrl: string, requestId: string) {
+function unauthorizedResponse(pathname: string, callbackUrl: string, requestUrl: string, requestId: string) {
   if (pathname.startsWith("/api/")) {
     const response = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     response.headers.set("x-request-id", requestId);
@@ -26,14 +26,15 @@ function unauthorizedResponse(pathname: string, requestUrl: string, requestId: s
   }
 
   const loginUrl = new URL("/login", requestUrl);
-  loginUrl.searchParams.set("callbackUrl", sanitizeCallbackUrl(pathname));
+  loginUrl.searchParams.set("callbackUrl", sanitizeCallbackUrl(callbackUrl));
   const response = NextResponse.redirect(loginUrl);
   response.headers.set("x-request-id", requestId);
   return response;
 }
 
 export default auth((request: NextAuthRequest) => {
-  const { pathname } = request.nextUrl;
+  const { pathname, search } = request.nextUrl;
+  const callbackUrl = `${pathname}${search}`;
   const startedAt = Date.now();
   const requestId = request.headers.get("x-request-id") ?? crypto.randomUUID();
   const requestHeaders = new Headers(request.headers);
@@ -44,7 +45,7 @@ export default auth((request: NextAuthRequest) => {
       headers: requestHeaders,
     },
   });
-  response.headers.set("x-pathname", pathname);
+  response.headers.set("x-pathname", callbackUrl);
   response.headers.set("x-request-id", requestId);
 
   if (isPublicPath(pathname)) {
@@ -65,7 +66,7 @@ export default auth((request: NextAuthRequest) => {
       authorized: false,
       durationMs: Date.now() - startedAt,
     });
-    return unauthorizedResponse(pathname, request.url, requestId);
+    return unauthorizedResponse(pathname, callbackUrl, request.url, requestId);
   }
 
   console.info("[perf] proxy.auth_check", {

--- a/tests/auth/callback-url.test.ts
+++ b/tests/auth/callback-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeCallbackUrl } from "@/lib/auth/callback-url";
+import { resolvePostLoginRedirect, sanitizeCallbackUrl } from "@/lib/auth/callback-url";
 
 describe("sanitizeCallbackUrl", () => {
   it("acepta rutas internas", () => {
@@ -16,5 +16,34 @@ describe("sanitizeCallbackUrl", () => {
 
   it("normaliza vacio a root", () => {
     expect(sanitizeCallbackUrl(" ")).toBe("/");
+  });
+
+  it("preserva querystrings internos", () => {
+    expect(sanitizeCallbackUrl("/production/requests?queue=assembly_blocked")).toBe("/production/requests?queue=assembly_blocked");
+  });
+});
+
+describe("resolvePostLoginRedirect", () => {
+  it("envia al callback permitido para el rol", () => {
+    expect(resolvePostLoginRedirect("/production/requests?queue=assembly_blocked", ["MANAGER"]))
+      .toBe("/production/requests?queue=assembly_blocked");
+  });
+
+  it("usa home del rol cuando falta callback", () => {
+    expect(resolvePostLoginRedirect("/", ["MANAGER"])).toBe("/home/manager");
+  });
+
+  it("rechaza callbacks externos y vuelve al home del rol", () => {
+    expect(resolvePostLoginRedirect("https://evil.example/steal", ["MANAGER"])).toBe("/home/manager");
+    expect(resolvePostLoginRedirect("//evil.example/steal", ["MANAGER"])).toBe("/home/manager");
+  });
+
+  it("rechaza callbacks no autorizados para el rol", () => {
+    expect(resolvePostLoginRedirect("/users", ["MANAGER"])).toBe("/home/manager");
+    expect(resolvePostLoginRedirect("/production/fulfillment", ["SALES_EXECUTIVE"])).toBe("/home/sales");
+  });
+
+  it("permite callback al home propio del rol", () => {
+    expect(resolvePostLoginRedirect("/home/sales", ["SALES_EXECUTIVE"])).toBe("/home/sales");
   });
 });

--- a/tests/e2e/login-callback-preservation.spec.ts
+++ b/tests/e2e/login-callback-preservation.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { EXPECTED_HOME, USERS, buildUrlExpectation, loginAs } from "./lib/auth.helpers";
+
+async function warmAuth(page: import("@playwright/test").Page) {
+  await page.request.get("/api/auth/session");
+  await page.request.get("/api/auth/csrf");
+}
+
+async function submitLogin(page: import("@playwright/test").Page, role: keyof typeof USERS) {
+  const user = USERS[role];
+  await page.getByLabel("Email").fill(user.email);
+  await page.getByLabel("Contrasena").fill(user.password);
+  await page.getByRole("button", { name: "Iniciar sesion" }).click();
+}
+
+test.describe("login callback preservation", () => {
+  test("unauthenticated protected route redirects to login with callback and returns after login", async ({ page }) => {
+    await warmAuth(page);
+    await page.goto("/production/requests?queue=assembly_blocked");
+    await expect(page).toHaveURL(/\/login\?callbackUrl=%2Fproduction%2Frequests%3Fqueue%3Dassembly_blocked$/);
+
+    await submitLogin(page, "MANAGER");
+
+    await expect(page).toHaveURL(buildUrlExpectation("/production/requests?queue=assembly_blocked"));
+    await expect(page.getByRole("heading", { level: 1, name: /Pedidos y surtidos/i })).toBeVisible();
+  });
+
+  test("unsafe external callback falls back to role home", async ({ page }) => {
+    await warmAuth(page);
+    await page.goto("/login?callbackUrl=https%3A%2F%2Fevil.example%2Fsteal");
+    await submitLogin(page, "SALES_EXECUTIVE");
+
+    await expect(page).toHaveURL(buildUrlExpectation(EXPECTED_HOME.SALES_EXECUTIVE));
+    await expect(page.getByRole("banner")).toContainText("Ejecutivo Ventas");
+  });
+
+  test("unauthorized callback falls back to role home", async ({ page }) => {
+    await warmAuth(page);
+    await page.goto("/login?callbackUrl=%2Fproduction%2Ffulfillment%3Fblocked%3Dtrue");
+    await submitLogin(page, "SALES_EXECUTIVE");
+
+    await expect(page).toHaveURL(buildUrlExpectation(EXPECTED_HOME.SALES_EXECUTIVE));
+    await expect(page.getByRole("banner")).toContainText("Ejecutivo Ventas");
+  });
+
+  test("direct login without callback still lands on role home", async ({ page }) => {
+    await loginAs(page, "WAREHOUSE_OPERATOR");
+    await expect(page).toHaveURL(buildUrlExpectation(EXPECTED_HOME.WAREHOUSE_OPERATOR));
+  });
+});

--- a/tests/e2e/login-enter-submit.spec.ts
+++ b/tests/e2e/login-enter-submit.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+import { EXPECTED_HOME, USERS } from "./lib/auth.helpers";
+
+test("login submits with a single Enter from the password field", async ({ page }) => {
+  await page.request.get("/api/auth/session");
+  await page.request.get("/api/auth/csrf");
+  await page.goto("/login?callbackUrl=%2Fhome%2Fsales");
+
+  await page.getByLabel("Email").fill(USERS.SALES_EXECUTIVE.email);
+  await page.getByLabel("Contrasena").fill(USERS.SALES_EXECUTIVE.password);
+  await page.getByLabel("Contrasena").press("Enter");
+
+  await expect(page).not.toHaveURL(/\/login/);
+  await expect(page).toHaveURL(buildExpectedUrl());
+  await expect(page.getByRole("banner")).toContainText("Ejecutivo Ventas");
+});
+
+function buildExpectedUrl() {
+  const escaped = EXPECTED_HOME.SALES_EXECUTIVE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped}(?:\\?.*)?$`);
+}

--- a/tests/e2e/role-dashboard-audit-fixes.spec.ts
+++ b/tests/e2e/role-dashboard-audit-fixes.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "@playwright/test";
+import {
+  buildUrlExpectation,
+  expectAllowed,
+  expectRedirectedAllowed,
+  loginAs,
+} from "./lib/auth.helpers";
+
+test.describe("role dashboard audit fixes", () => {
+  test("SYSTEM_ADMIN can open labels landing page", async ({ page }) => {
+    await loginAs(page, "SYSTEM_ADMIN");
+    await expectAllowed(page, "/labels", /Etiquetas/i);
+  });
+
+  test("MANAGER legacy blocked fulfillment route resolves to the canonical blocked queue", async ({ page }) => {
+    await loginAs(page, "MANAGER");
+    await expectRedirectedAllowed(
+      page,
+      "/production/fulfillment?blocked=true",
+      buildUrlExpectation("/production/requests?queue=assembly_blocked"),
+      /Pedidos|Órdenes/i,
+    );
+  });
+
+  test("WAREHOUSE_OPERATOR legacy active fulfillment route resolves to open assemblies", async ({ page }) => {
+    await loginAs(page, "WAREHOUSE_OPERATOR");
+    await expectRedirectedAllowed(
+      page,
+      "/production/fulfillment?status=active",
+      buildUrlExpectation("/production?ops=assembly_open"),
+      /Producción|Produccion/i,
+    );
+  });
+});

--- a/tests/rbac/route-access-map-coverage.test.ts
+++ b/tests/rbac/route-access-map-coverage.test.ts
@@ -39,7 +39,7 @@ describe("route access map coverage", () => {
       .sort();
 
     const routes = pageFiles.map(fileToRoute);
-    expect(routes).toHaveLength(65);
+    expect(routes).toHaveLength(67);
 
     const missing = routes.filter((route) => !getRouteAccessEntry(route));
     expect(missing).toEqual([]);

--- a/tests/rbac/route-access.integration.test.ts
+++ b/tests/rbac/route-access.integration.test.ts
@@ -31,6 +31,7 @@ describe("rbac role-route access matrix", () => {
     "/production/requests/new",
     "/production/availability",
     "/production/equivalences",
+    "/production/fulfillment",
     "/sales/customers",
     "/sales/customers/new",
     "/sales/customers/abc",
@@ -51,6 +52,8 @@ describe("rbac role-route access matrix", () => {
     expect(getRequiredPermissionForPath("/production/requests")).toBe("production.cockpit.view");
     expect(getRequiredPermissionForPath("/production/availability")).toBe("sales.view");
     expect(getRequiredPermissionForPath("/production/equivalences")).toBe("sales.view");
+    expect(getRequiredPermissionForPath("/production/fulfillment")).toBe("production.execute");
+    expect(getRequiredPermissionForPath("/production/fulfillment/abc")).toBe("production.execute");
     expect(getRequiredPermissionForPath("/production/orders")).toBe("production.view");
     expect(getRequiredPermissionForPath("/production/orders/new")).toBe("production.execute");
     expect(getRequiredPermissionForPath("/production/orders/abc")).toBe("production.view");
@@ -105,8 +108,12 @@ describe("rbac role-route access matrix", () => {
     expect(canAccess("MANAGER", "/production/requests/new")).toBe(true);
     expect(canAccess("MANAGER", "/production/availability")).toBe(true);
     expect(canAccess("MANAGER", "/production/equivalences")).toBe(true);
+    expect(canAccess("MANAGER", "/production/fulfillment")).toBe(true);
+    expect(canAccess("MANAGER", "/production/fulfillment/abc")).toBe(true);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/requests")).toBe(true);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/requests/abc")).toBe(true);
+    expect(canAccess("WAREHOUSE_OPERATOR", "/production/fulfillment")).toBe(true);
+    expect(canAccess("WAREHOUSE_OPERATOR", "/production/fulfillment/abc")).toBe(true);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/requests/new")).toBe(false);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/availability")).toBe(false);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/equivalences")).toBe(false);
@@ -114,6 +121,7 @@ describe("rbac role-route access matrix", () => {
     expect(canAccess("SALES_EXECUTIVE", "/production/requests/new")).toBe(true);
     expect(canAccess("SALES_EXECUTIVE", "/production/availability")).toBe(true);
     expect(canAccess("SALES_EXECUTIVE", "/production/equivalences")).toBe(true);
+    expect(canAccess("SALES_EXECUTIVE", "/production/fulfillment")).toBe(false);
   });
 
   it("customer routes respect view/manage split", () => {


### PR DESCRIPTION
## Summary

This PR completes the role-dashboard audit fixes and auth callback preservation work.

### Dashboard changes

- Added \/production/fulfillment\ landing behavior for audited dashboard flows:
  - \?blocked=true\ redirects to the blocked assembly queue
  - \?status=active\ redirects to open assembly operations
- Added \/labels\ landing page for label operations
- Added RBAC coverage for the new routes
- Confirmed sales equivalences points to canonical \/production/equivalences\

### Auth changes

- Added safe post-login callback resolution
- Preserves full protected-route callback path, including query string
- Rejects unsafe external, protocol-relative, internal framework, API, login/logout, and unauthorized callbacks
- Falls back to the user's role home when callback is invalid or not allowed
- Fixed login so pressing Enter once submits normally

### Tests

- Added/updated unit coverage for auth callback validation and RBAC route access
- Added E2E coverage for dashboard route fixes
- Added E2E coverage for login callback preservation
- Added E2E coverage for single-Enter login submit

## Validation

- [x] \
pm run lint\
- [x] \
pm run typecheck\
- [x] \
pm run build\
- [x] \
px vitest run tests/auth/callback-url.test.ts tests/rbac/route-access.integration.test.ts tests/rbac/route-access-map-coverage.test.ts\
- [x] \
px playwright test tests/e2e/dashboard-consistency.spec.ts tests/e2e/auth-callback.spec.ts tests/e2e/login-enter-submit.spec.ts tests/e2e/role-dashboard-audit-fixes.spec.ts tests/e2e/login-callback-preservation.spec.ts --project=chromium\

## Notes

Unrelated catalog whitespace edits were reverted before opening this PR.