### PR TITLE
KAN-118 semantic tokens for operational surfaces

### DIFF
--- a/app/styles/primitives.css
+++ b/app/styles/primitives.css
@@ -43,6 +43,12 @@
   box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
+.op-interactive:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
 .op-label {
   color: var(--text-secondary);
   font-size: 0.875rem;

--- a/components/CustomerSearchField.tsx
+++ b/components/CustomerSearchField.tsx
@@ -247,7 +247,7 @@ export default function CustomerSearchField({
       <input type="hidden" name={name} value={selectedId} required={required} />
 
       <label className="space-y-1">
-        <span className="text-sm text-slate-400">{label}</span>
+        <span className="op-label">{label}</span>
         <input
           value={query}
           disabled={disabled}
@@ -274,19 +274,19 @@ export default function CustomerSearchField({
               }
             }, 140);
           }}
-          className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white disabled:opacity-60 disabled:cursor-not-allowed"
+          className="op-field px-4 py-3 disabled:cursor-not-allowed disabled:opacity-60"
           placeholder={placeholder}
         />
       </label>
 
       {isLoading ? (
-        <p className="text-xs text-slate-500">Buscando clientes...</p>
+        <p className="op-helper">Buscando clientes...</p>
       ) : null}
       {!isLoading && helperText ? (
-        <p className="text-xs text-slate-500">{helperText}</p>
+        <p className="op-helper">{helperText}</p>
       ) : null}
       {searchError ? (
-        <p className="text-xs text-amber-300">{searchError}</p>
+        <p className="text-xs text-[var(--status-warning-text)]">{searchError}</p>
       ) : null}
       {showList ? (
         <div className="grid gap-2">
@@ -306,11 +306,11 @@ export default function CustomerSearchField({
                 setSearchError(null);
                 setIsOpen(false);
               }}
-              className="rounded-lg border border-white/10 p-3 text-left hover:border-cyan-400/50 hover:bg-white/5"
+              className="op-surface-muted op-interactive p-3 text-left"
             >
-              <p className="text-xs font-mono text-cyan-300">{option.code}</p>
-              <p className="text-sm text-slate-100">{option.name}</p>
-              <p className="text-xs text-slate-500">
+              <p className="text-xs font-mono text-[var(--text-accent)]">{option.code}</p>
+              <p className="text-sm text-[var(--text-primary)]">{option.name}</p>
+              <p className="op-helper">
                 {option.taxId ?? option.email ?? "Sin RFC/email"}
               </p>
             </button>
@@ -320,7 +320,7 @@ export default function CustomerSearchField({
               type="button"
               onMouseDown={(event) => event.preventDefault()}
               onClick={() => setCursor(nextCursor)}
-              className="rounded-lg border border-white/10 p-3 text-left text-sm text-cyan-300 hover:border-cyan-400/50 hover:bg-white/5"
+              className="op-surface-muted op-interactive p-3 text-left text-sm text-[var(--text-accent)]"
               disabled={isLoading}
             >
               {isLoading ? "Cargando..." : "Mostrar más coincidencias"}
@@ -330,7 +330,7 @@ export default function CustomerSearchField({
       ) : null}
 
       {canShowQuickCreate ? (
-        <div className="space-y-2 rounded-lg border border-white/10 bg-white/5 p-3">
+        <div className="op-surface-muted space-y-2 p-3">
           {!isQuickCreateOpen ? (
             <button
               type="button"
@@ -342,52 +342,52 @@ export default function CustomerSearchField({
                 setQuickCreateError(null);
                 setQuickCreateName(trimmedQuery);
               }}
-              className="rounded border border-cyan-500/40 px-3 py-2 text-sm text-cyan-300 hover:border-cyan-400 hover:text-cyan-200"
+              className="op-interactive rounded border border-[var(--status-info-border)] px-3 py-2 text-sm text-[var(--text-accent)]"
             >
               {quickCreateLabel}
             </button>
           ) : (
             <div className="grid gap-2 md:grid-cols-2">
               <label className="space-y-1 md:col-span-2">
-                <span className="text-xs text-slate-400">Nombre</span>
+                <span className="op-helper">Nombre</span>
                 <input
                   value={quickCreateName}
                   onChange={(event) => setQuickCreateName(event.target.value)}
-                  className="w-full rounded-lg border border-white/10 bg-slate-900/40 px-3 py-2 text-sm text-white"
+                  className="op-field px-3 py-2 text-sm"
                   placeholder="Cliente"
                 />
               </label>
               {allowQuickCreateCode ? (
                 <label className="space-y-1">
-                  <span className="text-xs text-slate-400">Código (opcional)</span>
+                  <span className="op-helper">Código (opcional)</span>
                   <input
                     value={quickCreateCode}
                     onChange={(event) => setQuickCreateCode(event.target.value)}
-                    className="w-full rounded-lg border border-white/10 bg-slate-900/40 px-3 py-2 text-sm text-white"
+                    className="op-field px-3 py-2 text-sm"
                     placeholder="CLI-2026-0001"
                   />
                 </label>
               ) : null}
               <label className="space-y-1">
-                <span className="text-xs text-slate-400">RFC (opcional)</span>
+                <span className="op-helper">RFC (opcional)</span>
                 <input
                   value={quickCreateTaxId}
                   onChange={(event) => setQuickCreateTaxId(event.target.value)}
-                  className="w-full rounded-lg border border-white/10 bg-slate-900/40 px-3 py-2 text-sm text-white"
+                  className="op-field px-3 py-2 text-sm"
                   placeholder="RFC"
                 />
               </label>
               <label className="space-y-1 md:col-span-2">
-                <span className="text-xs text-slate-400">Email (opcional)</span>
+                <span className="op-helper">Email (opcional)</span>
                 <input
                   value={quickCreateEmail}
                   onChange={(event) => setQuickCreateEmail(event.target.value)}
-                  className="w-full rounded-lg border border-white/10 bg-slate-900/40 px-3 py-2 text-sm text-white"
+                  className="op-field px-3 py-2 text-sm"
                   placeholder="contacto@cliente.com"
                 />
               </label>
               {quickCreateError ? (
-                <p className="text-xs text-amber-300 md:col-span-2">
+                <p className="text-xs text-[var(--status-warning-text)] md:col-span-2">
                   {quickCreateError}
                 </p>
               ) : null}
@@ -396,7 +396,7 @@ export default function CustomerSearchField({
                   type="button"
                   onClick={submitQuickCreate}
                   disabled={!canSubmitQuickCreate}
-                  className="rounded border border-cyan-500/40 px-3 py-2 text-xs text-cyan-300 hover:border-cyan-400 hover:text-cyan-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="op-interactive rounded border border-[var(--status-info-border)] px-3 py-2 text-xs text-[var(--text-accent)] disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {isQuickCreateSaving
                     ? "Guardando..."
@@ -406,7 +406,7 @@ export default function CustomerSearchField({
                   type="button"
                   onClick={resetQuickCreate}
                   disabled={isQuickCreateSaving}
-                  className="rounded border border-white/10 px-3 py-2 text-xs text-slate-300 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                  className="op-interactive rounded border border-[var(--border-default)] px-3 py-2 text-xs text-[var(--text-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Cancelar
                 </button>
@@ -417,12 +417,12 @@ export default function CustomerSearchField({
       ) : null}
 
       {selected ? (
-        <div className="rounded-lg border border-cyan-500/30 bg-cyan-500/10 p-3">
+        <div className="status-info rounded-lg p-3">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <p className="text-xs text-cyan-300 font-mono">{selected.code}</p>
-              <p className="text-sm text-slate-100">{selected.name}</p>
-              <p className="text-xs text-slate-300">
+              <p className="text-xs text-[var(--text-accent)] font-mono">{selected.code}</p>
+              <p className="text-sm text-[var(--text-primary)]">{selected.name}</p>
+              <p className="text-xs text-[var(--text-secondary)]">
                 {selected.taxId ?? selected.email ?? "Sin datos de contacto"}
               </p>
             </div>
@@ -438,7 +438,7 @@ export default function CustomerSearchField({
                 setCursor(null);
                 setNextCursor(null);
               }}
-              className="text-xs rounded border border-white/10 px-2 py-1 text-slate-300 hover:text-white"
+              className="op-interactive rounded border border-[var(--border-default)] px-2 py-1 text-xs text-[var(--text-secondary)]"
             >
               Limpiar
             </button>

--- a/components/NewOrderForm.tsx
+++ b/components/NewOrderForm.tsx
@@ -292,7 +292,7 @@ export function NewOrderForm({
             })}
           </nav>
           {serverError ? (
-            <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            <div className="status-danger rounded-xl px-4 py-3 text-sm">
               {serverError}
             </div>
           ) : null}
@@ -308,7 +308,7 @@ export function NewOrderForm({
               </div>
 
               {invalidProductContext ? (
-                <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+                <div className="status-warning rounded-xl p-4 text-sm">
                   No encontramos el producto seleccionado. Puedes corregir la
                   selección o seguir con la captura manual sin perder el
                   pedido.
@@ -345,7 +345,7 @@ export function NewOrderForm({
                     </div>
                   </div>
                   <div className="op-next-action text-sm">
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--execution-active-text)]">
                       Siguiente acción
                     </p>
                     <p className="mt-2">
@@ -355,8 +355,8 @@ export function NewOrderForm({
                   </div>
                 </div>
               ) : displayQuery ? (
-                <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4 text-sm text-cyan-50">
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">
+                <div className="status-info rounded-xl p-4 text-sm">
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--execution-active-text)]">
                     Contexto comercial
                   </p>
                   <p className="mt-2 text-lg font-semibold text-[var(--text-primary)]">

--- a/components/OrderSummary.tsx
+++ b/components/OrderSummary.tsx
@@ -122,7 +122,7 @@ export function OrderSummary({
       {/* Mobile collapsible version - visible on mobile */}
       <div className="lg:hidden" data-testid="order-summary-mobile">
         <details className="op-surface-muted">
-          <summary className="flex cursor-pointer items-center justify-between p-4 list-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900">
+          <summary className="flex cursor-pointer items-center justify-between p-4 list-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)]">
             <div className="flex items-center gap-3">
               <div className="w-8 h-8 rounded-lg bg-cyan-500/20 flex items-center justify-center">
                 <svg className="w-5 h-5 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -142,7 +142,7 @@ export function OrderSummary({
                 {readinessState === "not_ready" && "Pendiente"}
               </Badge>
             </div>
-            <svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5 text-[var(--text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
             </svg>
           </summary>
@@ -236,7 +236,7 @@ function OrderSummaryContent({
                   <span
                     className={cn(
                       "text-sm font-medium",
-                      isCompleted ? "text-emerald-300" : isCurrent ? "text-cyan-300" : "text-slate-300"
+                      isCompleted ? "text-[var(--status-success-text)]" : isCurrent ? "text-[var(--execution-active-text)]" : "text-[var(--text-secondary)]"
                     )}
                   >
                     {step.label}
@@ -330,41 +330,41 @@ function OrderSummaryContent({
       <div className="border-t border-[var(--border-soft)] pt-3 space-y-3">
         {/* Customer */}
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
             Cliente
           </p>
-          <p className={cn("text-sm", missingFields.includes("customerId") || missingFields.includes("customerName") ? "text-amber-300" : "text-white")}>
+          <p className={cn("text-sm", missingFields.includes("customerId") || missingFields.includes("customerName") ? "text-[var(--status-warning-text)]" : "text-[var(--text-primary)]")}>
             {customerName || customerId ? (
               <>
                 {customerName && <span className="font-medium">{customerName}</span>}
                 {customerId && <span className="font-mono text-xs text-slate-400 ml-1">({customerId})</span>}
               </>
             ) : (
-              <span className="text-slate-400">Cliente pendiente</span>
+              <span className="text-[var(--text-muted)]">Cliente pendiente</span>
             )}
           </p>
         </div>
 
         {/* Warehouse / Fulfillment Source */}
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
             Almacén / Origen
           </p>
-          <p className={cn("text-sm", missingFields.includes("warehouseId") ? "text-amber-300" : "text-white")}>
+          <p className={cn("text-sm", missingFields.includes("warehouseId") ? "text-[var(--status-warning-text)]" : "text-[var(--text-primary)]")}>
             {warehouseCode && warehouseName ? (
               <>{warehouseCode} - {warehouseName}</>
             ) : (
-              <span className="text-slate-400">Almacén pendiente</span>
+              <span className="text-[var(--text-muted)]">Almacén pendiente</span>
             )}
           </p>
         </div>
 
         {/* Delivery / Commitment Date */}
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
             Fecha compromiso
           </p>
-          <p className={cn("text-sm", missingFields.includes("dueDate") ? "text-amber-300" : "text-white")}>
+          <p className={cn("text-sm", missingFields.includes("dueDate") ? "text-[var(--status-warning-text)]" : "text-[var(--text-primary)]")}>
             {dueDate ? (
               new Date(dueDate).toLocaleDateString("es-MX", {
                 weekday: "short",
@@ -373,7 +373,7 @@ function OrderSummaryContent({
                 year: "numeric",
               })
             ) : (
-              <span className="text-slate-400">Fecha pendiente</span>
+              <span className="text-[var(--text-muted)]">Fecha pendiente</span>
             )}
           </p>
         </div>

--- a/tests/ux/operational-surfaces.contract.test.ts
+++ b/tests/ux/operational-surfaces.contract.test.ts
@@ -83,5 +83,20 @@ describe("operational surfaces UI contract", () => {
     expect(primitives).toContain(".op-progress-list");
     expect(primitives).toContain(".op-progress-marker");
     expect(primitives).toContain(".op-card");
+    expect(primitives).toContain(".op-interactive:focus-visible");
+  });
+
+  it("keeps customer selection and order feedback on semantic operational tokens", () => {
+    const customerSearch = read("components/CustomerSearchField.tsx");
+    const form = read("components/NewOrderForm.tsx");
+    const summary = read("components/OrderSummary.tsx");
+
+    expect(customerSearch).toContain('className="op-field px-4 py-3');
+    expect(customerSearch).toContain("op-interactive");
+    expect(customerSearch).toContain("status-info rounded-lg");
+    expect(form).toContain("status-danger rounded-xl");
+    expect(form).toContain("status-warning rounded-xl");
+    expect(summary).toContain("focus-visible:ring-[var(--focus-ring)]");
+    expect(summary).toContain('"text-[var(--status-warning-text)]"');
   });
 });


### PR DESCRIPTION
## What changed

Uses the existing semantic tokens in customer selection, Nuevo Pedido feedback and the order summary. Adds a shared visible-focus primitive and a contract test.

## Why

These operational surfaces still repeated dark-only Tailwind classes, weakening light-mode contrast and keyboard-focus consistency.

## Validation

- 
px vitest --config vitest.unit.config.ts run tests/ux/operational-surfaces.contract.test.ts tests/customers/request-new-customer-ui.contract.test.ts (12 passed)
- 
px tsc --noEmit (passed)
- Targeted ESLint and git diff --check (passed)

No workflow, RBAC, schema or database behavior changes.