### PR TITLE
feat(documents): comprobantes PDF de recepción, surtido y entrega

### DIFF
--- a/app/(shell)/production/fulfillment/[id]/page.tsx
+++ b/app/(shell)/production/fulfillment/[id]/page.tsx
@@ -283,6 +283,9 @@ export default async function ProductionFulfillmentPage({
               <p className="op-helper">
                 Liberada: {activePickList.releasedAt ? new Date(activePickList.releasedAt).toLocaleString("es-MX") : "--"} · Cerrada: {activePickList.completedAt ? new Date(activePickList.completedAt).toLocaleString("es-MX") : "--"}
               </p>
+              <a href={`/api/production/requests/${order.id}/pick-list.pdf`} className="mt-3 inline-flex text-sm font-semibold text-[var(--accent)] underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]">
+                Descargar lista de surtido
+              </a>
             </div>
           )}
 

--- a/app/(shell)/production/requests/[id]/page.tsx
+++ b/app/(shell)/production/requests/[id]/page.tsx
@@ -767,6 +767,11 @@ export default async function ProductionRequestDetailPage({
                     <button type="submit" className="btn-primary">Entregado al cliente</button>
                   </form>
                 ) : null}
+                {order.deliveredToCustomerAt ? (
+                  <a href={`/api/production/requests/${order.id}/delivery.pdf`} className={buttonStyles({ variant: "secondary" })}>
+                    Descargar comprobante de entrega
+                  </a>
+                ) : null}
               </>
             ) : (
               <p className="text-sm text-[var(--text-muted)]">Este rol puede revisar el pedido, pero no ejecutar acciones de escritura.</p>

--- a/app/api/production/requests/[id]/delivery.pdf/route.ts
+++ b/app/api/production/requests/[id]/delivery.pdf/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import React from "react";
+import { renderToBuffer } from "@react-pdf/renderer";
+import prisma from "@/lib/prisma";
+import { requireSalesWriteAccess } from "@/lib/rbac/sales";
+import { buildOperationalDocumentFilename, OperationalDocumentPdf } from "@/lib/operations/operational-document-pdf";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requireSalesWriteAccess();
+  const { id } = await params;
+  const order = await prisma.salesInternalOrder.findUnique({ where: { id }, select: { code: true, customerName: true, deliveredToCustomerAt: true, preparedForDeliveryAt: true, preparedForDeliveryNotes: true, warehouse: { select: { code: true, name: true } }, preparedForDeliveryLocation: { select: { code: true, name: true } }, deliveredByUser: { select: { name: true, email: true } }, lines: { select: { requestedQty: true, product: { select: { sku: true, name: true, unitLabel: true } }, assemblyConfiguration: { select: { assemblyQuantity: true, entryFittingProduct: { select: { sku: true } }, hoseProduct: { select: { sku: true } }, exitFittingProduct: { select: { sku: true } } } } } } } });
+  if (!order || !order.deliveredToCustomerAt) return NextResponse.json({ error: "El comprobante sólo está disponible después de registrar la entrega" }, { status: 409 });
+  const pdf = await renderToBuffer(React.createElement(OperationalDocumentPdf, { snapshot: { title: "Comprobante de entrega", folio: order.code, status: "Entregado al cliente", generatedAt: order.deliveredToCustomerAt, warehouse: order.warehouse ? `${order.warehouse.code} - ${order.warehouse.name}` : "Sin almacén", location: order.preparedForDeliveryLocation ? `${order.preparedForDeliveryLocation.code} - ${order.preparedForDeliveryLocation.name}` : null, responsible: order.deliveredByUser?.name || order.deliveredByUser?.email, reference: order.customerName, notes: order.preparedForDeliveryNotes, lines: order.lines.map((line) => line.product ? ({ sku: line.product.sku, name: line.product.name, quantity: line.requestedQty, unit: line.product.unitLabel || "unidad" }) : ({ sku: "ENSAMBLE", name: `${line.assemblyConfiguration?.entryFittingProduct.sku || ""} + ${line.assemblyConfiguration?.hoseProduct.sku || ""} + ${line.assemblyConfiguration?.exitFittingProduct.sku || ""}`.trim(), quantity: line.assemblyConfiguration?.assemblyQuantity || line.requestedQty, unit: "ensamble" })) } }) as unknown as Parameters<typeof renderToBuffer>[0]);
+  return new NextResponse(new Uint8Array(pdf), { headers: { "Content-Type": "application/pdf", "Content-Disposition": `attachment; filename="${buildOperationalDocumentFilename("entrega", order.code)}"`, "Cache-Control": "private, no-store" } });
+}

