### PR TITLE
[codex] Streamline sales catalog and equivalences flow

### DIFF
--- a/app/(shell)/catalog/page.tsx
+++ b/app/(shell)/catalog/page.tsx
@@ -113,6 +113,7 @@ export default async function CatalogPage({ searchParams }: PageProps) {
         getSessionContext(),
     ]);
     const currentPage = parsePositiveInt(params.page, 1);
+    const isSalesExecutive = sessionCtx.roles.includes("SALES_EXECUTIVE");
     const canEditCatalog =
         sessionCtx.isSystemAdmin || sessionCtx.permissions.includes("catalog.edit");
 
@@ -332,25 +333,27 @@ export default async function CatalogPage({ searchParams }: PageProps) {
         }
       />
 
-      <SectionCard
-        title="Flujo comercial"
-        description="Producto requerido → disponibilidad → equivalencias → pedido."
-      >
-        <div className="flex flex-wrap gap-2">
-          {commercialToolkitLinks.map((action) => (
-            <Link
-              key={action.label}
-              href={action.href}
-              className={buttonStyles({
-                variant: action.variant ?? "secondary",
-                size: "sm",
-              })}
-            >
-              {action.label}
-            </Link>
-          ))}
-        </div>
-      </SectionCard>
+      {!isSalesExecutive ? (
+        <SectionCard
+          title="Flujo comercial"
+          description="Producto requerido → disponibilidad → equivalencias → pedido."
+        >
+          <div className="flex flex-wrap gap-2">
+            {commercialToolkitLinks.map((action) => (
+              <Link
+                key={action.label}
+                href={action.href}
+                className={buttonStyles({
+                  variant: action.variant ?? "secondary",
+                  size: "sm",
+                })}
+              >
+                {action.label}
+              </Link>
+            ))}
+          </div>
+        </SectionCard>
+      ) : null}
 
       <CatalogFilters
         counts={counts}
@@ -359,7 +362,7 @@ export default async function CatalogPage({ searchParams }: PageProps) {
         subcategories={subcategories.length > 0 ? subcategories : TAXONOMY_SUBCATEGORIES.map((value) => ({ value, count: 0 }))}
         attributeKeys={attributeKeys}
         attributeValues={attributeValues}
-        isSalesExecutive={sessionCtx.roles.includes("SALES_EXECUTIVE")}
+        isSalesExecutive={isSalesExecutive}
       />
 
       <SectionCard

--- a/app/(shell)/production/equivalences/page.tsx
+++ b/app/(shell)/production/equivalences/page.tsx
@@ -56,7 +56,8 @@ export default async function ProductionEquivalencesPage({
     })),
   );
 
