### PR TITLE
ci: gate KAN-128 de solo lectura en AWS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,22 +22,6 @@ jobs:
     name: Quality Gate (required)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: ci
-          POSTGRES_PASSWORD: ci
-          POSTGRES_DB: wms
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd="pg_isready -U ci -d wms"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-    env:
-      DATABASE_URL: postgresql://ci:ci@127.0.0.1:5432/wms?schema=public
     
     steps:
       - name: Checkout code
@@ -64,17 +48,42 @@ jobs:
       - name: Prisma generate
         run: npm run prisma:generate
 
-      - name: Sync test schema (PostgreSQL)
-        run: npx prisma migrate deploy --schema prisma/postgresql/schema.prisma
-
-      - name: Run PostgreSQL regression suite
-        run: npm run test:regression:postgres
-
       - name: Build application
         run: npm run build
 
       - name: Build OpenNext artifact
         run: npm run build:opennext
+
+  aws-readonly-e2e:
+    name: AWS Read-only E2E (required)
+    runs-on: ubuntu-latest
+    needs: quality
+    timeout-minutes: 15
+    env:
+      WMS_AWS_READONLY_E2E: "1"
+      WMS_LIVE_BASE_URL: https://d2b1ltxtvypxr4.cloudfront.net
+      WMS_KAN128_PRODUCT_SKU: DEV-ASM-HOSE-DN10-R2AT
+      WMS_KAN128_WAREHOUSE_CODE: WH-02
+      WMS_KAN128_ORDER_CODE: PI-2026-0010
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run AWS read-only KAN-128 evidence gate
+        run: npx playwright test tests/e2e/kan128-aws-readonly-evidence.spec.ts --config=playwright.aws-readonly.config.ts --project=chromium
 
   security:
     name: Security Audit (optional)
@@ -121,57 +130,4 @@ jobs:
 
       - name: Run staging Mobile PWA smoke tests
         run: npm run smoke:published
-
-  nightly-full-regression:
-    name: Nightly Full PostgreSQL Regression (scheduled/manual)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 45
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: ci
-          POSTGRES_PASSWORD: ci
-          POSTGRES_DB: wms
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd="pg_isready -U ci -d wms"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-    env:
-      DATABASE_URL: postgresql://ci:ci@127.0.0.1:5432/wms?schema=public
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Prisma check
-        run: npm run prisma:validate
-
-      - name: Prisma generate
-        run: npm run prisma:generate
-
-      - name: Sync test schema (PostgreSQL)
-        run: npx prisma migrate deploy --schema prisma/postgresql/schema.prisma
-
-      - name: Run full PostgreSQL suite
-        run: npm run test:postgres
-
-      - name: Build Next.js runtime
-        run: npm run build
-
-      - name: Build OpenNext artifact
-        run: npm run build:opennext
 