--- a/app/api/production/requests/[id]/pick-list.pdf/route.ts
+++ b/app/api/production/requests/[id]/pick-list.pdf/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import React from "react";
+import { renderToBuffer } from "@react-pdf/renderer";
+import prisma from "@/lib/prisma";
+import { requirePermission } from "@/lib/rbac";
+import { buildOperationalDocumentFilename, OperationalDocumentPdf } from "@/lib/operations/operational-document-pdf";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requirePermission("production.execute");
+  const { id } = await params;
+  const order = await prisma.salesInternalOrder.findUnique({
+    where: { id },
+    select: {
+      code: true,
+      warehouse: { select: { code: true, name: true } },
+      pickLists: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: {
+          code: true,
+          status: true,
+          createdAt: true,
+          targetLocation: { select: { code: true, name: true } },
+          tasks: {
+            orderBy: { sequence: "asc" },
+            select: {
+              requestedQty: true,
+              pickedQty: true,
+              status: true,
+              sourceLocation: { select: { code: true } },
+              orderLine: { select: { product: { select: { sku: true, name: true, unitLabel: true } } } },
+            },
+          },
+        },
+      },
+    },
+  });
+  const pickList = order?.pickLists[0];
+  if (!order || !pickList) return NextResponse.json({ error: "Surtido no encontrado para este pedido" }, { status: 404 });
+  const pdf = await renderToBuffer(React.createElement(OperationalDocumentPdf, { snapshot: { title: "Lista de surtido", folio: pickList.code, status: pickList.status, generatedAt: pickList.createdAt, warehouse: order.warehouse ? `${order.warehouse.code} - ${order.warehouse.name}` : "Sin almacén", location: `${pickList.targetLocation.code} - ${pickList.targetLocation.name}`, reference: order.code, lines: pickList.tasks.map((task) => ({ sku: task.orderLine.product?.sku || "—", name: task.orderLine.product?.name || "Material configurado", quantity: task.requestedQty, unit: task.orderLine.product?.unitLabel || "unidad", detail: `Origen: ${task.sourceLocation.code} · Surtido: ${task.pickedQty} · ${task.status}` })) } }) as unknown as Parameters<typeof renderToBuffer>[0]);
+  return new NextResponse(new Uint8Array(pdf), { headers: { "Content-Type": "application/pdf", "Content-Disposition": `attachment; filename="${buildOperationalDocumentFilename("surtido", pickList.code)}"`, "Cache-Control": "private, no-store" } });
+}