-  const requestHref = query || sku
+  const hasProductContext = query || sku || productId || equivalentProductId;
+  const requestHref = hasProductContext
     ? buildCommercialRequestHref({
         productId: productId || undefined,
         sku: sku || undefined,
@@ -65,7 +66,7 @@ export default async function ProductionEquivalencesPage({
         equivalentProductId: equivalentProductId || undefined,
       })
     : "/production/requests/new";
-  const availabilityHref = query || sku
+  const availabilityHref = hasProductContext
     ? buildCommercialSearchHref("/production/availability", query || sku, {
         productId: productId || undefined,
         sku: sku || undefined,
@@ -74,16 +75,18 @@ export default async function ProductionEquivalencesPage({
       })
     : "/production/availability";
 
+  const showHeaderActions = hasProductContext && !isSalesExecutive;
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Alternativas y equivalencias"
         description="Revisa sustitutos registrados para decidir si conviene validar disponibilidad o crear un pedido comercial."
         meta={query ? `${groups.length} productos analizados` : "Busca un SKU o referencia para explorar equivalencias"}
-        actions={<Link href={requestHref} className="btn-primary">+ Nuevo pedido</Link>}
+        actions={showHeaderActions ? <Link href={requestHref} className="btn-primary">+ Nuevo pedido</Link> : null}
       />
 
-      {!isSalesExecutive && (
+      {!isSalesExecutive && hasProductContext && (
         <SectionCard
           title="Siguiente acción"
           description="Usa equivalencias para encontrar un sustituto y continuar con disponibilidad o captura de pedido."
@@ -140,6 +143,13 @@ export default async function ProductionEquivalencesPage({
           title="Busca un producto requerido"
           description="Ingresa un SKU, referencia o nombre para ver alternativas disponibles y decidir si validas existencia o creas el pedido comercial."
           actions={
+            isSalesExecutive ? (
+              <>
+                <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                  Ir al catálogo
+                </Link>
+              </>
+            ) : (
               <>
                 <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
                   Ir al catálogo
@@ -151,24 +161,38 @@ export default async function ProductionEquivalencesPage({
                   Crear pedido
                 </Link>
               </>
-            }
-          />
+            )
+          }
+        />
       ) : groups.length === 0 ? (
         <EmptyState
           title="Sin resultados"
           description="No se encontraron productos base para esa búsqueda. Prueba con otro SKU, referencia o vuelve al catálogo para buscar el producto requerido."
           actions={
-            <>
-              <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
-                Buscar en catálogo
-              </Link>
-              <Link href={availabilityHref} className={buttonStyles({ variant: "secondary", size: "sm" })}>
-                Ver disponibilidad
-              </Link>
-              <Link href={requestHref} className={buttonStyles({ size: "sm" })}>
-                Crear pedido
-              </Link>
-            </>
+            isSalesExecutive ? (
+              <>
+                <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                  Buscar en catálogo
+                </Link>
+                {hasProductContext && (
+                  <Link href={availabilityHref} className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                    Ver disponibilidad
+                  </Link>
+                )}
+              </>
+            ) : (
+              <>
+                <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                  Buscar en catálogo
+                </Link>
+                <Link href={availabilityHref} className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                  Ver disponibilidad
+                </Link>
+                <Link href={requestHref} className={buttonStyles({ size: "sm" })}>
+                  Crear pedido
+                </Link>
+              </>
+            )
           }
         />
       ) : (

--- a/app/(shell)/production/equivalences/page.tsx
+++ b/app/(shell)/production/equivalences/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import prisma from "@/lib/prisma";
 import { pageGuard } from "@/components/rbac/PageGuard";
+import { getSessionContext } from "@/lib/auth/session-context";
 import { PageHeader } from "@/components/ui/page-header";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SectionCard } from "@/components/ui/section-card";
@@ -29,6 +30,8 @@ export default async function ProductionEquivalencesPage({
   searchParams: Promise<SearchParams>;
 }) {
   await pageGuard("sales.view");
+  const sessionContext = await getSessionContext();
+  const isSalesExecutive = sessionContext.roles.includes("SALES_EXECUTIVE");
   const sp = await searchParams;
   const query = sp.q?.trim() ?? "";
   const warehouseId = sp.warehouseId?.trim() ?? "";
@@ -80,22 +83,24 @@ export default async function ProductionEquivalencesPage({
         actions={<Link href={requestHref} className="btn-primary">+ Nuevo pedido</Link>}
       />
 
-      <SectionCard
-        title="Siguiente acción"
-        description="Usa equivalencias para encontrar un sustituto y continuar con disponibilidad o captura de pedido."
-      >
-        <div className="flex flex-wrap gap-2">
-          <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
-            Buscar en catálogo
-          </Link>
-          <Link href={availabilityHref} className={buttonStyles({ variant: "secondary", size: "sm" })}>
-            Ver disponibilidad
-          </Link>
-          <Link href={requestHref} className={buttonStyles({ size: "sm" })}>
-            Crear pedido
-          </Link>
-        </div>
-      </SectionCard>
+      {!isSalesExecutive && (
+        <SectionCard
+          title="Siguiente acción"
+          description="Usa equivalencias para encontrar un sustituto y continuar con disponibilidad o captura de pedido."
+        >
+          <div className="flex flex-wrap gap-2">
+            <Link href="/catalog" className={buttonStyles({ variant: "secondary", size: "sm" })}>
+              Buscar en catálogo
+            </Link>
+            <Link href={availabilityHref} className={buttonStyles({ variant: "secondary", size: "sm" })}>
+              Ver disponibilidad
+            </Link>
+            <Link href={requestHref} className={buttonStyles({ size: "sm" })}>
+              Crear pedido
+            </Link>
+          </div>
+        </SectionCard>
+      )}
 
       <form className="glass-card grid gap-4 md:grid-cols-[1.5fr_1fr_auto]">
         <label className="space-y-1">

--- a/tests/e2e/kan74-catalog-commercial-mode.spec.ts
+++ b/tests/e2e/kan74-catalog-commercial-mode.spec.ts
@@ -11,6 +11,8 @@ test.describe("KAN-74: Commercial catalog mode for SALES_EXECUTIVE", () => {
 
     // Should land on catalog page with commercial heading
     await expect(page.getByRole("heading", { name: /Catálogo comercial/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Flujo comercial/i })).toHaveCount(0);
+    await expect(page.getByText(/Producto requerido → disponibilidad/i)).toHaveCount(0);
 
     // Primary search input should be prominent and accessible
     const searchInput = page.getByLabel("Buscar producto");
@@ -46,8 +48,7 @@ test.describe("KAN-74: Commercial catalog mode for SALES_EXECUTIVE", () => {
     await expect(page.getByRole("button", { name: /Aplicar/i })).toBeVisible();
     await expect(page.getByRole("button", { name: /Limpiar todo/i })).toBeVisible();
 
-    // Commercial flow shortcuts should be visible (disponibilidad, equivalencias, crear pedido)
-    // Use .first() since there are multiple per product row
+    // Commercial actions stay attached to product/result context.
     await expect(page.getByRole("link", { name: /Ver disponibilidad/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Revisar equivalencias/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
@@ -115,6 +116,7 @@ test.describe("KAN-74: Commercial catalog mode for SALES_EXECUTIVE", () => {
 
     // Should NOT see "Más filtros" button (it's only for SALES_EXECUTIVE)
     await expect(page.getByRole("button", { name: /Más filtros/i })).toBeHidden();
+    await expect(page.getByRole("heading", { name: /Flujo comercial/i })).toBeVisible();
 
     // Should see "Limpiar" and "Aplicar filtros" buttons (use .first() since there are two of each)
     await expect(page.getByRole("button", { name: /Limpiar/i }).first()).toBeVisible();

--- a/tests/e2e/sales-equivalences-clutter-cleanup.spec.ts
+++ b/tests/e2e/sales-equivalences-clutter-cleanup.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@playwright/test";
+import { loginAs, EXPECTED_HOME } from "./lib/auth.helpers";
+
+test.describe("Sales Equivalences Clutter Cleanup", () => {
+  test("SALES_EXECUTIVE on /production/equivalences does not see standalone Siguiente acción card", async ({
+    page,
+  }) => {
+    await loginAs(page, "SALES_EXECUTIVE", EXPECTED_HOME.SALES_EXECUTIVE, EXPECTED_HOME.SALES_EXECUTIVE);
+    await page.goto("/production/equivalences");
+
+    // Should land on equivalences page
+    await expect(page.getByRole("heading", { name: /Alternativas y equivalencias/i })).toBeVisible();
+
+    // Should NOT see standalone Siguiente acción instructional card
+    await expect(page.getByRole("heading", { name: /Siguiente acción/i })).toHaveCount(0);
+    await expect(page.getByText(/Usa equivalencias para encontrar un sustituto/i)).toHaveCount(0);
+
+    // Should NOT see premature Crear pedido in header
+    await expect(page.getByRole("link", { name: /^\+ Nuevo pedido$/i })).toHaveCount(0);
+
+    // Search form should be prominent
+    await expect(page.getByLabel(/Producto requerido/i)).toBeVisible();
+
+    // Basic actions should be available for non-SALES_EXECUTIVE roles
+  });
+
+  test("SALES_EXECUTIVE on empty /production/equivalences does not see premature Crear pedido", async ({
+    page,
+  }) => {
+    await loginAs(page, "SALES_EXECUTIVE", EXPECTED_HOME.SALES_EXECUTIVE, EXPECTED_HOME.SALES_EXECUTIVE);
+    await page.goto("/production/equivalences");
+
+    // Empty state should only show "Ir al catálogo" for SALES_EXECUTIVE
+    await expect(page.getByRole("link", { name: /Ir al catálogo/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver disponibilidad/i })).toHaveCount(0);
+    await expect(page.getByRole("link", { name: /Crear pedido/i })).toHaveCount(0);
+  });
+
+  test("SALES_EXECUTIVE sees Crear pedido only when product/equivalence results exist", async ({
+    page,
+  }) => {
+    await loginAs(page, "SALES_EXECUTIVE", EXPECTED_HOME.SALES_EXECUTIVE, EXPECTED_HOME.SALES_EXECUTIVE);
+    
+    // Navigate WITH product context (query + productId + sku) - this creates hasProductContext=true
+    await page.goto("/production/equivalences?q=TEST&productId=test-id&sku=TEST-SKU&source=catalog");
+    await page.waitForLoadState("networkidle");
+
+    // With product context but NO actual search results (since test data doesn't exist):
+    // - SALES_EXECUTIVE should see empty state with "Buscar en catálogo" and "Ver disponibilidad"
+    // - But NOT "Crear pedido" 
+    await expect(page.getByRole("link", { name: /Buscar en catálogo/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver disponibilidad/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Crear pedido/i })).toHaveCount(0);
+    
+    // Also verify header doesn't show + Nuevo pedido for SALES_EXECUTIVE
+    await expect(page.getByRole("link", { name: /^\+ Nuevo pedido$/i })).toHaveCount(0);
+  });
+
+  test("Manager sees Siguiente acción card when there's product context", async ({ page }) => {
+    await loginAs(page, "MANAGER", EXPECTED_HOME.MANAGER, EXPECTED_HOME.MANAGER);
+    await page.goto("/production/equivalences?q=TEST&productId=test-id&sku=TEST-SKU&source=catalog");
+    await page.waitForLoadState("networkidle");
+
+    // Manager SHOULD see Siguiente acción when there's product context
+    await expect(page.getByRole("heading", { name: /Siguiente acción/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver disponibilidad/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Crear pedido/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /^\+ Nuevo pedido$/i })).toBeVisible();
+  });
+
+  test("Manager does NOT see Siguiente acción card when no product context", async ({ page }) => {
+    await loginAs(page, "MANAGER", EXPECTED_HOME.MANAGER, EXPECTED_HOME.MANAGER);
+    await page.goto("/production/equivalences");
+    await page.waitForLoadState("networkidle");
+
+    // Manager should NOT see Siguiente acción when there's no product context
+    await expect(page.getByRole("heading", { name: /Siguiente acción/i })).toHaveCount(0);
+    await expect(page.getByRole("link", { name: /^\+ Nuevo pedido$/i })).toHaveCount(0);
+
+    // But should see full empty state with all actions
+    await expect(page.getByRole("link", { name: /Ir al catálogo/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Ver disponibilidad/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Crear pedido/i })).toBeVisible();
+  });
+
+  test("Mobile equivalences view does not horizontally overflow", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await loginAs(page, "SALES_EXECUTIVE", EXPECTED_HOME.SALES_EXECUTIVE, EXPECTED_HOME.SALES_EXECUTIVE);
+    await page.goto("/production/equivalences");
+
+    await expect(page.getByRole("heading", { name: /Alternativas y equivalencias/i })).toBeVisible();
+
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(410);
+  });
+
+  test("Handoff context preserved through equivalence -> availability -> new request", async ({ page }) => {
+    await loginAs(page, "SALES_EXECUTIVE", EXPECTED_HOME.SALES_EXECUTIVE, EXPECTED_HOME.SALES_EXECUTIVE);
+    
+    // This test assumes there might be some fixture data - if not, it validates the URL structure
+    await page.goto("/production/equivalences?q=TEST&productId=test-id&sku=TEST-SKU&source=catalog");
+    await page.waitForLoadState("networkidle");
+
+    // Verify URL parameters are preserved in links
+    const availabilityLink = page.getByRole("link", { name: /Ver disponibilidad/i }).first();
+    const requestLink = page.getByRole("link", { name: /Crear pedido/i }).first();
+
+    if (await availabilityLink.isVisible()) {
+      const href = await availabilityLink.getAttribute("href");
+      expect(href).toContain("source=equivalences");
+      expect(href).toContain("productId=");
+    }
+
+    if (await requestLink.isVisible()) {
+      const href = await requestLink.getAttribute("href");
+      expect(href).toContain("source=equivalences");
+      expect(href).toContain("equivalentProductId=");
+    }
+  });
+});


### PR DESCRIPTION
## Summary - Hide generic commercial-flow clutter from the SALES_EXECUTIVE catalog/equivalences flow. - Remove premature `Siguiente acción`, `+ Nuevo pedido`, and `Crear pedido` entry points before product context exists. - Preserve product-scoped commercial actions and equivalence handoff context. - Preserve manager/admin behavior where broader toolkit actions are still useful.  ## Scope - KAN-74 / KAN-81 sales UX cleanup. - Does not close KAN-54. - Does not close KAN-125. - Email work is out of scope.  ## Files changed - `app/(shell)/catalog/page.tsx` - `app/(shell)/production/equivalences/page.tsx` - `tests/e2e/kan74-catalog-commercial-mode.spec.ts` - `tests/e2e/sales-equivalences-clutter-cleanup.spec.ts`  ## Validation - `npm run typecheck` - `npm run lint` - `npm run build` - `npx playwright test tests/e2e/kan74-catalog-commercial-mode.spec.ts tests/e2e/sales-equivalences-clutter-cleanup.spec.ts --project=chromium --reporter=list`