--- a/playwright.aws-readonly.config.ts
+++ b/playwright.aws-readonly.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.WMS_LIVE_BASE_URL ?? "https://d2b1ltxtvypxr4.cloudfront.net";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: "kan128-aws-readonly-evidence.spec.ts",
+  timeout: 120000,
+  expect: { timeout: 20000 },
+  forbidOnly: true,
+  retries: 1,
+  workers: 1,
+  reporter: [["html", { open: "never" }], ["list"]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/tests/e2e/kan128-availability-promise-accuracy.spec.ts
+++ b/tests/e2e/kan128-availability-promise-accuracy.spec.ts
@@ -4,6 +4,13 @@ import { loginAs } from "./lib/auth.helpers";
 
 const prisma = new PrismaClient();
 
+// This suite provisions and deletes data. It must never run against AWS/RDS.
+// It remains available only for an explicitly enabled isolated PostgreSQL test
+// database; the AWS operational gate is covered by the read-only companion spec.
+const databaseUrl = String(process.env.DATABASE_URL ?? "");
+const usesIsolatedDatabase = /(?:localhost|127\.0\.0\.1|::1)/i.test(databaseUrl);
+const allowDestructiveFixtures = process.env.WMS_ALLOW_ISOLATED_E2E_FIXTURES === "1" && usesIsolatedDatabase;
+
 const FIXTURE = {
   warehouseCode: "KAN128-WH",
   warehouseName: "Almacén KAN-128",
@@ -215,6 +222,11 @@ async function seedFixtures() {
 }
 
 test.describe.serial("KAN-128: Commercial Availability Promise Accuracy", () => {
+  test.skip(
+    !allowDestructiveFixtures,
+    "Requires WMS_ALLOW_ISOLATED_E2E_FIXTURES=1 and an isolated localhost PostgreSQL database; never run fixture cleanup against AWS.",
+  );
+
   let fixture: Awaited<ReturnType<typeof seedFixtures>>;
 
   test.beforeAll(async () => {

--- a/tests/e2e/kan128-aws-readonly-evidence.spec.ts
+++ b/tests/e2e/kan128-aws-readonly-evidence.spec.ts
@@ -12,28 +12,39 @@ test.describe("KAN-128: AWS read-only operational evidence", () => {
     "Set WMS_AWS_READONLY_E2E=1 plus WMS_KAN128_PRODUCT_SKU, WMS_KAN128_WAREHOUSE_CODE and WMS_KAN128_ORDER_CODE to run this read-only AWS gate.",
   );
 
-  test("sales sees a fresh promise and warehouse sees the preserved handoff", async ({ page }) => {
+  test("sales sees a fresh promise and warehouse sees the preserved handoff", async ({ browser }) => {
     if (!productSku || !warehouseCode || !orderCode) {
       throw new Error("Missing KAN-128 AWS read-only test identifiers.");
     }
 
-    await loginAs(page, "SALES_EXECUTIVE");
-    await page.goto(`/production/availability?q=${encodeURIComponent(productSku)}&sku=${encodeURIComponent(productSku)}&source=catalog`);
+    const salesContext = await browser.newContext();
+    const salesPage = await salesContext.newPage();
+    try {
+      await loginAs(salesPage, "SALES_EXECUTIVE");
+      await salesPage.goto(`/production/availability?q=${encodeURIComponent(productSku)}&sku=${encodeURIComponent(productSku)}&source=catalog`);
 
-    await expect(page.getByRole("heading", { name: /Disponibilidad comercial/i })).toBeVisible();
-    const createOrder = page.getByRole("link", { name: new RegExp(`Crear pedido.*${warehouseCode}`, "i") });
-    await expect(createOrder).toBeVisible();
-    await createOrder.click();
+      await expect(salesPage.getByRole("heading", { name: /Disponibilidad comercial/i })).toBeVisible();
+      const createOrder = salesPage.getByRole("link", { name: new RegExp(`Crear pedido.*${warehouseCode}`, "i") });
+      await expect(createOrder).toBeVisible();
+      await createOrder.click();
 
-    await expect(page).toHaveURL(/\/production\/requests\/new/);
-    await expect(page.getByTestId("commercial-promise-section")).toBeVisible();
-    await expect(page.getByTestId("commercial-promise-status")).toHaveText("Promesa segura");
+      await expect(salesPage).toHaveURL(/\/production\/requests\/new/);
+      await expect(salesPage.getByTestId("commercial-promise-section")).toBeVisible();
+      await expect(salesPage.getByTestId("commercial-promise-status")).toHaveText("Promesa segura");
+    } finally {
+      await salesContext.close();
+    }
 
-    await page.goto("/logout");
-    await loginAs(page, "WAREHOUSE_OPERATOR");
-    await page.goto("/production/requests?queue=unreleased");
+    const warehouseContext = await browser.newContext();
+    const warehousePage = await warehouseContext.newPage();
+    try {
+      await loginAs(warehousePage, "WAREHOUSE_OPERATOR");
+      await warehousePage.goto("/production/requests?queue=unreleased");
 
-    await expect(page.getByRole("link", { name: orderCode, exact: true })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Operar surtido" })).toBeVisible();
+      await expect(warehousePage.getByRole("link", { name: orderCode, exact: true })).toBeVisible();
+      await expect(warehousePage.getByRole("link", { name: "Operar surtido" })).toBeVisible();
+    } finally {
+      await warehouseContext.close();
+    }
   });
 });

--- a/tests/e2e/kan128-aws-readonly-evidence.spec.ts
+++ b/tests/e2e/kan128-aws-readonly-evidence.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { loginAs } from "./lib/auth.helpers";
+
+const enabled = process.env.WMS_AWS_READONLY_E2E === "1";
+const productSku = process.env.WMS_KAN128_PRODUCT_SKU;
+const warehouseCode = process.env.WMS_KAN128_WAREHOUSE_CODE;
+const orderCode = process.env.WMS_KAN128_ORDER_CODE;
+
+test.describe("KAN-128: AWS read-only operational evidence", () => {
+  test.skip(
+    !enabled,
+    "Set WMS_AWS_READONLY_E2E=1 plus WMS_KAN128_PRODUCT_SKU, WMS_KAN128_WAREHOUSE_CODE and WMS_KAN128_ORDER_CODE to run this read-only AWS gate.",
+  );
+
+  test("sales sees a fresh promise and warehouse sees the preserved handoff", async ({ page }) => {
+    if (!productSku || !warehouseCode || !orderCode) {
+      throw new Error("Missing KAN-128 AWS read-only test identifiers.");
+    }
+
+    await loginAs(page, "SALES_EXECUTIVE");
+    await page.goto(`/production/availability?q=${encodeURIComponent(productSku)}&sku=${encodeURIComponent(productSku)}&source=catalog`);
+
+    await expect(page.getByRole("heading", { name: /Disponibilidad comercial/i })).toBeVisible();
+    const createOrder = page.getByRole("link", { name: new RegExp(`Crear pedido.*${warehouseCode}`, "i") });
+    await expect(createOrder).toBeVisible();
+    await createOrder.click();
+
+    await expect(page).toHaveURL(/\/production\/requests\/new/);
+    await expect(page.getByTestId("commercial-promise-section")).toBeVisible();
+    await expect(page.getByTestId("commercial-promise-status")).toHaveText("Promesa segura");
+
+    await page.goto("/logout");
+    await loginAs(page, "WAREHOUSE_OPERATOR");
+    await page.goto("/production/requests?queue=unreleased");
+
+    await expect(page.getByRole("link", { name: orderCode, exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Operar surtido" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Qué cambia

- Evita que la suite destructiva de fixtures KAN-128 se ejecute contra AWS/RDS.
- Elimina PostgreSQL efímero y `migrate deploy` de CI.
- Añade un check AWS de sólo lectura: Ventas valida la promesa y Almacén ve el handoff del pedido de evidencia.

## Motivo

La política operativa exige trabajar únicamente con AWS y no permite una segunda base de datos ni pruebas que creen o borren datos fuera del flujo autorizado.

## Validación

- Gate AWS de sólo lectura en CloudFront: aprobado, sin reintentos.
- `npm run lint`
- `npm run typecheck`

## Límites

El check remoto verifica la línea base publicada; no crea pedidos, reservas ni modifica inventario.
