### PR TITLE
Prevent long SKU overlap in operational PDFs

### DIFF
--- a/lib/operations/operational-document-pdf.tsx
+++ b/lib/operations/operational-document-pdf.tsx
@@ -42,8 +42,8 @@ const styles = StyleSheet.create({
   value: { fontSize: 9, color: "#172033" },
   tableHead: { flexDirection: "row", backgroundColor: "#0f2b5b", color: "#ffffff", padding: 6 },
   row: { flexDirection: "row", borderBottomWidth: 1, borderBottomColor: "#cbd5e1", paddingVertical: 6 },
-  sku: { width: "20%", fontSize: 8 },
-  product: { width: "52%", fontSize: 8 },
+  sku: { width: "22%", flexShrink: 1, fontSize: 7, paddingRight: 5 },
+  product: { width: "50%", flexShrink: 1, fontSize: 8, paddingRight: 4 },
   quantity: { width: "28%", textAlign: "right", fontSize: 8 },
   note: { marginTop: 14, padding: 8, backgroundColor: "#fff7ed", borderRadius: 3, color: "#7c2d12" },
   footer: { position: "absolute", bottom: 20, left: 28, right: 28, fontSize: 7, color: "#64748b", textAlign: "center" },
@@ -51,6 +51,12 @@ const styles = StyleSheet.create({
 
 function formatDate(value: Date) {
   return value.toLocaleString("es-MX", { dateStyle: "medium", timeStyle: "short" });
+}
+
+function formatSkuForDocument(sku: string) {
+  // Un SKU puede ser una clave continua de trazabilidad. Sólo se parte para
+  // impresión, evitando que invada la columna de material.
+  return sku.length > 18 ? sku.match(/.{1,18}/g)?.join("\n") ?? sku : sku;
 }
 
 export function OperationalDocumentPdf({ snapshot }: { snapshot: OperationalDocumentSnapshot }) {
@@ -83,7 +89,7 @@ export function OperationalDocumentPdf({ snapshot }: { snapshot: OperationalDocu
         </View>
         {snapshot.lines.map((line, index) => (
           <View key={`${line.sku}-${index}`} style={styles.row}>
-            <Text style={styles.sku}>{line.sku}</Text>
+            <Text style={styles.sku}>{formatSkuForDocument(line.sku)}</Text>
             <View style={styles.product}><Text>{line.name}</Text>{line.detail ? <Text style={styles.label}>{line.detail}</Text> : null}</View>
             <Text style={styles.quantity}>{line.quantity.toLocaleString("es-MX")} {line.unit}</Text>
           </View>

--- a/tests/operations/operational-document-pdf.unit.test.ts
+++ b/tests/operations/operational-document-pdf.unit.test.ts
@@ -18,7 +18,7 @@ describe("operational document PDFs", () => {
           generatedAt: new Date("2026-07-21T12:00:00Z"),
           warehouse: "WH-01 - Almacén Principal",
           location: "DESP-01 - Entregas",
-          lines: [{ sku: "MANG-01", name: "Manguera hidráulica", quantity: 2, unit: "m" }],
+          lines: [{ sku: "SKU-DE-TRAZABILIDAD-MUY-LARGO-001", name: "Manguera hidráulica", quantity: 2, unit: "m" }],
         },
       }) as Parameters<typeof renderToBuffer>[0],
     );


### PR DESCRIPTION
## What changed

Wraps long SKU traceability values within the SKU column of the shared operational PDF layout and slightly protects the SKU/material column widths.

## Root cause

A long continuous SKU could visually overlap the Material column in the reception proof.

## Validation

- 
px vitest --config vitest.unit.config.ts run tests/operations/operational-document-pdf.unit.test.ts (2 passed)
- Browser evidence: receipt download plus direct Sales to Warehouse to Delivery flow (2 passed)
- Visual render with Poppler at 150 dpi: receipt, pick list and delivery proof reviewed with no overlap, clipping or unreadable fields after the fix.

No schema, business-flow or AWS data changes.