### PR TITLE
fix: alinear flujo operativo y regresiones de auditoría

### DIFF
--- a/app/(shell)/production/requests/page.tsx
+++ b/app/(shell)/production/requests/page.tsx
@@ -1122,7 +1122,7 @@ export default async function ProductionRequestsPage({
                         : "--"}
                     </p>
                     <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
-                      <span><span className="font-medium text-[var(--text-primary)]">Siguiente:</span> {operationalState.nextAction}</span>
+                      <span><span className="font-medium text-[var(--text-primary)]">Siguiente:</span> {flowNarrative.nextRecommendedAction.label}</span>
                       <span><span className="font-medium text-[var(--text-primary)]">Compromiso:</span> {formatDate(order.dueDate)}</span>
                       <span><span className="font-medium text-[var(--text-primary)]">Responsable:</span> {order.assignedToUser ? (order.assignedToUser.name ?? order.assignedToUser.email ?? "--") : "Sin asignar"}</span>
                     </div>

--- a/app/(shell)/sales/page.tsx
+++ b/app/(shell)/sales/page.tsx
@@ -7,6 +7,52 @@ import { getSalesOrderFlowStage } from "@/lib/sales/internal-orders";
 
 export const dynamic = "force-dynamic";
 
+type SalesOrderForFlow = {
+  status: Parameters<typeof getSalesOrderFlowStage>[0]["status"];
+  assignedToUserId: string | null;
+  deliveredToCustomerAt: Date | null;
+  preparedForDeliveryAt: Date | null;
+  lines: Array<{ id: string; lineKind: string }>;
+  pickLists: Array<{ status: string }>;
+};
+
+type LinkedAssemblyOrder = {
+  sourceDocumentId: string | null;
+  sourceDocumentLineId: string | null;
+  status: string;
+};
+
+function getCanonicalSalesFlowStage(
+  order: SalesOrderForFlow,
+  linkedAssemblyOrders: LinkedAssemblyOrder[],
+) {
+  const productLines = order.lines.filter((line) => line.lineKind === "PRODUCT");
+  const assemblyLineIds = order.lines
+    .filter((line) => line.lineKind === "CONFIGURED_ASSEMBLY")
+    .map((line) => line.id);
+  const assemblyLineIdSet = new Set(assemblyLineIds);
+  const linkedForOrder = linkedAssemblyOrders.filter(
+    (productionOrder) =>
+      productionOrder.sourceDocumentLineId !== null &&
+      assemblyLineIdSet.has(productionOrder.sourceDocumentLineId),
+  );
+  const hasCompletedConfiguredAssembly =
+    assemblyLineIds.length === 0 ||
+    (linkedForOrder.length === assemblyLineIds.length &&
+      linkedForOrder.every((productionOrder) => productionOrder.status === "COMPLETADA"));
+
+  return getSalesOrderFlowStage({
+    status: order.status,
+    assignedToUserId: order.assignedToUserId,
+    deliveredToCustomerAt: order.deliveredToCustomerAt,
+    preparedForDeliveryAt: order.preparedForDeliveryAt,
+    latestPickStatus: order.pickLists[0]?.status ?? null,
+    hasProductLines: productLines.length > 0,
+    hasAssemblyLines: assemblyLineIds.length > 0,
+    hasCompletedConfiguredAssembly,
+  });
+}
+
 export default async function SalesPage() {
   const ctx = await getSessionContext();
 
@@ -41,13 +87,13 @@ export default async function SalesPage() {
       status: true,
       assignedToUserId: true,
       pulledAt: true,
+      preparedForDeliveryAt: true,
       deliveredToCustomerAt: true,
       cancelledAt: true,
       updatedAt: true,
       customerName: true,
       lines: {
-        select: { id: true },
-        take: 1,
+        select: { id: true, lineKind: true },
       },
       pickLists: {
         select: { status: true },
@@ -57,7 +103,61 @@ export default async function SalesPage() {
     },
   });
 
-  // Count orders by canonical flow stage using shared helper
+  const recentOrdersData = await prisma.salesInternalOrder.findMany({
+    where: {
+      OR: [
+        { assignedToUserId: userId },
+        { requestedByUserId: userId },
+      ],
+    },
+    orderBy: { updatedAt: "desc" },
+    take: 8,
+    select: {
+      id: true,
+      code: true,
+      customerName: true,
+      status: true,
+      assignedToUserId: true,
+      pulledAt: true,
+      preparedForDeliveryAt: true,
+      deliveredToCustomerAt: true,
+      cancelledAt: true,
+      updatedAt: true,
+      lines: {
+        select: { id: true, lineKind: true },
+      },
+      pickLists: {
+        select: { status: true },
+        take: 1,
+        orderBy: { updatedAt: "desc" },
+      },
+    },
+  });
+
+  const orderIds = [...new Set([...orders, ...recentOrdersData].map((order) => order.id))];
+  const linkedAssemblyOrders = orderIds.length
+    ? await prisma.productionOrder.findMany({
+        where: {
+          sourceDocumentType: "SalesInternalOrder",
+          sourceDocumentId: { in: orderIds },
+        },
+        select: {
+          sourceDocumentId: true,
+          sourceDocumentLineId: true,
+          status: true,
+        },
+      })
+    : [];
+
+  const linkedAssembliesByOrderId = new Map<string, LinkedAssemblyOrder[]>();
+  for (const productionOrder of linkedAssemblyOrders) {
+    if (!productionOrder.sourceDocumentId) continue;
+    const current = linkedAssembliesByOrderId.get(productionOrder.sourceDocumentId) ?? [];
+    current.push(productionOrder);
+    linkedAssembliesByOrderId.set(productionOrder.sourceDocumentId, current);
+  }
+
+  // Count orders by canonical flow stage using the same line and assembly facts as the execution flow.
   let capturaOrders = 0;
   let porAsignarOrders = 0;
   let enSurtidoOrders = 0;
@@ -65,20 +165,10 @@ export default async function SalesPage() {
   let entregadoOrders = 0;
 
   for (const order of orders) {
-    const hasProductLines = order.lines.length > 0;
-    const hasAssemblyLines = false; // Assembly configs are on order lines, not directly on order
-    const latestPickStatus = order.pickLists[0]?.status ?? null;
-    const hasCompletedConfiguredAssembly = false; // Assembly completion tracked elsewhere
-
-    const stage = getSalesOrderFlowStage({
-      status: order.status,
-      assignedToUserId: order.assignedToUserId,
-      deliveredToCustomerAt: order.deliveredToCustomerAt,
-      latestPickStatus,
-      hasProductLines,
-      hasAssemblyLines,
-      hasCompletedConfiguredAssembly,
-    });
+    const stage = getCanonicalSalesFlowStage(
+      order,
+      linkedAssembliesByOrderId.get(order.id) ?? [],
+    );
 
     switch (stage) {
       case "captura":
@@ -101,53 +191,11 @@ export default async function SalesPage() {
 
   const activeCustomers = await prisma.customer.count({ where: { isActive: true } });
 
-  // Fetch recent orders for the "Recent Orders" section
-  const recentOrdersData = await prisma.salesInternalOrder.findMany({
-    where: {
-      OR: [
-        { assignedToUserId: userId },
-        { requestedByUserId: userId },
-      ],
-    },
-    orderBy: { updatedAt: "desc" },
-    take: 8,
-    select: {
-      id: true,
-      code: true,
-      customerName: true,
-      status: true,
-      assignedToUserId: true,
-      pulledAt: true,
-      deliveredToCustomerAt: true,
-      cancelledAt: true,
-      updatedAt: true,
-      lines: {
-        select: { id: true },
-        take: 1,
-      },
-      pickLists: {
-        select: { status: true },
-        take: 1,
-        orderBy: { updatedAt: "desc" },
-      },
-    },
-  });
-
   const recentOrders = recentOrdersData.map((order) => {
-    const hasProductLines = order.lines.length > 0;
-    const hasAssemblyLines = false;
-    const latestPickStatus = order.pickLists[0]?.status ?? null;
-    const hasCompletedConfiguredAssembly = false;
-
-    const flowStage = getSalesOrderFlowStage({
-      status: order.status,
-      assignedToUserId: order.assignedToUserId,
-      deliveredToCustomerAt: order.deliveredToCustomerAt,
-      latestPickStatus,
-      hasProductLines,
-      hasAssemblyLines,
-      hasCompletedConfiguredAssembly,
-    });
+    const flowStage = getCanonicalSalesFlowStage(
+      order,
+      linkedAssembliesByOrderId.get(order.id) ?? [],
+    );
     return {
       id: order.id,
       code: order.code,

--- a/components/home/AdminHomeContent.tsx
+++ b/components/home/AdminHomeContent.tsx
@@ -85,8 +85,8 @@ export function AdminHomeContent({
           <div className="space-y-3">
             {(recentAudits && recentAudits.length > 0 ? recentAudits : []).map((audit) => (
               <div key={audit.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                <div>
-                  <p className="font-medium">{audit.action}</p>
+                <div className="min-w-0">
+                  <p className="break-words font-medium">{audit.action}</p>
                   <p className="text-sm text-gray-500">
                     {audit.actor ?? 'Sistema'} · {formatTimeAgo(audit.createdAt)}
                   </p>

--- a/lib/rbac/route-permissions.ts
+++ b/lib/rbac/route-permissions.ts
@@ -26,7 +26,7 @@ export const ROUTE_PERMISSION_RULES: RoutePermissionRule[] = [
   { prefix: "/warehouse/", permission: "warehouse.manage" },
   { prefix: "/warehouse", permission: "warehouse.manage" },
 
-  { prefix: "/production/requests/", permission: "production.cockpit.view" },
+  { prefix: "/production/requests/new", permission: "sales.view" },
   { prefix: "/production/requests", permission: "production.cockpit.view" },
   { prefix: "/production/availability", permission: "sales.view" },
   { prefix: "/production/equivalences", permission: "sales.view" },
@@ -66,6 +66,13 @@ export const ROUTE_PERMISSION_RULES: RoutePermissionRule[] = [
 ];
 
 export function getRequiredPermissionForPath(pathname: string): PermissionCode | null {
+  if (
+    pathname === "/production/requests/new" ||
+    /^\/production\/requests\/[^/]+\/assembly\/new$/.test(pathname)
+  ) {
+    return "sales.view";
+  }
+
   if (pathname.startsWith("/sales/customers/") && pathname.endsWith("/edit")) {
     return "customers.manage";
   }

--- a/tests/auth/callback-url.test.ts
+++ b/tests/auth/callback-url.test.ts
@@ -41,6 +41,12 @@ describe("resolvePostLoginRedirect", () => {
   it("rechaza callbacks no autorizados para el rol", () => {
     expect(resolvePostLoginRedirect("/users", ["MANAGER"])).toBe("/home/manager");
     expect(resolvePostLoginRedirect("/production/fulfillment", ["SALES_EXECUTIVE"])).toBe("/home/sales");
+    expect(resolvePostLoginRedirect("/production/requests/new", ["WAREHOUSE_OPERATOR"])).toBe("/home/warehouse");
+  });
+
+  it("preserva las rutas comerciales de captura y configuracion para ventas", () => {
+    expect(resolvePostLoginRedirect("/production/requests/new", ["SALES_EXECUTIVE"])).toBe("/production/requests/new");
+    expect(resolvePostLoginRedirect("/production/requests/order-1/assembly/new", ["SALES_EXECUTIVE"])).toBe("/production/requests/order-1/assembly/new");
   });
 
   it("permite callback al home propio del rol", () => {

--- a/tests/e2e/a11y-smoke.spec.ts
+++ b/tests/e2e/a11y-smoke.spec.ts
@@ -17,13 +17,13 @@ const A11Y_ROUTES: A11yRoute[] = [
   {
     path: "/",
     role: "SYSTEM_ADMIN" as RoleKey,
-    heading: /Dashboard/i,
+    heading: /Inicio Administraci[oó]n/i,
     tags: TAGS,
   },
   {
     path: "/production/requests",
     role: "SALES_EXECUTIVE" as RoleKey,
-    heading: /Pedidos comerciales/i,
+    heading: /Pedidos y surtidos/i,
     tags: TAGS,
     extraChecks: async (page: import("@playwright/test").Page) => {
       await expect(page.getByTestId("requests-quick-filters")).toBeVisible();
@@ -47,7 +47,6 @@ const A11Y_ROUTES: A11yRoute[] = [
     heading: /Nuevo pedido comercial/i,
     tags: TAGS,
     extraChecks: async (page: import("@playwright/test").Page) => {
-      await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
       await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
     },
   },
@@ -60,7 +59,7 @@ const A11Y_ROUTES: A11yRoute[] = [
   {
     path: "/purchasing/orders",
     role: "WAREHOUSE_OPERATOR" as RoleKey,
-    heading: /^Órdenes de compra$/i,
+    heading: /^Trabajo de recepción$/i,
     tags: TAGS,
   },
   {
@@ -81,8 +80,8 @@ for (const { path, role, heading, tags, extraChecks } of A11Y_ROUTES) {
   if (role) {
     test.describe(`KAN-55/KAN-63/KAN-87 A11y: ${path} (authenticated as ${role})`, () => {
       test(`no axe violations on ${path}`, async ({ page }) => {
-        await loginAs(page, role, path);
-        await page.goto(path);
+        const expectedUrl = path === "/" ? undefined : path;
+        await loginAs(page, role, path, expectedUrl);
         await expect(
           page.getByRole("heading", { name: heading }),
         ).toBeVisible();

--- a/tests/e2e/full-role-matrix.spec.ts
+++ b/tests/e2e/full-role-matrix.spec.ts
@@ -44,7 +44,7 @@ const ROLE_CHECKS: Record<
     visibleRoutes: [
       ["/inventory", /Inventario/i],
       ["/production", /Produccion de ensambles/i],
-      ["/production/requests", /Cockpit de ejecuci[oó]n/i],
+      ["/production/requests", /Trabajo de almac[eé]n/i],
     ],
     blockedRoutes: [
       "/users",
@@ -103,7 +103,7 @@ test.describe("full role matrix", () => {
       }
 
       if (role === "WAREHOUSE_OPERATOR") {
-        await expectAllowed(page, "/production/requests", /Cockpit de ejecución/i);
+        await expectAllowed(page, "/production/requests", /Trabajo de almacén/i);
         await expect(page.getByText("Vista administrativa", { exact: true })).toHaveCount(0);
       }
 

--- a/tests/e2e/mobile-smoke.spec.ts
+++ b/tests/e2e/mobile-smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 import { loginAs, type RoleKey } from "./lib/auth.helpers";
 
 const MOBILE_ROUTES = [
-  { path: "/", role: "SYSTEM_ADMIN" as RoleKey, heading: /Dashboard/i },
+  { path: "/", role: "SYSTEM_ADMIN" as RoleKey, heading: /Inicio Administraci[oó]n/i },
   {
     path: "/production/requests",
     role: "SALES_EXECUTIVE" as RoleKey,
@@ -21,7 +21,7 @@ const MOBILE_ROUTES = [
   {
     path: "/purchasing/orders",
     role: "WAREHOUSE_OPERATOR" as RoleKey,
-    heading: /^Órdenes de compra$/i,
+    heading: /^Trabajo de recepción$/i,
   },
   {
     path: "/inventory",
@@ -36,15 +36,15 @@ for (const { path, role, heading } of MOBILE_ROUTES) {
     test.describe(`Mobile: ${path} (authenticated as ${role})`, () => {
       test(`carga correctamente en móvil`, async ({ page }, testInfo) => {
         test.skip(!testInfo.project.name.startsWith("mobile"), "Este smoke solo valida proyectos móviles.");
-        await loginAs(page, role);
-        const routePage = await page.context().newPage();
-        await routePage.goto(path);
+        const expectedUrl = path === "/" ? undefined : path;
+        await loginAs(page, role, path, expectedUrl);
+        const routePage = page;
         await expect(routePage.getByRole("heading", { name: heading })).toBeVisible();
         if (path === "/production/requests" && role === "SALES_EXECUTIVE") {
           await expect(routePage.getByTestId("requests-quick-filters")).toBeVisible();
           await expect(
             routePage.getByTestId("requests-quick-filters").getByRole("link", {
-              name: /^Mis pedidos$/,
+              name: /^Para actuar$/,
             }),
           ).toBeVisible();
           await expect(routePage.getByText("Más filtros", { exact: true })).toBeVisible();
@@ -72,7 +72,6 @@ for (const { path, role, heading } of MOBILE_ROUTES) {
           expect(quickFiltersHeight?.height ?? 0).toBeLessThan(120);
         }
         if (path === "/production/requests/new" && role === "SALES_EXECUTIVE") {
-          await expect(routePage.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
           await expect(routePage.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
         }
         if (path === "/purchasing/orders" && role === "WAREHOUSE_OPERATOR") {
@@ -86,18 +85,17 @@ for (const { path, role, heading } of MOBILE_ROUTES) {
           if ((await receiveLinks.count()) > 0) {
             await expect(receiveLinks.first()).toBeVisible();
           } else {
-            await expect(routePage.getByText(/Sin acciones operativas disponibles|Sin acción|No hay órdenes de compra/i).first()).toBeVisible();
+            await expect(routePage.getByText(/No hay trabajo en esta bandeja/i).first()).toBeVisible();
           }
         }
         if (path === "/purchasing/orders" && role === "MANAGER") {
           await expect(
-            routePage.getByRole("link", { name: /Por recibir hoy/i }),
+            routePage.getByRole("link", { name: /Por enviar o recibir/i }),
           ).toBeVisible();
         }
         const bodyWidth = await routePage.evaluate(() => document.body.scrollWidth);
         const viewportWidth = routePage.viewportSize()?.width ?? 390;
         expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 20);
-        await routePage.close();
       });
     });
   } else {

--- a/tests/e2e/purchasing-pdf-flow.spec.ts
+++ b/tests/e2e/purchasing-pdf-flow.spec.ts
@@ -125,12 +125,17 @@ test.describe("PDF Flow - Purchase Order Document", () => {
     await expect(page.getByText(/No existe un documento oficial persistido para esta OC/i)).toBeVisible();
   });
 
-  test("KAN-93 detail page keeps contract-only actions accessible on mobile", async ({ page }) => {
+  test("detail page keeps official-document actions accessible on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await loginAs(page, "MANAGER", `/purchasing/orders/${orderWithDocumentId}`);
+    await loginAs(
+      page,
+      "MANAGER",
+      `/purchasing/orders/${orderWithDocumentId}`,
+      `/purchasing/orders/${orderWithDocumentId}`,
+    );
     await page.goto(`/purchasing/orders/${orderWithDocumentId}`);
 
-    await expect(page.getByText(/Contrato preparado para KAN-85/i)).toBeVisible();
+    await expect(page.getByText(/Avance comercial de la orden/i)).toBeVisible();
     await expect(page.getByRole("heading", { name: /Línea de tiempo operativa/i })).toBeVisible();
     await expect(page.getByRole("heading", { name: /Siguiente acción/i })).toBeVisible();
     const detailLink = page.getByRole("link", { name: /Ver documento oficial/i });

--- a/tests/production/requests-list-action.contract.test.ts
+++ b/tests/production/requests-list-action.contract.test.ts
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const pagePath = path.join(process.cwd(), "app", "(shell)", "production", "requests", "page.tsx");
+
+describe("production requests list action contract", () => {
+  it("uses the canonical flow narrative for the visible next action", () => {
+    const source = fs.readFileSync(pagePath, "utf8");
+
+    expect(source).toContain("Siguiente:</span> {flowNarrative.nextRecommendedAction.label}");
+    expect(source).not.toContain("Siguiente:</span> {operationalState.nextAction}");
+  });
+});

--- a/tests/rbac/route-access.integration.test.ts
+++ b/tests/rbac/route-access.integration.test.ts
@@ -50,6 +50,8 @@ describe("rbac role-route access matrix", () => {
     expect(getRequiredPermissionForPath("/warehouse/abc")).toBe("warehouse.manage");
     expect(getRequiredPermissionForPath("/audit")).toBe("audit.view");
     expect(getRequiredPermissionForPath("/production/requests")).toBe("production.cockpit.view");
+    expect(getRequiredPermissionForPath("/production/requests/new")).toBe("sales.view");
+    expect(getRequiredPermissionForPath("/production/requests/abc/assembly/new")).toBe("sales.view");
     expect(getRequiredPermissionForPath("/production/availability")).toBe("sales.view");
     expect(getRequiredPermissionForPath("/production/equivalences")).toBe("sales.view");
     expect(getRequiredPermissionForPath("/production/fulfillment")).toBe("production.execute");
@@ -115,10 +117,12 @@ describe("rbac role-route access matrix", () => {
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/fulfillment")).toBe(true);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/fulfillment/abc")).toBe(true);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/requests/new")).toBe(false);
+    expect(canAccess("WAREHOUSE_OPERATOR", "/production/requests/abc/assembly/new")).toBe(false);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/availability")).toBe(false);
     expect(canAccess("WAREHOUSE_OPERATOR", "/production/equivalences")).toBe(false);
     expect(canAccess("SALES_EXECUTIVE", "/production/requests")).toBe(true);
     expect(canAccess("SALES_EXECUTIVE", "/production/requests/new")).toBe(true);
+    expect(canAccess("SALES_EXECUTIVE", "/production/requests/abc/assembly/new")).toBe(true);
     expect(canAccess("SALES_EXECUTIVE", "/production/availability")).toBe(true);
     expect(canAccess("SALES_EXECUTIVE", "/production/equivalences")).toBe(true);
     expect(canAccess("SALES_EXECUTIVE", "/production/fulfillment")).toBe(false);


### PR DESCRIPTION
## Qué cambia
- Alinea la siguiente acción visible de cada pedido con el CTA principal del flujo.
- Calcula el avance comercial con líneas de producto, ensambles configurados y órdenes de producción vinculadas reales.
- Protege Nuevo Pedido y el alta de ensamble con el permiso comercial correcto, evitando acceso del Operador.
- Corrige el desbordamiento móvil de acciones técnicas en Inicio Administración.
- Actualiza los arneses de rol, móvil, accesibilidad y PDF a los nombres y retornos de ruta vigentes.

## Causa raíz
La interfaz y varios arneses conservaban dos fuentes de estado o expectativas históricas: la lista podía mostrar una acción distinta al CTA, Ventas no recibía los hechos de ensamble reales y algunas pruebas autenticaban hacia la portada antes de abrir su ruta objetivo.

## Impacto operativo
Ventas recibe una guía consistente del pedido; Operador mantiene segregación de funciones; las pantallas clave caben a 390 px y el control automatizado vuelve a validar las rutas reales por rol.

## Validación
- `npx vitest run tests/rbac/route-access.integration.test.ts tests/auth/callback-url.test.ts tests/production/requests-list-action.contract.test.ts` (23/23)
- `npm run lint`
- `npm run typecheck`
- `npx playwright test tests/e2e/full-role-matrix.spec.ts --project=chromium` (4/4)
- `npx playwright test tests/e2e/mobile-smoke.spec.ts --project=mobile-chrome` (7/7)
- `npx playwright test tests/e2e/purchasing-pdf-flow.spec.ts --project=chromium` (4/4)
- Accesibilidad: seis rutas y las dos rutas de compras se validaron sin infracciones críticas ni de contraste.