### PR TITLE
Receipt proof download and browser evidence

### DIFF
--- a/app/(shell)/labels/document/[documentType]/[documentId]/page.tsx
+++ b/app/(shell)/labels/document/[documentType]/[documentId]/page.tsx
@@ -41,13 +41,27 @@ export default async function LabelsByDocumentPage({
         </Link>
       </div>
 
-      {isPurchaseReceipt && receiptLocation ? (
+      {isPurchaseReceipt ? (
         <div className="glass-card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="font-semibold text-white">Siguiente paso: mover material</p>
-            <p className="text-sm text-slate-300">Lleva la mercancía de {receiptLocation} a su ubicación final.</p>
+            <p className="font-semibold text-white">{receiptLocation ? "Siguiente paso: mover material" : "Comprobante de recepción disponible"}</p>
+            <p className="text-sm text-slate-300">
+              {receiptLocation
+                ? `Lleva la mercancía de ${receiptLocation} a su ubicación final.`
+                : "Conserva el comprobante para documentar la recepción física."}
+            </p>
           </div>
-          <Link href={`/inventory/transfer?from=${encodeURIComponent(receiptLocation)}&reference=${encodeURIComponent("Recepción")}`} className="btn-primary">Mover material</Link>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Link
+              href={`/api/purchasing/receipts/${documentId}/pdf`}
+              className="rounded-lg border border-white/20 px-4 py-2 text-center text-sm font-medium text-slate-100 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+            >
+              Descargar comprobante
+            </Link>
+            {receiptLocation ? (
+              <Link href={`/inventory/transfer?from=${encodeURIComponent(receiptLocation)}&reference=${encodeURIComponent("Recepción")}`} className="btn-primary">Mover material</Link>
+            ) : null}
+          </div>
         </div>
       ) : null}
 
@@ -76,4 +90,3 @@ export default async function LabelsByDocumentPage({
     </div>
   );
 }
-

--- a/tests/e2e/receipt-pdf-browser.spec.ts
+++ b/tests/e2e/receipt-pdf-browser.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { PrismaClient } from "@prisma/client";
+import { loginAs } from "./lib/auth.helpers";
+
+const prisma = new PrismaClient();
+const suffix = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+let supplierId = "";
+let productId = "";
+let warehouseId = "";
+let locationId = "";
+let orderId = "";
+let receiptId = "";
+
+async function cleanupFixture() {
+  if (receiptId) {
+    await prisma.purchaseReceiptLine.deleteMany({ where: { purchaseReceiptId: receiptId } });
+    await prisma.purchaseReceipt.deleteMany({ where: { id: receiptId } });
+  }
+  if (orderId) {
+    await prisma.purchaseOrderLine.deleteMany({ where: { purchaseOrderId: orderId } });
+    await prisma.purchaseOrder.deleteMany({ where: { id: orderId } });
+  }
+  if (locationId) await prisma.location.deleteMany({ where: { id: locationId } });
+  if (warehouseId) await prisma.warehouse.deleteMany({ where: { id: warehouseId } });
+  if (supplierId) await prisma.supplier.deleteMany({ where: { id: supplierId } });
+  if (productId) await prisma.product.deleteMany({ where: { id: productId } });
+}
+
+test.describe.serial("Comprobante de recepción", () => {
+  test.beforeAll(async () => {
+    const supplier = await prisma.supplier.create({
+      data: { code: `E2E-PDF-SUP-${suffix}`, name: "Proveedor evidencia PDF", isActive: true },
+      select: { id: true },
+    });
+    supplierId = supplier.id;
+    const product = await prisma.product.create({
+      data: { sku: `E2E-PDF-SKU-${suffix}`, name: "Material evidencia PDF", type: "HOSE" },
+      select: { id: true },
+    });
+    productId = product.id;
+    const warehouse = await prisma.warehouse.create({
+      data: { code: `E2E-PDF-WH-${suffix}`, name: "Almacén evidencia PDF" },
+      select: { id: true },
+    });
+    warehouseId = warehouse.id;
+    const location = await prisma.location.create({
+      data: {
+        code: `RECV-E2E-PDF-${suffix}`,
+        name: "Recepción evidencia PDF",
+        warehouseId,
+        usageType: "RECEIVING",
+      },
+      select: { id: true },
+    });
+    locationId = location.id;
+    const order = await prisma.purchaseOrder.create({
+      data: {
+        folio: `E2E-PDF-OC-${suffix}`,
+        supplierId,
+        deliveryWarehouseId: warehouseId,
+        status: "RECIBIDA",
+        lines: { create: { productId, qtyOrdered: 2, qtyReceived: 2, unitPrice: 125, currency: "MXN" } },
+      },
+      select: { id: true, lines: { select: { id: true } } },
+    });
+    orderId = order.id;
+    const receipt = await prisma.purchaseReceipt.create({
+      data: {
+        purchaseOrderId: orderId,
+        locationId,
+        referenceDoc: `REM-E2E-${suffix}`,
+        notes: "Fixture aislado para validar comprobante descargable.",
+        lines: { create: { purchaseOrderLineId: order.lines[0].id, productId, qtyReceived: 2 } },
+      },
+      select: { id: true },
+    });
+    receiptId = receipt.id;
+  });
+
+  test.afterAll(async () => {
+    await cleanupFixture();
+    await prisma.$disconnect();
+  });
+
+  test("el responsable de recepción descarga el comprobante desde su cierre operativo", async ({ page }) => {
+    await loginAs(
+      page,
+      "WAREHOUSE_OPERATOR",
+      `/labels/document/PURCHASE_RECEIPT/${receiptId}`,
+      `/labels/document/PURCHASE_RECEIPT/${receiptId}`,
+    );
+    await page.goto(`/labels/document/PURCHASE_RECEIPT/${receiptId}`);
+
+    await expect(page.getByRole("heading", { name: "Etiquetas de recepción" })).toBeVisible();
+    const receiptPdf = page.getByRole("link", { name: "Descargar comprobante" });
+    await expect(receiptPdf).toHaveAttribute("href", `/api/purchasing/receipts/${receiptId}/pdf`);
+
+    const downloadPromise = page.waitForEvent("download");
+    await receiptPdf.click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/^recepcion-E2E-PDF-OC-.*\.pdf$/);
+    await download.saveAs(`output/pdf/${download.suggestedFilename()}`);
+  });
+});


### PR DESCRIPTION
## What changed

Adds one clear Descargar comprobante action after a purchase receipt, next to the physical transfer action. The receipt remains accessible even when no material trace exists.

## Why

The protected receipt PDF endpoint existed, but the operator closing a receipt had no visible route to it.

## Validation

- 
px playwright test tests/e2e/receipt-pdf-browser.spec.ts --project=chromium (passed)
- Targeted ESLint and git diff --check (passed)

The E2E fixture uses the E2E-PDF prefix and deletes only its own supplier, product, warehouse, location, OC, receipt and lines.