### PR TITLE
test(KAN-134): guard assembly-only delivery path

### DIFF
--- a/tests/sales/prepared-for-delivery.unit.test.ts
+++ b/tests/sales/prepared-for-delivery.unit.test.ts
@@ -47,6 +47,34 @@ describe("prepared for delivery sales order contract", () => {
     });
   });
 
+  it("keeps an assembly-only order on its linked assembly until the work is complete", () => {
+    const cta = resolveSalesOrderPrimaryCta({
+      orderId: "order-assembly-only",
+      roles: ["WAREHOUSE_OPERATOR"],
+      flowStage: "en_surtido",
+      hasProductLines: false,
+      hasAssemblyLines: true,
+      hasCompletedConfiguredAssembly: false,
+      assemblyHref: "/production/orders/assembly-order-1",
+    });
+
+    expect(cta).toMatchObject({
+      code: "COMPLETE_ASSEMBLY",
+      action: { href: "/production/orders/assembly-order-1" },
+      isAllowed: true,
+    });
+    expect(
+      getMarkDeliveredEligibility({
+        ...completedWork,
+        hasCompletedConfiguredAssembly: false,
+        preparedForDeliveryAt: new Date("2026-07-16T10:20:00.000Z"),
+      }),
+    ).toMatchObject({
+      canMarkDelivered: false,
+      deliveredBlockedReason: "Todas las órdenes de ensamble ligadas deben estar completadas",
+    });
+  });
+
   it("exposes prepared for delivery only after the physical area is recorded", () => {
     const preparedAt = new Date("2026-07-16T10:20:00.000Z");
     expect(


### PR DESCRIPTION
## Alcance\n- Cubre el pedido sólo de ensamble en la decisión operativa del operador.\n- Impide habilitar entrega mientras falte una orden de ensamble ligada.\n\n## Validación\n- 
px vitest --config vitest.unit.config.ts run tests/sales/prepared-for-delivery.unit.test.ts (4 aprobadas)\n- ESLint del archivo objetivo.\n\nLa continuidad de navegador directo, ensamble y mixto quedó validada y fusionada en PR #77.