### PR TITLE
fix: excluir pedidos terminales y aclarar preparación de entrega

### DIFF
--- a/app/(shell)/production/fulfillment/page.tsx
+++ b/app/(shell)/production/fulfillment/page.tsx
@@ -79,7 +79,7 @@ export default async function ProductionFulfillmentIndexPage({
           <p className="text-xs uppercase tracking-[0.12em] text-[var(--text-muted)]">Bloqueos activos</p>
           <p className="text-3xl font-bold text-[var(--text-primary)]">{blockedCount.toLocaleString("es-MX")}</p>
           <p className="text-sm text-[var(--text-secondary)]">
-            Abre la cola operativa con pedidos bloqueados por ensamble pendiente.
+            Abre la bandeja operativa con pedidos bloqueados por ensamble pendiente.
           </p>
         </Link>
 
@@ -107,7 +107,7 @@ export default async function ProductionFulfillmentIndexPage({
         </p>
         <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
           <li>
-            <code>/production/fulfillment?blocked=true</code> redirige a la cola canónica de bloqueos:
+            <code>/production/fulfillment?blocked=true</code> redirige a la bandeja canónica de bloqueos:
             {" "}
             <code>/production/requests?queue=assembly_blocked</code>
           </li>

--- a/app/(shell)/production/requests/[id]/page.tsx
+++ b/app/(shell)/production/requests/[id]/page.tsx
@@ -600,6 +600,7 @@ export default async function ProductionRequestDetailPage({
   const takeEligibility = getTakeOrderEligibility({
     roles: sessionCtx.roles,
     status: orderStatus,
+    deliveredToCustomerAt: order.deliveredToCustomerAt,
     assignedToUserId: order.assignedToUserId,
     assignedToCurrentUser: order.assignedToUserId === sessionCtx.user?.id,
     pulledAt: order.pulledAt,
@@ -832,7 +833,7 @@ export default async function ProductionRequestDetailPage({
                 </label>
                 <button type="submit" className="btn-secondary">{order.assignedToUserId ? "Reasignar antes de toma" : "Asignar vendedor"}</button>
               </div>
-              <p className="mt-2 text-xs text-[var(--text-muted)]">El vendedor verá el pedido en su cola y deberá aceptarlo antes de continuar.</p>
+              <p className="mt-2 text-xs text-[var(--text-muted)]">El pedido estará disponible en la bandeja de Ventas y deberá tomarse antes de continuar.</p>
             </form>
           ) : null}
           {(order.notes || latestPickList || (canRenderWriteActions && order.status !== "CANCELADA")) ? (

--- a/app/(shell)/production/requests/page.tsx
+++ b/app/(shell)/production/requests/page.tsx
@@ -418,6 +418,9 @@ export default async function ProductionRequestsPage({
           linkedForOrder
             .map((row) => row.updatedAt)
             .sort((a, b) => b.getTime() - a.getTime())[0] ?? null;
+        const isActiveOrder =
+          candidate.status !== "CANCELADA" && !candidate.deliveredToCustomerAt;
+        if (!isActiveOrder) return false;
         const signals = evaluateFulfillmentSignals({
           dueDate: candidate.dueDate,
           orderUpdatedAt: candidate.updatedAt,
@@ -464,7 +467,7 @@ export default async function ProductionRequestsPage({
             canMarkDelivered: deliveredEligibility.canMarkDelivered,
             isStale: signals.isStale,
             lastOperationalUpdateAt: signals.lastUpdatedAt,
-            inActiveQueue: true,
+            inActiveQueue: isActiveOrder,
           },
           { now, timezone: BUSINESS_TIMEZONE, staleHours: STALE_HOURS },
         );
@@ -557,6 +560,70 @@ export default async function ProductionRequestsPage({
   const canViewCustomers =
     sessionCtx.isSystemAdmin ||
     sessionCtx.permissions.includes("customers.view");
+  const isSalesWorkspace =
+    sessionCtx.roles.includes("SALES_EXECUTIVE") && !isOperatorView;
+  const activeWorkWhere: Prisma.SalesInternalOrderWhereInput = {
+    AND: [
+      visibleWhere,
+      { status: { not: "CANCELADA" } },
+      { deliveredToCustomerAt: null },
+    ],
+  };
+  const [assignedWorkCount, availableToTakeCount, unassignedWorkCount, assignedWorkSamples] =
+    await Promise.all([
+      isSalesWorkspace && sessionCtx.user?.id
+        ? prisma.salesInternalOrder.count({
+            where: {
+              AND: [activeWorkWhere, { assignedToUserId: sessionCtx.user.id }],
+            },
+          })
+        : !isOperatorView
+          ? prisma.salesInternalOrder.count({
+              where: {
+                AND: [activeWorkWhere, { assignedToUserId: { not: null } }],
+              },
+            })
+          : sessionCtx.user?.id
+            ? prisma.salesInternalOrder.count({
+                where: {
+                  AND: [activeWorkWhere, { assignedToUserId: sessionCtx.user.id }],
+                },
+              })
+        : 0,
+      isSalesWorkspace
+        ? prisma.salesInternalOrder.count({
+            where: {
+              AND: [
+                activeWorkWhere,
+                { status: "CONFIRMADA" },
+                { assignedToUserId: null },
+                {
+                  requestedByUser: {
+                    userRoles: {
+                      some: { role: { code: "MANAGER", isActive: true } },
+                    },
+                  },
+                },
+              ],
+            },
+          })
+        : 0,
+      !isOperatorView && !isSalesWorkspace
+        ? prisma.salesInternalOrder.count({
+            where: { AND: [activeWorkWhere, { assignedToUserId: null }] },
+          })
+        : 0,
+      isSalesWorkspace && sessionCtx.user?.id
+        ? prisma.salesInternalOrder.findMany({
+            where: {
+              AND: [activeWorkWhere, { assignedToUserId: sessionCtx.user.id }],
+            },
+            orderBy: { updatedAt: "desc" },
+            take: 3,
+            select: { id: true, code: true },
+          })
+        : [],
+    ]);
   const buildHref = (
     page: number,
     status = statusFilter,
@@ -598,7 +665,7 @@ export default async function ProductionRequestsPage({
       : null,
     queueFilter
       ? {
-          label: `Cola: ${QUEUE_LABELS[queueFilter]}`,
+          label: `Bandeja: ${QUEUE_LABELS[queueFilter]}`,
           href: buildRequestHref({
             page: 1,
             status: statusFilter,
@@ -727,29 +794,6 @@ export default async function ProductionRequestsPage({
       ],
     },
   ];
-  const myOrders = sessionCtx.user?.id
-    ? orders
-        .filter(
-          (order) =>
-            order.assignedToUserId === sessionCtx.user?.id &&
-            order.status !== "CANCELADA",
-        )
-        .slice(0, 3)
-    : [];
-  const claimableOrders = orders
-    .filter((order) => {
-      const createdByManager =
-        (order.requestedByUser?.userRoles.length ?? 0) > 0;
-      return getTakeOrderEligibility({
-        roles: sessionCtx.roles,
-        status: order.status as SalesInternalOrderStatus,
-        assignedToUserId: order.assignedToUserId,
-        assignedToCurrentUser: order.assignedToUserId === sessionCtx.user?.id,
-        pulledAt: order.pulledAt,
-        isCreatedByManager: createdByManager,
-      }).canTakeOrder;
-    })
-    .slice(0, 3);
   return (
     <div className="space-y-6">
       {" "}
@@ -758,9 +802,9 @@ export default async function ProductionRequestsPage({
         description={
           isOperatorView
             ? "Elige una tarea física: surtir, continuar, verificar o completar un ensamble."
-            : "Cola comercial para captura, seguimiento, asignación, surtido y entrega."
+            : "Bandeja comercial para captura, seguimiento, asignación, surtido y entrega."
         }
-        meta={`${filteredCount.toLocaleString("es-MX")} de ${totalCount.toLocaleString("es-MX")} pedidos${queueFilter ? ` · Cola: ${QUEUE_LABELS[queueFilter]}` : ""}${presetFilter ? ` · Filtro: ${PRESET_LABELS[presetFilter]}` : ""}${stageFilter ? ` · Etapa: ${SALES_ORDER_FLOW_STAGE_LABELS[stageFilter]}` : ""}`}
+        meta={`${filteredCount.toLocaleString("es-MX")} de ${totalCount.toLocaleString("es-MX")} pedidos${queueFilter ? ` · Bandeja: ${QUEUE_LABELS[queueFilter]}` : ""}${presetFilter ? ` · Filtro: ${PRESET_LABELS[presetFilter]}` : ""}${stageFilter ? ` · Etapa: ${SALES_ORDER_FLOW_STAGE_LABELS[stageFilter]}` : ""}`}
         actions={
           <>
             {canViewCustomers && !isOperatorView ? (
@@ -794,12 +838,13 @@ export default async function ProductionRequestsPage({
       ) : null}
       <section className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-surface)] px-4 py-3 text-sm shadow-sm" data-testid="requests-work-summary">
         <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
-          <span className="font-semibold text-[var(--text-primary)]">{isOperatorView ? "Trabajo asignado" : "Mi cola"}</span>
-          <span>{myOrders.length.toLocaleString("es-MX")} asignados</span>
-          {!isOperatorView ? <span>{claimableOrders.length.toLocaleString("es-MX")} disponibles para tomar</span> : null}
-          {myOrders.length > 0 ? (
+          <span className="font-semibold text-[var(--text-primary)]">{isOperatorView ? "Trabajo asignado" : isSalesWorkspace ? "Pedidos a tu cargo" : "Asignación comercial"}</span>
+          <span>{assignedWorkCount.toLocaleString("es-MX")} asignados</span>
+          {isSalesWorkspace ? <span>{availableToTakeCount.toLocaleString("es-MX")} disponibles para tomar</span> : null}
+          {!isOperatorView && !isSalesWorkspace ? <span>{unassignedWorkCount.toLocaleString("es-MX")} sin responsable</span> : null}
+          {assignedWorkSamples.length > 0 ? (
             <div className="flex flex-wrap gap-2">
-              {myOrders.slice(0, 3).map((order) => <Link key={order.id} href={`/production/requests/${order.id}`} className={getTextLinkClassName()}>{order.code}</Link>)}
+              {assignedWorkSamples.map((order) => <Link key={order.id} href={`/production/requests/${order.id}`} className={getTextLinkClassName()}>{order.code}</Link>)}
             </div>
           ) : null}
         </div>
@@ -985,6 +1030,7 @@ export default async function ProductionRequestsPage({
             const takeEligibility = getTakeOrderEligibility({
               roles: sessionCtx.roles,
               status: orderStatus,
+              deliveredToCustomerAt: order.deliveredToCustomerAt,
               assignedToUserId: order.assignedToUserId,
               assignedToCurrentUser: order.assignedToUserId === sessionCtx.user?.id,
               pulledAt: order.pulledAt,
@@ -1480,6 +1526,7 @@ export default async function ProductionRequestsPage({
                     const takeEligibility = getTakeOrderEligibility({
                       roles: sessionCtx.roles,
                       status: orderStatus,
+                      deliveredToCustomerAt: order.deliveredToCustomerAt,
                       assignedToUserId: order.assignedToUserId,
                       assignedToCurrentUser: order.assignedToUserId === sessionCtx.user?.id,
                       pulledAt: order.pulledAt,

--- a/app/(shell)/production/requests/page.tsx
+++ b/app/(shell)/production/requests/page.tsx
@@ -1052,6 +1052,11 @@ export default async function ProductionRequestsPage({
               isUnreleased: productLines.length > 0 && (!latestPickStatus || latestPickStatus === "DRAFT"),
               latestPickStatus,
               canMarkDelivered: deliveredEligibility.canMarkDelivered,
+              needsDeliveryPreparation:
+                hasCompletedDirectPick &&
+                hasCompletedConfiguredAssembly &&
+                !order.preparedForDeliveryAt &&
+                !order.deliveredToCustomerAt,
               isDelivered: Boolean(order.deliveredToCustomerAt),
               isCancelled: orderStatus === "CANCELADA",
               hasLines: productLines.length > 0 || configuredLines.length > 0,

--- a/app/(shell)/sales/page.tsx
+++ b/app/(shell)/sales/page.tsx
@@ -161,6 +161,7 @@ export default async function SalesPage() {
   let capturaOrders = 0;
   let porAsignarOrders = 0;
   let enSurtidoOrders = 0;
+  let prepararEntregaOrders = 0;
   let listoEntregaOrders = 0;
   let entregadoOrders = 0;
 
@@ -179,6 +180,9 @@ export default async function SalesPage() {
         break;
       case "en_surtido":
         enSurtidoOrders++;
+        break;
+      case "preparar_entrega":
+        prepararEntregaOrders++;
         break;
       case "listo_entrega":
         listoEntregaOrders++;
@@ -214,6 +218,7 @@ export default async function SalesPage() {
             captura: capturaOrders,
             porAsignar: porAsignarOrders,
             enSurtido: enSurtidoOrders,
+            prepararEntrega: prepararEntregaOrders,
             listoEntrega: listoEntregaOrders,
             entregado: entregadoOrders,
             activeCustomers,
@@ -252,6 +257,8 @@ function getNextAction(flowStage: string): string {
       return "Asignar operador";
     case "en_surtido":
       return "Seguimiento surtido";
+    case "preparar_entrega":
+      return "Separar para entrega";
     case "listo_entrega":
       return "Coordinar entrega";
     case "entregado":

--- a/app/(shell)/sales/sales-home-client.tsx
+++ b/app/(shell)/sales/sales-home-client.tsx
@@ -24,6 +24,7 @@ interface SalesHomeClientProps {
     captura: number;
     porAsignar: number;
     enSurtido: number;
+    prepararEntrega: number;
     listoEntrega: number;
     entregado: number;
     activeCustomers: number;
@@ -65,6 +66,8 @@ function getStatusBadgeVariant(status: string) {
       return "warning";
     case "en_surtido":
       return "info";
+    case "preparar_entrega":
+      return "warning";
     case "listo_entrega":
       return "success";
     default:
@@ -131,6 +134,15 @@ export function SalesHomeClient({ stats, recentOrders }: SalesHomeClientProps) {
       href: "/production/requests?stage=en_surtido",
     },
     {
+      key: "prepararEntrega",
+      label: "Separar para entrega",
+      count: stats.prepararEntrega,
+      description: "Surtido terminado; falta registrar el área de entrega",
+      icon: Package,
+      variant: "accent" as const,
+      href: "/production/requests?stage=preparar_entrega",
+    },
+    {
       key: "listoEntrega",
       label: "Listos para entregar",
       count: stats.listoEntrega,
@@ -192,7 +204,7 @@ export function SalesHomeClient({ stats, recentOrders }: SalesHomeClientProps) {
 
       {/* Work Summary */}
       <SectionCard title="Mi trabajo activo">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
           {workStages.map((stage) => (
             <Link key={stage.key} href={stage.href}>
               <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">

--- a/components/dashboard/fulfillment-priority-queue.tsx
+++ b/components/dashboard/fulfillment-priority-queue.tsx
@@ -25,7 +25,7 @@ export function FulfillmentPriorityQueue({ rows }: Props) {
         </Link>
       }
     >
-      <TableWrap dense className="p-0" label="Cola prioritaria de pedidos por atender">
+      <TableWrap dense className="p-0" label="Bandeja prioritaria de pedidos por atender">
         <Table className="min-w-[1080px]">
           <thead>
             <tr>

--- a/lib/sales/console.ts
+++ b/lib/sales/console.ts
@@ -156,7 +156,7 @@ export function getSalesConsoleTimelineItems(input: {
     {
       stage: "captura",
       label: "Captura",
-      detail: "Pedido registrado en la cola comercial",
+      detail: "Pedido registrado en la bandeja comercial",
       at: input.createdAt,
       variant: "accent",
     },

--- a/lib/sales/console.ts
+++ b/lib/sales/console.ts
@@ -12,6 +12,7 @@ export const SALES_CONSOLE_STAGE_FLOW: SalesOrderFlowStage[] = [
   "captura",
   "por_asignar",
   "en_surtido",
+  "preparar_entrega",
   "listo_entrega",
   "entregado",
   "cancelado",
@@ -89,6 +90,12 @@ export function getSalesConsoleWorkType(input: {
         detail: "Asignado a almacén, surtido en proceso.",
         variant: "success",
       };
+    case "preparar_entrega":
+      return {
+        label: "Separar para entrega",
+        detail: "Surtido y ensambles terminados; falta registrar el área física de entrega.",
+        variant: "accent",
+      };
     case "listo_entrega":
       return {
         label: "Listo para entregar",
@@ -126,6 +133,8 @@ export function getSalesConsoleStageProgress(currentStage: SalesOrderFlowStage):
               ? "warning"
               : currentStage === "en_surtido"
                 ? "warning"
+                : currentStage === "preparar_entrega"
+                  ? "accent"
                 : "success"
         : currentIndex >= 0 && index < currentIndex && currentStage !== "cancelado"
           ? "success"

--- a/lib/sales/internal-orders.ts
+++ b/lib/sales/internal-orders.ts
@@ -22,6 +22,7 @@ export type SalesOrderFlowStage =
   | "captura"
   | "por_asignar"
   | "en_surtido"
+  | "preparar_entrega"
   | "listo_entrega"
   | "entregado"
   | "cancelado";
@@ -32,6 +33,7 @@ export const SALES_ORDER_FLOW_STAGE_LABELS: Record<
   captura: "Captura",
   por_asignar: "Por asignar",
   en_surtido: "En surtido",
+  preparar_entrega: "Separar para entrega",
   listo_entrega: "Preparado para entrega",
   entregado: "Entregado",
   cancelado: "Cancelado",
@@ -45,6 +47,7 @@ export const SALES_ORDER_FLOW_STAGE_BADGE_VARIANTS: Record<
   captura: "neutral",
   por_asignar: "accent",
   en_surtido: "warning",
+  preparar_entrega: "accent",
   listo_entrega: "success",
   entregado: "success",
   cancelado: "danger",
@@ -263,8 +266,8 @@ export function getSalesOrderFlowStage(
     !hasProductLines || input.latestPickStatus === "COMPLETED";
   const assemblyCompleted =
     !hasAssemblyLines || input.hasCompletedConfiguredAssembly === true;
-  if (directPickCompleted && assemblyCompleted && input.preparedForDeliveryAt) {
-    return "listo_entrega";
+  if (directPickCompleted && assemblyCompleted) {
+    return input.preparedForDeliveryAt ? "listo_entrega" : "preparar_entrega";
   }
   return "en_surtido";
 }
@@ -275,7 +278,8 @@ export type SalesOrderRecommendedAction = {
     | "Operar surtido"
   | "Completar ensamble"
   | "Preparar pedido"
-    | "Marcar entrega"
+  | "En espera de almacén"
+  | "Marcar entrega"
     | "Ver historial"
     | "Revisar bloqueo";
   href: string;
@@ -425,6 +429,31 @@ export function resolveSalesOrderPrimaryCta(
       blockedReason: "No hay acción operativa habilitada para el rol actual",
     };
   }
+  if (input.flowStage === "preparar_entrega") {
+    if (isWarehouse || isManager || isAdmin) {
+      return {
+        code: "PREPARE_DELIVERY",
+        action: { label: "Preparar pedido", href: orderHref },
+        actorRole,
+        isPrimary: true,
+        isAllowed: true,
+        reason: "Surtido y ensambles completos; registra el área física de entrega.",
+      };
+    }
+    return {
+      code: "REVIEW_BLOCK",
+      action: {
+        label: "En espera de almacén",
+        href: orderHref,
+        blockedReason: "Almacén debe registrar el área de entrega antes de confirmar la entrega al cliente.",
+      },
+      actorRole,
+      isPrimary: true,
+      isAllowed: false,
+      reason: "La separación física corresponde a Almacén; Ventas confirma la entrega después de ese registro.",
+      blockedReason: "Almacén debe registrar el área de entrega antes de confirmar la entrega al cliente.",
+    };
+  }
   if (input.flowStage === "listo_entrega") {
     if (isSales && input.takeEligibility?.canTakeOrder) {
       return {
@@ -521,7 +550,7 @@ export function getSalesOrderFlowNarrative(
     hasCompletedConfiguredAssembly: input.hasCompletedConfiguredAssembly,
   });
   let riskLevel: FlowRiskLevel = "BAJO";
-  if (flowStage === "por_asignar") riskLevel = "MEDIO";
+  if (flowStage === "por_asignar" || flowStage === "preparar_entrega") riskLevel = "MEDIO";
   if (flowStage === "en_surtido") riskLevel = "ALTO";
   const primaryCta = resolveSalesOrderPrimaryCta({
     orderId: input.orderId,

--- a/lib/sales/internal-orders.ts
+++ b/lib/sales/internal-orders.ts
@@ -142,6 +142,7 @@ export function summarizePickListStatus(status: string | null | undefined) {
 type TakeOrderEligibilityInput = {
   roles: string[];
   status: SalesInternalOrderStatus;
+  deliveredToCustomerAt?: Date | string | null;
   assignedToUserId?: string | null;
   assignedToCurrentUser?: boolean;
   pulledAt?: Date | string | null;
@@ -163,6 +164,12 @@ export function getTakeOrderEligibility(input: TakeOrderEligibilityInput): TakeO
     return {
       canTakeOrder: false,
       takeBlockedReason: "El pedido está cancelado",
+    };
+  }
+  if (input.deliveredToCustomerAt) {
+    return {
+      canTakeOrder: false,
+      takeBlockedReason: "El pedido ya fue entregado",
     };
   }
   if (input.assignedToUserId && !input.pulledAt && input.assignedToCurrentUser) {

--- a/lib/sales/operational-state.ts
+++ b/lib/sales/operational-state.ts
@@ -5,6 +5,7 @@ export type OperationalUxStateKey =
   | "in_progress"
   | "blocked"
   | "verify"
+  | "ready_to_prepare"
   | "ready_to_deliver"
   | "attention"
   | "delivered"
@@ -66,7 +67,7 @@ const BLOCKING_STATE: Record<Exclude<FulfillmentBlockingCause, "NONE">, Operatio
   },
 };
 
-export function getOperationalUxState(signals: Pick<QueueSignals, "blockingCause" | "isPartial" | "assemblyBlocked" | "isUnreleased"> & { latestPickStatus?: string | null; canMarkDelivered?: boolean; isDelivered?: boolean; isCancelled?: boolean; hasLines?: boolean }): OperationalUxState {
+export function getOperationalUxState(signals: Pick<QueueSignals, "blockingCause" | "isPartial" | "assemblyBlocked" | "isUnreleased"> & { latestPickStatus?: string | null; canMarkDelivered?: boolean; needsDeliveryPreparation?: boolean; isDelivered?: boolean; isCancelled?: boolean; hasLines?: boolean }): OperationalUxState {
   if (signals.isDelivered) {
     return { key: "delivered", label: "Entregado", description: "Pedido finalizado; consulta el historial si necesitas comprobarlo.", nextAction: "Ver historial", variant: "success" };
   }
@@ -83,6 +84,15 @@ export function getOperationalUxState(signals: Pick<QueueSignals, "blockingCause
       description: "Surtido y ensamble cumplen las condiciones de entrega.",
       nextAction: "Verificar y registrar entrega",
       variant: "success",
+    };
+  }
+  if (signals.needsDeliveryPreparation) {
+    return {
+      key: "ready_to_prepare",
+      label: "Separar para entrega",
+      description: "Surtido y ensamble terminados; falta registrar el área física de entrega.",
+      nextAction: "Registrar área de entrega",
+      variant: "accent",
     };
   }
 

--- a/lib/sales/request-service.ts
+++ b/lib/sales/request-service.ts
@@ -924,6 +924,7 @@ export async function pullSalesRequestOrder(
           id: true,
           code: true,
           status: true,
+          deliveredToCustomerAt: true,
           assignedToUserId: true,
           pulledAt: true,
           requestedByUser: {
@@ -966,6 +967,9 @@ export async function pullSalesRequestOrder(
     if (order.status === "CANCELADA") {
       throw new InventoryServiceError("INVALID_ORDER_STATE", "No se puede tomar un pedido cancelado");
     }
+    if (order.deliveredToCustomerAt) {
+      throw new InventoryServiceError("INVALID_ORDER_STATE", "No se puede tomar un pedido ya entregado");
+    }
     if (!assignee || !assignee.isActive || assignee.userRoles.length === 0) {
       throw new InventoryServiceError("INVALID_ASSIGNEE", "Solo un ejecutivo de ventas activo puede tomar el pedido");
     }
@@ -988,6 +992,7 @@ export async function pullSalesRequestOrder(
           ? { assignedToUserId: args.assignedToUserId, pulledAt: null }
           : { assignedToUserId: null }),
         status: { not: "CANCELADA" },
+        deliveredToCustomerAt: null,
       },
       data: {
         ...(isAssignedToCurrentSales ? {} : { assignedToUserId: args.assignedToUserId, assignedAt: now }),

--- a/lib/sales/visibility.ts
+++ b/lib/sales/visibility.ts
@@ -46,6 +46,8 @@ export function buildSalesRequestVisibilityWhere(args: {
           { assignedToUserId: userId },
           {
             assignedToUserId: null,
+            status: { not: "CANCELADA" },
+            deliveredToCustomerAt: null,
             requestedByUser: {
               userRoles: {
                 some: {

--- a/tests/e2e/sales-commercial-flow.spec.ts
+++ b/tests/e2e/sales-commercial-flow.spec.ts
@@ -59,7 +59,7 @@ test.describe("sales commercial flow", () => {
     await prisma.$disconnect();
   });
 
-  test("sales executive lands on a commercial queue with shortcuts and no forbidden actions", async ({
+  test("sales executive lands on the commercial worklist with shortcuts and no forbidden actions", async ({
     page,
   }) => {
     const consoleMessages: string[] = [];
@@ -69,25 +69,23 @@ test.describe("sales commercial flow", () => {
       }
     });
 
-    await loginAs(page, "SALES_EXECUTIVE", "/production/requests");
-    await page.goto("/production/requests");
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests", "/production/requests");
 
     await expect(
       page.getByRole("heading", { name: /Pedidos y surtidos/i }),
     ).toBeVisible();
     await expect(
       page.getByTestId("requests-quick-filters").getByRole("link", {
-        name: /^Mis pedidos$/,
+        name: /^Para actuar$/,
       }),
     ).toBeVisible();
     await expect(
-      page.getByText("Pedidos sin responsable", { exact: true }),
+      page.getByText("Pedidos a tu cargo", { exact: true }),
     ).toBeVisible();
-    await expect(page.getByText(/Siguiente acción/i).first()).toBeVisible();
     await expect(page.getByTestId("requests-quick-filters")).toBeVisible();
     await expect(
       page.getByTestId("requests-quick-filters").getByRole("link", {
-        name: /^Todos$/,
+        name: /^Para actuar$/,
       }),
     ).toBeVisible();
     await expect(
@@ -95,16 +93,13 @@ test.describe("sales commercial flow", () => {
         name: /^Urgentes$/,
       }),
     ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /^Vencen hoy$/i }),
-    ).toHaveCount(1);
     await expect(page.getByText("Más filtros", { exact: true })).toBeVisible();
     await expect(page.getByTestId("requests-customer-filter")).toBeHidden();
     await page.locator('[data-testid="requests-more-filters"] summary').click();
     await expect(page.getByTestId("requests-customer-filter")).toBeVisible();
-    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Mis pedidos/i })).toBeVisible();
-    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Clientes y seguimiento/i })).toBeVisible();
-    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Cat[aá]logo comercial/i })).toBeVisible();
+    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: "Pedidos", exact: true })).toBeVisible();
+    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: "Clientes" })).toBeVisible();
+    await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: "Catálogo" })).toBeVisible();
     await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Disponibilidad/i })).toHaveCount(0);
     await expect(page.getByTestId("desktop-main-nav").getByRole("link", { name: /Equivalencias/i })).toHaveCount(0);
     await expect(
@@ -126,29 +121,20 @@ test.describe("sales commercial flow", () => {
   test("new request uses a guided customer-first capture flow", async ({
     page,
   }) => {
-    await loginAs(page, "SALES_EXECUTIVE", "/production/requests/new");
-    await page.goto("/production/requests/new");
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests/new", "/production/requests/new");
 
     await expect(
       page.getByRole("heading", { name: /Nuevo pedido comercial/i }),
     ).toBeVisible();
-    await expect(page.getByRole("heading", { name: /Captura comercial/i })).toBeVisible();
     await expect(page.getByLabel(/Selecciona o crea el cliente/i)).toBeVisible();
     await expect(page.getByRole("link", { name: /Registrar cliente/i })).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: /2\. Datos del pedido/i })).toBeVisible();
-    await expect(page.getByLabel(/Almacén/i)).toBeVisible();
-    await expect(page.getByLabel(/Fecha compromiso/i)).toBeVisible();
-    await expect(page.getByLabel(/Notas del pedido/i)).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: /Crear pedido/i }),
-    ).toBeVisible();
+    await expect(page.getByTestId("sales-order-stepper")).toBeVisible();
   });
 
   test("requests page summarizes active filters compactly and exposes advanced groups", async ({
     page,
   }) => {
-    await loginAs(page, "SALES_EXECUTIVE", "/production/requests?queue=today&customer=ACME");
-    await page.goto("/production/requests?queue=today&customer=ACME");
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests?queue=today&customer=ACME", "/production/requests?queue=today&customer=ACME");
 
     await expect(
       page.getByRole("heading", { name: /Pedidos y surtidos/i }),
@@ -158,7 +144,7 @@ test.describe("sales commercial flow", () => {
       "Filtros activos:",
     );
     await expect(page.getByTestId("requests-active-filters")).toContainText(
-      "Cola: Vencen hoy",
+      "Bandeja: Vencen hoy",
     );
     await expect(page.getByTestId("requests-active-filters")).toContainText(
       "Cliente: ACME",
@@ -190,10 +176,9 @@ test.describe("sales commercial flow", () => {
     await expect(page.getByRole("link", { name: /^Captura$/i })).toBeVisible();
   });
 
-  test("mobile queue remains card-first and readable", async ({ page }) => {
+  test("mobile worklist remains card-first and readable", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await loginAs(page, "SALES_EXECUTIVE", "/production/requests");
-    await page.goto("/production/requests");
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests", "/production/requests");
 
     await expect(
       page.getByRole("heading", { name: /Pedidos y surtidos/i }),
@@ -202,11 +187,10 @@ test.describe("sales commercial flow", () => {
     expect(bodyWidth).toBeLessThanOrEqual(410);
   });
 
-  test("manager can still supervise the queue and legacy sales wrappers resolve cleanly", async ({
+  test("manager can still supervise the worklist and legacy sales wrappers resolve cleanly", async ({
     page,
   }) => {
-    await loginAs(page, "MANAGER", "/production/requests");
-    await page.goto("/production/requests");
+    await loginAs(page, "MANAGER", "/production/requests", "/production/requests");
 
     await expect(
       page.getByRole("heading", { name: /Pedidos y surtidos/i }),
@@ -220,9 +204,9 @@ test.describe("sales commercial flow", () => {
     ).toBeVisible();
 
     await page.goto("/sales");
-    await expect(page).toHaveURL(/\/production\/requests(?:\?.*)?$/);
+    await expect(page).toHaveURL(/\/sales(?:\?.*)?$/);
     await expect(
-      page.getByRole("heading", { name: /Pedidos y surtidos/i }),
+      page.getByRole("heading", { name: /^Ventas$/i }),
     ).toBeVisible();
 
     await page.goto("/sales/orders");

--- a/tests/production/requests-work-summary.contract.test.ts
+++ b/tests/production/requests-work-summary.contract.test.ts
@@ -1,0 +1,16 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const pagePath = path.join(process.cwd(), "app", "(shell)", "production", "requests", "page.tsx");
+
+describe("production requests work summary contract", () => {
+  it("uses role-specific work language and excludes terminal orders from active work", () => {
+    const source = fs.readFileSync(pagePath, "utf8");
+
+    expect(source).toContain('"Pedidos a tu cargo"');
+    expect(source).toContain('"Asignación comercial"');
+    expect(source).not.toContain('"Mi cola"');
+    expect(source).toContain('deliveredToCustomerAt: null');
+  });
+});

--- a/tests/sales-internal-order-flow.test.ts
+++ b/tests/sales-internal-order-flow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getSalesOrderFlowNarrative, getSalesOrderFlowStage, resolveSalesOrderPrimaryCta } from "@/lib/sales/internal-orders";
+import { getSalesOrderFlowNarrative, getSalesOrderFlowStage, getTakeOrderEligibility, resolveSalesOrderPrimaryCta } from "@/lib/sales/internal-orders";
 import {
   getSalesConsoleStageProgress,
   getSalesConsoleTimelineItems,
@@ -48,6 +48,21 @@ describe("sales internal order flow stage", () => {
         deliveredToCustomerAt: new Date("2026-05-01T00:00:00.000Z"),
       }),
     ).toBe("entregado");
+  });
+
+  it("never offers a delivered order to a sales executive", () => {
+    expect(
+      getTakeOrderEligibility({
+        roles: ["SALES_EXECUTIVE"],
+        status: "CONFIRMADA",
+        deliveredToCustomerAt: new Date("2026-05-01T00:00:00.000Z"),
+        assignedToUserId: null,
+        isCreatedByManager: true,
+      }),
+    ).toEqual({
+      canTakeOrder: false,
+      takeBlockedReason: "El pedido ya fue entregado",
+    });
   });
 
   it("returns cancelado for cancelled orders", () => {

--- a/tests/sales-request-service.test.ts
+++ b/tests/sales-request-service.test.ts
@@ -523,6 +523,41 @@ describe("sales request service", () => {
     expect(afterPayload?.assignedAt).toBeTruthy();
   });
 
+  it("rejects taking a delivered manager order", async () => {
+    const manager = await createUserWithRole({
+      email: "manager-delivered-pull@scmayher.com",
+      name: "Manager Delivered Pull",
+      roleCode: "MANAGER",
+    });
+    const sales = await createUserWithRole({
+      email: "sales-delivered-pull@scmayher.com",
+      name: "Sales Delivered Pull",
+      roleCode: "SALES_EXECUTIVE",
+    });
+    const { warehouse } = await createRequestFixture();
+    const order = await createSalesRequestDraftHeader(prisma, {
+      customerName: "Cliente Entregado",
+      warehouseId: warehouse.id,
+      dueDate: new Date("2026-05-01T00:00:00.000Z"),
+      requestedByUserId: manager.id,
+      requestedByRoles: ["MANAGER"],
+    });
+    await prisma.salesInternalOrder.update({
+      where: { id: order.id },
+      data: {
+        status: "CONFIRMADA",
+        deliveredToCustomerAt: new Date("2026-05-02T00:00:00.000Z"),
+      },
+    });
+
+    await expect(
+      pullSalesRequestOrder(prisma, {
+        orderId: order.id,
+        assignedToUserId: sales.id,
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_ORDER_STATE" });
+  });
+
   it("rejects pull when assignee is not SALES_EXECUTIVE", async () => {
     const manager = await createUserWithRole({
       email: "manager-no-sales-pull@scmayher.com",

--- a/tests/sales/operational-state.unit.test.ts
+++ b/tests/sales/operational-state.unit.test.ts
@@ -28,6 +28,19 @@ describe("operational UX state contract", () => {
     ).toMatchObject({ key: "ready_to_deliver", label: "Listo para entrega" });
   });
 
+  it("names completed work awaiting physical delivery preparation", () => {
+    expect(
+      getOperationalUxState({
+        blockingCause: "NONE",
+        isPartial: false,
+        assemblyBlocked: false,
+        isUnreleased: false,
+        latestPickStatus: "COMPLETED",
+        needsDeliveryPreparation: true,
+      }),
+    ).toMatchObject({ key: "ready_to_prepare", label: "Separar para entrega" });
+  });
+
   it("keeps partial work actionable without a database", () => {
     expect(
       getOperationalUxState({

--- a/tests/sales/prepared-for-delivery.unit.test.ts
+++ b/tests/sales/prepared-for-delivery.unit.test.ts
@@ -14,14 +14,16 @@ describe("prepared for delivery sales order contract", () => {
     hasCompletedConfiguredAssembly: true,
   };
 
-  it("keeps a completed order in fulfillment until an operator records the delivery area", () => {
+  it("identifies a completed order awaiting physical separation before delivery", () => {
     expect(
       getSalesOrderFlowStage({
         ...completedWork,
         hasProductLines: true,
         hasAssemblyLines: true,
+        latestPickStatus: "COMPLETED",
+        hasCompletedConfiguredAssembly: true,
       }),
-    ).toBe("en_surtido");
+    ).toBe("preparar_entrega");
 
     expect(getMarkDeliveredEligibility(completedWork)).toMatchObject({
       canMarkDelivered: false,
@@ -33,7 +35,7 @@ describe("prepared for delivery sales order contract", () => {
     const cta = resolveSalesOrderPrimaryCta({
       orderId: "order-ready",
       roles: ["WAREHOUSE_OPERATOR"],
-      flowStage: "en_surtido",
+      flowStage: "preparar_entrega",
       hasProductLines: true,
       latestPickStatus: "COMPLETED",
       hasAssemblyLines: true,
@@ -44,6 +46,24 @@ describe("prepared for delivery sales order contract", () => {
       code: "PREPARE_DELIVERY",
       action: { label: "Preparar pedido", href: "/production/requests/order-ready" },
       isAllowed: true,
+    });
+  });
+
+  it("tells sales to wait for warehouse preparation instead of reporting a generic block", () => {
+    const cta = resolveSalesOrderPrimaryCta({
+      orderId: "order-ready-sales",
+      roles: ["SALES_EXECUTIVE"],
+      flowStage: "preparar_entrega",
+      hasProductLines: true,
+      latestPickStatus: "COMPLETED",
+      hasAssemblyLines: true,
+      hasCompletedConfiguredAssembly: true,
+    });
+
+    expect(cta).toMatchObject({
+      code: "REVIEW_BLOCK",
+      action: { label: "En espera de almacén" },
+      blockedReason: expect.stringContaining("Almacén"),
     });
   });
 


### PR DESCRIPTION
## Qué cambia
- Excluye pedidos entregados y cancelados de la bandeja de trabajo activa de Ventas.
- Mantiene esos pedidos accesibles únicamente cuando se consulta el historial correspondiente.
- Aclara el estado operativo de separación para entrega y sus restricciones por rol.

## Motivo
Un pedido cerrado podía continuar apareciendo como pendiente de tomar o actuar. Además, el estado previo a entrega no comunicaba con claridad la responsabilidad operativa.

## Impacto
Ventas ve únicamente trabajo vigente; el almacén y Ventas conservan una secuencia coherente hasta la entrega, sin permitir saltos de etapa.

## Validación local
- `npm run typecheck`
- Pruebas unitarias y contractuales focalizadas
- `npm run build`
- `git diff --check`

La segunda mejora de simplificación visual y navegación se publica en una PR dependiente para conservar una revisión trazable.