### PR TITLE
[codex] Streamline sales catalog layout

### DIFF
--- a/app/(shell)/catalog/page.tsx
+++ b/app/(shell)/catalog/page.tsx
@@ -113,6 +113,7 @@ export default async function CatalogPage({ searchParams }: PageProps) {
         getSessionContext(),
     ]);
     const currentPage = parsePositiveInt(params.page, 1);
+    const isSalesExecutive = sessionCtx.roles.includes("SALES_EXECUTIVE");
     const canEditCatalog =
         sessionCtx.isSystemAdmin || sessionCtx.permissions.includes("catalog.edit");
 
@@ -332,25 +333,27 @@ export default async function CatalogPage({ searchParams }: PageProps) {
         }
       />
 
-      <SectionCard
-        title="Flujo comercial"
-        description="Producto requerido → disponibilidad → equivalencias → pedido."
-      >
-        <div className="flex flex-wrap gap-2">
-          {commercialToolkitLinks.map((action) => (
-            <Link
-              key={action.label}
-              href={action.href}
-              className={buttonStyles({
-                variant: action.variant ?? "secondary",
-                size: "sm",
-              })}
-            >
-              {action.label}
-            </Link>
-          ))}
-        </div>
-      </SectionCard>
+      {!isSalesExecutive ? (
+        <SectionCard
+          title="Flujo comercial"
+          description="Producto requerido → disponibilidad → equivalencias → pedido."
+        >
+          <div className="flex flex-wrap gap-2">
+            {commercialToolkitLinks.map((action) => (
+              <Link
+                key={action.label}
+                href={action.href}
+                className={buttonStyles({
+                  variant: action.variant ?? "secondary",
+                  size: "sm",
+                })}
+              >
+                {action.label}
+              </Link>
+            ))}
+          </div>
+        </SectionCard>
+      ) : null}
 
       <CatalogFilters
         counts={counts}
@@ -359,7 +362,7 @@ export default async function CatalogPage({ searchParams }: PageProps) {
         subcategories={subcategories.length > 0 ? subcategories : TAXONOMY_SUBCATEGORIES.map((value) => ({ value, count: 0 }))}
         attributeKeys={attributeKeys}
         attributeValues={attributeValues}
-        isSalesExecutive={sessionCtx.roles.includes("SALES_EXECUTIVE")}
+        isSalesExecutive={isSalesExecutive}
       />
 
       <SectionCard

--- a/tests/e2e/kan74-catalog-commercial-mode.spec.ts
+++ b/tests/e2e/kan74-catalog-commercial-mode.spec.ts
@@ -11,6 +11,8 @@ test.describe("KAN-74: Commercial catalog mode for SALES_EXECUTIVE", () => {
 
     // Should land on catalog page with commercial heading
     await expect(page.getByRole("heading", { name: /Catálogo comercial/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Flujo comercial/i })).toHaveCount(0);
+    await expect(page.getByText(/Producto requerido → disponibilidad/i)).toHaveCount(0);
 
     // Primary search input should be prominent and accessible
     const searchInput = page.getByLabel("Buscar producto");
@@ -46,8 +48,7 @@ test.describe("KAN-74: Commercial catalog mode for SALES_EXECUTIVE", () => {
     await expect(page.getByRole("button", { name: /Aplicar/i })).toBeVisible();
     await expect(page.getByRole("button", { name: /Limpiar todo/i })).toBeVisible();
 
-    // Commercial flow shortcuts should be visible (disponibilidad, equivalencias, crear pedido)
-    // Use .first() since there are multiple per product row
+    // Commercial actions stay attached to product/result context.
     await expect(page.getByRole("link", { name: /Ver disponibilidad/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Revisar equivalencias/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
@@ -115,6 +116,7 @@ test.describe("KAN-74: Commercial catalog mode for SALES_EXECUTIVE", () => {
 
     // Should NOT see "Más filtros" button (it's only for SALES_EXECUTIVE)
     await expect(page.getByRole("button", { name: /Más filtros/i })).toBeHidden();
+    await expect(page.getByRole("heading", { name: /Flujo comercial/i })).toBeVisible();
 
     // Should see "Limpiar" and "Aplicar filtros" buttons (use .first() since there are two of each)
     await expect(page.getByRole("button", { name: /Limpiar/i }).first()).toBeVisible();


### PR DESCRIPTION
## Summary
- Hide the standalone `Flujo comercial` instructional card for `SALES_EXECUTIVE` on `/catalog`.
- Keep `Catálogo comercial`, search, filters, pagination, product cards/table, and product-scoped commercial actions intact.
- Preserve manager/admin catalog behavior, including catalog management actions and the existing commercial-flow card for non-sales-executive roles.

## Screenshot-driven reason
The sales catalog screenshot showed a large pre-search card explaining `Producto requerido -> disponibilidad -> equivalencias -> pedido` and repeating `Ver disponibilidad`, `Revisar equivalencias`, and `Crear pedido` before the seller had selected a product. For the sales-executive workflow, this makes `/catalog` feel instructional instead of operational.

## What changed
- Removed the standalone `Flujo comercial` card/copy from the `SALES_EXECUTIVE` catalog view.
- Kept commercial actions near each product/result context:
  - `Ver disponibilidad`
  - `Revisar equivalencias`
  - `Crear pedido`
- Updated KAN-74 e2e coverage to assert the sales-executive clutter is gone and manager behavior is preserved.

## Validation
- `npm run typecheck` passed
- `npm run lint` passed
- `npm run build` passed
- `npx playwright test tests/e2e/kan74-catalog-commercial-mode.spec.ts --project=chromium` passed: 6/6
- Visual checks captured locally:
  - `output/playwright/sales-catalog-clutter-cleanup/01-sales-catalog-desktop.png`
  - `output/playwright/sales-catalog-clutter-cleanup/02-sales-catalog-mobile.png`
  - `output/playwright/sales-catalog-clutter-cleanup/03-manager-catalog-desktop.png`

## Scope notes
- Email work is out of scope.
- KAN-54 is not closed by this PR.