--- a/app/api/purchasing/receipts/[id]/pdf/route.ts
+++ b/app/api/purchasing/receipts/[id]/pdf/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import React from "react";
+import { renderToBuffer } from "@react-pdf/renderer";
+import prisma from "@/lib/prisma";
+import { requirePermission } from "@/lib/rbac";
+import { buildOperationalDocumentFilename, OperationalDocumentPdf } from "@/lib/operations/operational-document-pdf";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requirePermission("purchasing.receive");
+  const { id } = await params;
+  const receipt = await prisma.purchaseReceipt.findUnique({
+    where: { id },
+    select: {
+      id: true, receivedAt: true, notes: true, referenceDoc: true,
+      location: { select: { code: true, name: true, warehouse: { select: { code: true, name: true } } } },
+      purchaseOrder: { select: { folio: true } },
+      lines: { select: { qtyReceived: true, qtyDamaged: true, qtyMissing: true, qtyRejected: true, purchaseOrderLine: { select: { product: { select: { sku: true, name: true, unitLabel: true } } } } } },
+    },
+  });
+  if (!receipt) return NextResponse.json({ error: "Recepción no encontrada" }, { status: 404 });
+  const pdf = await renderToBuffer(React.createElement(OperationalDocumentPdf, { snapshot: {
+    title: "Comprobante de recepción", folio: receipt.purchaseOrder.folio, status: "Recibido", generatedAt: receipt.receivedAt,
+    warehouse: `${receipt.location.warehouse.code} - ${receipt.location.warehouse.name}`, location: `${receipt.location.code} - ${receipt.location.name}`,
+    reference: receipt.referenceDoc, notes: receipt.notes,
+    lines: receipt.lines.map((line) => ({ sku: line.purchaseOrderLine.product.sku, name: line.purchaseOrderLine.product.name, quantity: line.qtyReceived, unit: line.purchaseOrderLine.product.unitLabel || "unidad", detail: line.qtyDamaged || line.qtyMissing || line.qtyRejected ? `Daño: ${line.qtyDamaged}; faltante: ${line.qtyMissing}; rechazado: ${line.qtyRejected}` : null })),
+  } }) as unknown as Parameters<typeof renderToBuffer>[0]);
+  return new NextResponse(new Uint8Array(pdf), { headers: { "Content-Type": "application/pdf", "Content-Disposition": `attachment; filename="${buildOperationalDocumentFilename("recepcion", receipt.purchaseOrder.folio)}"`, "Cache-Control": "private, no-store" } });
+}

--- a/lib/operations/operational-document-pdf.tsx
+++ b/lib/operations/operational-document-pdf.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Document, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+
+export type OperationalDocumentLine = {
+  sku: string;
+  name: string;
+  quantity: number;
+  unit: string;
+  detail?: string | null;
+};
+
+export type OperationalDocumentSnapshot = {
+  title: string;
+  folio: string;
+  status: string;
+  generatedAt: Date;
+  warehouse: string;
+  location?: string | null;
+  responsible?: string | null;
+  reference?: string | null;
+  notes?: string | null;
+  lines: OperationalDocumentLine[];
+};
+
+export function buildOperationalDocumentFilename(prefix: string, folio: string) {
+  const safe = `${prefix}-${folio}`
+    .normalize("NFKD")
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[.-]+|[.-]+$/g, "");
+  return `${safe || prefix}.pdf`;
+}
+
+const styles = StyleSheet.create({
+  page: { padding: 28, fontFamily: "Helvetica", fontSize: 9, color: "#172033" },
+  header: { borderBottomWidth: 2, borderBottomColor: "#1d4ed8", paddingBottom: 10, marginBottom: 14 },
+  title: { fontSize: 18, fontFamily: "Helvetica-Bold", color: "#0f2b5b" },
+  folio: { fontSize: 11, marginTop: 4, color: "#334155" },
+  grid: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 14 },
+  field: { width: "48%", padding: 7, backgroundColor: "#f1f5f9", borderRadius: 3 },
+  label: { fontSize: 7, color: "#64748b", textTransform: "uppercase", marginBottom: 2 },
+  value: { fontSize: 9, color: "#172033" },
+  tableHead: { flexDirection: "row", backgroundColor: "#0f2b5b", color: "#ffffff", padding: 6 },
+  row: { flexDirection: "row", borderBottomWidth: 1, borderBottomColor: "#cbd5e1", paddingVertical: 6 },
+  sku: { width: "20%", fontSize: 8 },
+  product: { width: "52%", fontSize: 8 },
+  quantity: { width: "28%", textAlign: "right", fontSize: 8 },
+  note: { marginTop: 14, padding: 8, backgroundColor: "#fff7ed", borderRadius: 3, color: "#7c2d12" },
+  footer: { position: "absolute", bottom: 20, left: 28, right: 28, fontSize: 7, color: "#64748b", textAlign: "center" },
+});
+
+function formatDate(value: Date) {
+  return value.toLocaleString("es-MX", { dateStyle: "medium", timeStyle: "short" });
+}
+
+export function OperationalDocumentPdf({ snapshot }: { snapshot: OperationalDocumentSnapshot }) {
+  const fields = [
+    ["Estado", snapshot.status],
+    ["Almacén", snapshot.warehouse],
+    ["Ubicación", snapshot.location || "—"],
+    ["Responsable", snapshot.responsible || "—"],
+    ["Fecha", formatDate(snapshot.generatedAt)],
+    ["Referencia", snapshot.reference || "—"],
+  ];
+
+  return (
+    <Document title={`${snapshot.title} ${snapshot.folio}`} author="WMS SCMayher">
+      <Page size="A4" style={styles.page}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{snapshot.title}</Text>
+          <Text style={styles.folio}>Folio: {snapshot.folio}</Text>
+        </View>
+        <View style={styles.grid}>
+          {fields.map(([label, value]) => (
+            <View key={label} style={styles.field}>
+              <Text style={styles.label}>{label}</Text>
+              <Text style={styles.value}>{value}</Text>
+            </View>
+          ))}
+        </View>
+        <View style={styles.tableHead}>
+          <Text style={styles.sku}>SKU</Text><Text style={styles.product}>Material</Text><Text style={styles.quantity}>Cantidad</Text>
+        </View>
+        {snapshot.lines.map((line, index) => (
+          <View key={`${line.sku}-${index}`} style={styles.row}>
+            <Text style={styles.sku}>{line.sku}</Text>
+            <View style={styles.product}><Text>{line.name}</Text>{line.detail ? <Text style={styles.label}>{line.detail}</Text> : null}</View>
+            <Text style={styles.quantity}>{line.quantity.toLocaleString("es-MX")} {line.unit}</Text>
+          </View>
+        ))}
+        {snapshot.notes ? <View style={styles.note}><Text>Notas: {snapshot.notes}</Text></View> : null}
+        <Text style={styles.footer}>Documento generado por WMS SCMayher · Conserva este comprobante con el movimiento físico.</Text>
+      </Page>
+    </Document>
+  );
+}

