### PR TITLE
feat(KAN-75): streamline sales availability view

### DIFF
--- a/app/(shell)/production/availability/page.tsx
+++ b/app/(shell)/production/availability/page.tsx
@@ -46,12 +46,14 @@ export default async function ProductionAvailabilityPage({
   const source = sp.source?.trim() ?? "";
   const equivalentProductId = sp.equivalentProductId?.trim() ?? "";
 
+  // For sales view: only show available stock (no operational noise)
+  // We still need to query quantity/reserved for filtering but only expose available
   const inventoryWhere: Prisma.InventoryWhereInput = selectedWarehouse
     ? { location: { warehouse: { code: selectedWarehouse } } }
     : {};
   const where: Prisma.ProductWhereInput = {
     ...(query ? buildProductSearchWhere(query) : {}),
-    inventory: { some: inventoryWhere },
+    inventory: { some: { ...inventoryWhere, available: { gt: 0 } } },
   };
 
   const [totalRows, products, warehouses] = await Promise.all([
@@ -71,8 +73,6 @@ export default async function ProductionAvailabilityPage({
         inventory: {
           where: inventoryWhere,
           select: {
-            quantity: true,
-            reserved: true,
             available: true,
             location: {
               select: {
@@ -92,20 +92,16 @@ export default async function ProductionAvailabilityPage({
   ]);
 
   const rows = products.map((product) => {
-    const total = product.inventory.reduce((acc, row) => acc + row.quantity, 0);
-    const reserved = product.inventory.reduce((acc, row) => acc + row.reserved, 0);
     const available = product.inventory.reduce((acc, row) => acc + row.available, 0);
     const byWarehouse = Object.values(
-      product.inventory.reduce<Record<string, { warehouseCode: string; quantity: number; reserved: number; available: number }>>((acc, row) => {
+      product.inventory.reduce<Record<string, { warehouseCode: string; warehouseName: string; available: number }>>((acc, row) => {
         const warehouseCode = row.location.warehouse.code;
+        const warehouseName = row.location.warehouse.name;
         const current = acc[warehouseCode] ?? {
           warehouseCode,
-          quantity: 0,
-          reserved: 0,
+          warehouseName,
           available: 0,
         };
-        current.quantity += row.quantity;
-        current.reserved += row.reserved;
         current.available += row.available;
         acc[warehouseCode] = current;
         return acc;
@@ -114,8 +110,6 @@ export default async function ProductionAvailabilityPage({
 
     return {
       ...product,
-      total,
-      reserved,
       available,
       byWarehouse,
     };
@@ -159,8 +153,8 @@ export default async function ProductionAvailabilityPage({
     <div className="space-y-6">
       <PageHeader
         title="Disponibilidad comercial"
-        description="Consulta existencia disponible, reservada y total para decidir si avanzas al pedido o revisas equivalencias."
-        meta={`${totalRows.toLocaleString("es-MX")} productos con inventario`}
+        description="Consulta existencia disponible para decidir si avanzas al pedido o revisas equivalencias. Sin ruido operativo."
+        meta={`${totalRows.toLocaleString("es-MX")} productos con disponibilidad`}
         actions={<Link href={requestHref} className="btn-primary">+ Nuevo pedido</Link>}
       />
 
@@ -239,8 +233,6 @@ export default async function ProductionAvailabilityPage({
               <tr className="border-b border-white/10 text-slate-400">
                 <th className="py-3 text-left">SKU</th>
                 <th className="py-3 text-left">Producto</th>
-                <th className="py-3 text-right">Total</th>
-                <th className="py-3 text-right">Reservado</th>
                 <th className="py-3 text-right">Disponible</th>
                 <th className="py-3 text-left">Por almacén</th>
                 <th className="py-3 text-left">Siguiente acción</th>
@@ -257,14 +249,12 @@ export default async function ProductionAvailabilityPage({
                     <p>{row.name}</p>
                     <p className="text-xs text-slate-500">{row.brand ?? row.type}</p>
                   </td>
-                  <td className="py-3 text-right text-slate-200">{row.total.toLocaleString("es-MX")}</td>
-                  <td className="py-3 text-right text-amber-300">{row.reserved.toLocaleString("es-MX")}</td>
                   <td className="py-3 text-right text-emerald-300">{row.available.toLocaleString("es-MX")}</td>
                   <td className="py-3 text-xs text-slate-400">
                     <div className="space-y-1">
                       {row.byWarehouse.map((warehouse) => (
                         <p key={warehouse.warehouseCode}>
-                          {warehouse.warehouseCode}: T {warehouse.quantity.toLocaleString("es-MX")} / R {warehouse.reserved.toLocaleString("es-MX")} / D {warehouse.available.toLocaleString("es-MX")}
+                          {warehouse.warehouseCode}: D {warehouse.available.toLocaleString("es-MX")}
                         </p>
                       ))}
                     </div>

--- a/app/(shell)/production/availability/page.tsx
+++ b/app/(shell)/production/availability/page.tsx
@@ -2,9 +2,11 @@ import Link from "next/link";
 import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { pageGuard } from "@/components/rbac/PageGuard";
+import { Badge } from "@/components/ui/badge";
 import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
 import { buttonStyles } from "@/components/ui/button";
+import { Table, TableRow, TableWrap, Td, Th } from "@/components/ui/table";
 import { buildProductSearchWhere } from "@/lib/product-search";
 import {
   buildCommercialRequestHref,
@@ -30,6 +32,16 @@ function parsePage(value: string | undefined) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
 }
 
+function getCommercialStatus(available: number) {
+  if (available <= 0) {
+    return { label: "Sin disponibilidad", variant: "danger" as const };
+  }
+  if (available <= 5) {
+    return { label: "Limitado", variant: "warning" as const };
+  }
+  return { label: "Disponible", variant: "success" as const };
+}
+
 export default async function ProductionAvailabilityPage({
   searchParams,
 }: {
@@ -44,15 +56,16 @@ export default async function ProductionAvailabilityPage({
   const sku = sp.sku?.trim() ?? "";
   const source = sp.source?.trim() ?? "";
   const equivalentProductId = sp.equivalentProductId?.trim() ?? "";
+  const hasSearchContext = Boolean(query || productId || sku || equivalentProductId);
 
-  // For sales view: only show available stock (no operational noise)
-  // We still need to query quantity/reserved for filtering but only expose available
   const inventoryWhere: Prisma.InventoryWhereInput = selectedWarehouse
     ? { location: { warehouse: { code: selectedWarehouse } } }
     : {};
   const where: Prisma.ProductWhereInput = {
-    ...(query ? buildProductSearchWhere(query) : {}),
-    inventory: { some: { ...inventoryWhere, available: { gt: 0 } } },
+    ...(productId ? { id: productId } : sku ? { sku } : query ? buildProductSearchWhere(query) : {}),
+    ...(!hasSearchContext
+      ? { inventory: { some: { ...inventoryWhere, available: { gt: 0 } } } }
+      : {}),
   };
 
   const [totalRows, products, warehouses] = await Promise.all([
@@ -111,6 +124,7 @@ export default async function ProductionAvailabilityPage({
       ...product,
       available,
       byWarehouse,
+      status: getCommercialStatus(available),
     };
   });
 
@@ -139,22 +153,24 @@ export default async function ProductionAvailabilityPage({
         equivalentProductId: equivalentProductId || undefined,
       })
     : "/production/requests/new";
+  const hasResultRows = rows.length > 0;
+  const showContextualEmptyActions = Boolean(query || sku || productId || equivalentProductId);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PageHeader
         title="Disponibilidad comercial"
-        description="Consulta existencia disponible por producto y almacén."
-        meta={`${totalRows.toLocaleString("es-MX")} productos con disponibilidad`}
+        description="Consulta rápida para promesa comercial."
+        meta={hasResultRows ? `${totalRows.toLocaleString("es-MX")} resultados` : undefined}
       />
 
-      <form className="glass-card grid gap-4 md:grid-cols-[1.5fr_1fr_auto]">
+      <form className="surface grid gap-3 rounded-[var(--radius-lg)] p-4 md:grid-cols-[minmax(0,1.7fr)_minmax(14rem,1fr)_auto] md:items-end">
         <label className="space-y-1">
-          <span className="text-sm text-slate-400">Producto requerido</span>
+          <span className="text-sm text-[var(--text-muted)]">Producto requerido</span>
           <input
             name="q"
             defaultValue={query}
-            className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white"
+            className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-primary)] px-3 py-2.5 text-[var(--text-primary)]"
             placeholder="SKU, referencia, nombre o marca..."
           />
           <input type="hidden" name="productId" value={productId} />
@@ -163,8 +179,12 @@ export default async function ProductionAvailabilityPage({
           <input type="hidden" name="equivalentProductId" value={equivalentProductId} />
         </label>
         <label className="space-y-1">
-          <span className="text-sm text-slate-400">Almacén</span>
-          <select name="warehouse" defaultValue={selectedWarehouse} className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white">
+          <span className="text-sm text-[var(--text-muted)]">Almacén</span>
+          <select
+            name="warehouse"
+            defaultValue={selectedWarehouse}
+            className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-primary)] px-3 py-2.5 text-[var(--text-primary)]"
+          >
             <option value="">Todos</option>
             {warehouses.map((warehouse) => (
               <option key={warehouse.code} value={warehouse.code}>
@@ -173,80 +193,163 @@ export default async function ProductionAvailabilityPage({
             ))}
           </select>
         </label>
-        <div className="flex items-end gap-2">
-          <button type="submit" className="btn-primary">Ver disponibilidad</button>
-          <Link href="/production/availability" className="rounded-lg border border-white/10 px-4 py-3 text-sm text-slate-300 hover:text-white">
+        <div className="flex flex-wrap items-center gap-2 md:justify-end">
+          <button type="submit" className={buttonStyles()}>
+            Ver disponibilidad
+          </button>
+          <Link
+            href="/production/availability"
+            className={buttonStyles({ variant: "secondary" })}
+          >
             Limpiar filtros
           </Link>
         </div>
       </form>
 
-      {rows.length === 0 ? (
-          <EmptyState
-            title="Busca un producto requerido"
-            description="Usa SKU, referencia, nombre o marca para revisar la existencia disponible. Si no encuentras el producto, pasa al catálogo, equivalencias o nuevo pedido."
-            actions={
+      {!hasResultRows ? (
+        <EmptyState
+          compact
+          title={hasSearchContext ? "Sin disponibilidad para esa búsqueda" : "Sin resultados para mostrar"}
+          description={
+            hasSearchContext
+              ? "Ajusta el producto o almacén, o revisa alternativas si necesitas una opción comercial."
+              : "Usa la búsqueda para revisar la disponibilidad comercial por producto."
+          }
+          actions={
+            showContextualEmptyActions ? (
               <>
-                <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
-                  Ir al catálogo
-                </Link>
-                <Link href={buildCommercialSearchHref("/production/equivalences", query || sku, { productId: productId || undefined, sku: sku || undefined, source: "availability", equivalentProductId: equivalentProductId || undefined })} className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                <Link
+                  href={buildCommercialSearchHref("/production/equivalences", query || sku, {
+                    productId: productId || undefined,
+                    sku: sku || undefined,
+                    source: "availability",
+                    equivalentProductId: equivalentProductId || undefined,
+                  })}
+                  className={buttonStyles({ variant: "secondary", size: "sm" })}
+                >
                   Revisar equivalencias
                 </Link>
                 <Link href={requestHref} className={buttonStyles({ size: "sm" })}>
                   Crear pedido
                 </Link>
               </>
-            }
-          />
+            ) : undefined
+          }
+        />
       ) : (
-        <div className="glass-card overflow-x-auto">
-          <table className="w-full text-sm">
+        <>
+          <div className="grid gap-3 md:hidden">
+            {rows.map((row) => (
+              <article key={row.id} className="surface space-y-3 rounded-[var(--radius-lg)] p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <Link href={`/catalog/${row.id}`} className="text-sm font-semibold text-[var(--text-primary)] hover:text-[var(--accent)]">
+                      {row.name}
+                    </Link>
+                    <p className="font-mono text-xs text-[var(--text-muted)]">
+                      {row.sku}
+                      {row.referenceCode ? ` · ${row.referenceCode}` : ""}
+                    </p>
+                  </div>
+                  <Badge variant={row.status.variant}>{row.status.label}</Badge>
+                </div>
+                <div className="grid gap-2 text-sm sm:grid-cols-2">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">Disponible para vender</p>
+                    <p className="text-lg font-semibold text-[var(--text-primary)]">{row.available.toLocaleString("es-MX")}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">Dónde hay</p>
+                    <div className="space-y-1 text-sm text-[var(--text-secondary)]">
+                      {row.byWarehouse.length > 0 ? row.byWarehouse.map((warehouse) => (
+                        <p key={warehouse.warehouseCode}>
+                          {warehouse.warehouseCode} - {warehouse.warehouseName}: {warehouse.available.toLocaleString("es-MX")}
+                        </p>
+                      )) : <p>Sin stock disponible</p>}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Link
+                    href={buildCommercialRequestHref({ productId: row.id, sku: row.sku, q: query || row.sku, source: "availability" })}
+                    className={buttonStyles({ size: "sm" })}
+                  >
+                    Crear pedido
+                  </Link>
+                  <Link
+                    href={buildCommercialSearchHref("/production/equivalences", row.sku, { productId: row.id, sku: row.sku, source: "availability" })}
+                    className={buttonStyles({ variant: "secondary", size: "sm" })}
+                  >
+                    Revisar equivalencias
+                  </Link>
+                  <Link href={`/catalog/${row.id}`} className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                    Ver producto
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <TableWrap className="hidden md:block" dense label="Tabla comercial de disponibilidad">
+            <Table>
             <thead>
-              <tr className="border-b border-white/10 text-slate-400">
-                <th className="py-3 text-left">SKU</th>
-                <th className="py-3 text-left">Producto</th>
-                <th className="py-3 text-right">Disponible</th>
-                <th className="py-3 text-left">Por almacén</th>
-                <th className="py-3 text-left">Siguiente acción</th>
-              </tr>
+              <TableRow>
+                <Th>Producto / SKU / referencia</Th>
+                <Th className="text-right">Disponible para vender</Th>
+                <Th>Estado comercial</Th>
+                <Th>Dónde hay</Th>
+                <Th>Acción</Th>
+              </TableRow>
             </thead>
             <tbody>
               {rows.map((row) => (
-                <tr key={row.id} className="border-b border-white/5 align-top hover:bg-white/5">
-                  <td className="py-3 font-mono text-cyan-300">
-                    <Link href={`/catalog/${row.id}`}>{row.sku}</Link>
-                    {row.referenceCode ? <p className="text-[11px] text-slate-500">{row.referenceCode}</p> : null}
-                  </td>
-                  <td className="py-3 text-slate-300">
-                    <p>{row.name}</p>
-                    <p className="text-xs text-slate-500">{row.brand ?? row.type}</p>
-                  </td>
-                  <td className="py-3 text-right text-emerald-300">{row.available.toLocaleString("es-MX")}</td>
-                  <td className="py-3 text-xs text-slate-400">
+                <TableRow key={row.id} className="align-top">
+                  <Td>
                     <div className="space-y-1">
-                      {row.byWarehouse.map((warehouse) => (
-                        <p key={warehouse.warehouseCode}>
-                          {warehouse.warehouseCode}: D {warehouse.available.toLocaleString("es-MX")}
-                        </p>
-                      ))}
-                    </div>
-                  </td>
-                <td className="py-3">
-                    <div className="flex flex-wrap gap-2">
-                      <Link href={buildCommercialSearchHref("/production/equivalences", row.sku, { productId: row.id, sku: row.sku, source: "availability" })} className={buttonStyles({ variant: "secondary", size: "sm" })}>
-                        Ver equivalencias
+                      <Link href={`/catalog/${row.id}`} className="font-semibold text-[var(--text-primary)] hover:text-[var(--accent)]">
+                        {row.name}
                       </Link>
+                      <p className="font-mono text-xs text-[var(--text-muted)]">{row.sku}</p>
+                      {row.referenceCode ? <p className="text-xs text-[var(--text-muted)]">{row.referenceCode}</p> : null}
+                    </div>
+                  </Td>
+                  <Td className="text-right font-semibold text-[var(--text-primary)]">
+                    {row.available.toLocaleString("es-MX")}
+                  </Td>
+                  <Td>
+                    <Badge variant={row.status.variant}>{row.status.label}</Badge>
+                  </Td>
+                  <Td className="text-sm">
+                    <div className="space-y-1">
+                      {row.byWarehouse.length > 0 ? row.byWarehouse.map((warehouse) => (
+                        <p key={warehouse.warehouseCode}>
+                          <span className="font-medium text-[var(--text-primary)]">
+                            {warehouse.warehouseCode} - {warehouse.warehouseName}
+                          </span>
+                          <span className="text-[var(--text-muted)]">: {warehouse.available.toLocaleString("es-MX")}</span>
+                        </p>
+                      )) : <p className="text-[var(--text-muted)]">Sin stock disponible</p>}
+                    </div>
+                  </Td>
+                  <Td>
+                    <div className="flex flex-wrap gap-2">
                       <Link href={buildCommercialRequestHref({ productId: row.id, sku: row.sku, q: query || row.sku, source: "availability" })} className={buttonStyles({ size: "sm" })}>
                         Crear pedido
                       </Link>
+                      <Link href={buildCommercialSearchHref("/production/equivalences", row.sku, { productId: row.id, sku: row.sku, source: "availability" })} className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                        Revisar equivalencias
+                      </Link>
+                      <Link href={`/catalog/${row.id}`} className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                        Ver producto
+                      </Link>
                     </div>
-                  </td>
-                </tr>
+                  </Td>
+                </TableRow>
               ))}
             </tbody>
-          </table>
-        </div>
+            </Table>
+          </TableWrap>
+        </>
       )}
 
       {totalPages > 1 ? (

--- a/app/(shell)/production/availability/page.tsx
+++ b/app/(shell)/production/availability/page.tsx
@@ -4,7 +4,6 @@ import prisma from "@/lib/prisma";
 import { pageGuard } from "@/components/rbac/PageGuard";
 import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
-import { SectionCard } from "@/components/ui/section-card";
 import { buttonStyles } from "@/components/ui/button";
 import { buildProductSearchWhere } from "@/lib/product-search";
 import {
@@ -140,40 +139,14 @@ export default async function ProductionAvailabilityPage({
         equivalentProductId: equivalentProductId || undefined,
       })
     : "/production/requests/new";
-  const equivalenceHref = query || sku
-    ? buildCommercialSearchHref("/production/equivalences", query || sku, {
-        productId: productId || undefined,
-        sku: sku || undefined,
-        source: "availability",
-        equivalentProductId: equivalentProductId || undefined,
-      })
-    : "/production/equivalences";
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Disponibilidad comercial"
-        description="Consulta existencia disponible para decidir si avanzas al pedido o revisas equivalencias. Sin ruido operativo."
+        description="Consulta existencia disponible por producto y almacén."
         meta={`${totalRows.toLocaleString("es-MX")} productos con disponibilidad`}
-        actions={<Link href={requestHref} className="btn-primary">+ Nuevo pedido</Link>}
       />
-
-      <SectionCard
-        title="Siguiente acción"
-        description="Si la existencia disponible no cubre el pedido, sigue con equivalencias o captura el pedido comercial."
-      >
-        <div className="flex flex-wrap gap-2">
-          <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
-            Buscar en catálogo
-          </Link>
-          <Link href={equivalenceHref} className={buttonStyles({ variant: "secondary", size: "sm" })}>
-            Revisar equivalencias
-          </Link>
-          <Link href={requestHref} className={buttonStyles({ size: "sm" })}>
-            Crear pedido
-          </Link>
-        </div>
-      </SectionCard>
 
       <form className="glass-card grid gap-4 md:grid-cols-[1.5fr_1fr_auto]">
         <label className="space-y-1">

--- a/tests/e2e/commercial-toolkit-flow.spec.ts
+++ b/tests/e2e/commercial-toolkit-flow.spec.ts
@@ -229,9 +229,15 @@ test.describe.serial("commercial toolkit flow", () => {
         page.getByRole("heading", { name: /Disponibilidad comercial/i }),
       ).toBeVisible();
       await expect(page.getByLabel(/Producto requerido/i)).toHaveValue(fixture.baseSku);
-      await expect(page.getByRole("link", { name: /Ver equivalencias/i }).first()).toBeVisible();
+      await expect(page.getByRole("columnheader", { name: /Disponible para vender/i })).toBeVisible();
+      await expect(page.getByRole("columnheader", { name: /Estado comercial/i })).toBeVisible();
+      await expect(page.getByRole("columnheader", { name: /^Acción$/i })).toBeVisible();
+      await expect(page.getByText("Siguiente acción", { exact: true })).toHaveCount(0);
+      await expect(page.getByRole("columnheader", { name: /^Total$/i })).toHaveCount(0);
+      await expect(page.getByRole("columnheader", { name: /^Reservado$/i })).toHaveCount(0);
+      await expect(page.getByRole("link", { name: /Revisar equivalencias/i }).first()).toBeVisible();
 
-      await page.getByRole("link", { name: /Ver equivalencias/i }).first().click();
+      await page.getByRole("link", { name: /Revisar equivalencias/i }).first().click();
       await expect(page).toHaveURL(/\/production\/equivalences(?:\?.*)?$/);
       await expect(
         page.getByRole("heading", { name: /Alternativas y equivalencias/i }),

--- a/tests/e2e/full-jira-ux-audit.spec.ts
+++ b/tests/e2e/full-jira-ux-audit.spec.ts
@@ -347,6 +347,11 @@ test.describe
     await expect(
       page.getByRole("link", { name: /Limpiar filtros/i }),
     ).toBeVisible();
+    await expect(page.getByText("Siguiente acción", { exact: true })).toHaveCount(0);
+    await expect(page.getByRole("columnheader", { name: /Disponible para vender/i })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: /Estado comercial/i })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: /^Total$/i })).toHaveCount(0);
+    await expect(page.getByRole("columnheader", { name: /^Reservado$/i })).toHaveCount(0);
 
     await page.goto("/production/equivalences");
     await expect(

--- a/tests/e2e/product-aware-handoff.spec.ts
+++ b/tests/e2e/product-aware-handoff.spec.ts
@@ -234,8 +234,13 @@ test.describe.serial("product aware handoff", () => {
 
     await expect(page.getByRole("heading", { name: /Disponibilidad comercial/i })).toBeVisible();
     await expect(page.getByLabel(/Producto requerido/i)).toHaveValue(fixture.baseSku);
+    await expect(page.getByText("Siguiente acción", { exact: true })).toHaveCount(0);
+    await expect(page.getByRole("columnheader", { name: /Disponible para vender/i })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: /Estado comercial/i })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: /^Total$/i })).toHaveCount(0);
+    await expect(page.getByRole("columnheader", { name: /^Reservado$/i })).toHaveCount(0);
     await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /Ver equivalencias/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Revisar equivalencias/i }).first()).toBeVisible();
 
     await page.getByRole("link", { name: /Crear pedido/i }).first().click();
     await expect(page).toHaveURL(/\/production\/requests\/new\?.*source=availability/);

--- a/tests/production/availability-page.contract.test.ts
+++ b/tests/production/availability-page.contract.test.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readWorkspaceFile(relativePath: string) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+describe("production availability page contract", () => {
+  it("keeps the sales availability screen focused on compact commercial results", () => {
+    const content = readWorkspaceFile("app/(shell)/production/availability/page.tsx");
+
+    expect(content).toContain('title="Disponibilidad comercial"');
+    expect(content).toContain("Consulta rápida para promesa comercial.");
+    expect(content).toContain("Disponible para vender");
+    expect(content).toContain("Estado comercial");
+    expect(content).toContain("Dónde hay");
+    expect(content).toContain("Crear pedido");
+    expect(content).toContain("Revisar equivalencias");
+    expect(content).toContain("Ver producto");
+    expect(content).toContain("Sin disponibilidad");
+    expect(content).toContain("Limitado");
+    expect(content).toContain("Disponible");
+
+    expect(content).not.toContain("Siguiente acción");
+    expect(content).not.toContain("Ir al catálogo");
+    expect(content).not.toContain(">Total<");
+    expect(content).not.toContain(">Reservado<");
+  });
+});


### PR DESCRIPTION
## Summary
- streamline `/production/availability` into a compact sales-first working screen
- remove instructional clutter and pre-result emphasis that made the page feel operational instead of commercial
- preserve route, RBAC, search params, warehouse filter, pagination, and catalog/equivalence/request handoff links

## Screenshot-driven UX changes
- removed the standalone `Siguiente acción` primary results column
- shortened the page intro to a single compact commercial subtitle
- reduced the filter area to a compact search + warehouse row with immediate results below
- removed catalog/equivalence action clutter from the default empty state unless there is concrete product/search context
- replaced the operational results emphasis with `Disponible para vender`, `Estado comercial`, `Dónde hay`, and `Acción`
- removed `Total` and `Reservado` as primary sales columns and removed reserved quantities from warehouse detail
- added compact commercial status badges: `Disponible`, `Limitado`, `Sin disponibilidad`
- kept per-result actions for `Crear pedido`, `Revisar equivalencias`, and `Ver producto`
- added a mobile card layout so the sales view stays readable without horizontal overflow pressure

## Acceptance criteria mapping
- title remains `Disponibilidad comercial`
- route remains `/production/availability`
- RBAC remains `sales.view`
- existing search params are preserved: `q`, `warehouse`, `page`, `productId`, `sku`, `source`, `equivalentProductId`
- warehouse filter and pagination remain in place
- catalog, equivalences, and order-creation links remain in place
- first screen is compact and no longer centers operational coaching
- `Siguiente acción`, primary `Total`, and primary `Reservado` are removed from the rendered sales UI
- warehouse detail now shows warehouse code/name plus available quantity only

## Files changed
- `app/(shell)/production/availability/page.tsx`
- `tests/production/availability-page.contract.test.ts`
- `tests/e2e/commercial-toolkit-flow.spec.ts`
- `tests/e2e/product-aware-handoff.spec.ts`
- `tests/e2e/full-jira-ux-audit.spec.ts`

## Validation results
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npx vitest run tests/production/availability-page.contract.test.ts tests/rbac/route-access.integration.test.ts` ✅
- runtime browser verification against `/production/availability` as `SALES_EXECUTIVE` ✅
  - confirmed no `Siguiente acción`
  - confirmed no primary `Total` / `Reservado` columns
  - confirmed `Disponible para vender`, `Estado comercial`, and `Acción` columns render
  - confirmed warehouse detail only shows warehouse + available quantity

## Jira reference
- KAN-75

## Out of scope
- email work remains out of scope for this PR