--- a/tests/operations/operational-document-pdf.unit.test.ts
+++ b/tests/operations/operational-document-pdf.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import React from "react";
+import { buildOperationalDocumentFilename, OperationalDocumentPdf } from "@/lib/operations/operational-document-pdf";
+
+describe("operational document PDFs", () => {
+  it("uses safe, traceable filenames", () => {
+    expect(buildOperationalDocumentFilename("entrega", "PI-2026/0001")).toBe("entrega-PI-2026-0001.pdf");
+  });
+
+  it("renders a readable PDF with the operational folio", async () => {
+    const pdf = await renderToBuffer(
+      React.createElement(OperationalDocumentPdf, {
+        snapshot: {
+          title: "Comprobante de entrega",
+          folio: "PI-2026-0001",
+          status: "Entregado al cliente",
+          generatedAt: new Date("2026-07-21T12:00:00Z"),
+          warehouse: "WH-01 - Almacén Principal",
+          location: "DESP-01 - Entregas",
+          lines: [{ sku: "MANG-01", name: "Manguera hidráulica", quantity: 2, unit: "m" }],
+        },
+      }) as Parameters<typeof renderToBuffer>[0],
+    );
+    expect(Buffer.from(pdf).subarray(0, 4).toString()).toBe("%PDF");
+    expect(pdf.byteLength).toBeGreaterThan(800);
+  });
+});


### PR DESCRIPTION
## Alcance\n- Agrega PDF trazable para recepción de compras, lista de surtido y entrega al cliente.\n- Aplica permisos por operación: recepción, ejecución de almacén y escritura de Ventas.\n- Expone accesos directos para surtido y entrega.\n\n## Validación\n- 
pm run typecheck\n- 
pm run test:unit (96 pruebas)\n- E2E mixed-order-continuity.spec.ts en Chromium contra fixtures temporales: aprobado.\n\n## Datos\nLas rutas son de solo lectura; la E2E usó y limpió únicamente fixtures temporales.