### PR TITLE
fix: preserve commercial due dates

### DIFF
--- a/app/(shell)/production/requests/[id]/page.tsx
+++ b/app/(shell)/production/requests/[id]/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import type { SalesInternalOrderStatus } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { getSessionContext } from "@/lib/auth/session-context";
+import { formatBusinessDate } from "@/lib/business-date";
 import { Badge } from "@/components/ui/badge";
 import { buttonStyles } from "@/components/ui/button";
 import RequestProductLineForm from "@/components/RequestProductLineForm";
@@ -330,10 +331,7 @@ async function deleteLine(formData: FormData) {
 }
 
 function formatDate(value: Date | string | null | undefined) {
-  if (!value) return "--";
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return "--";
-  return date.toLocaleDateString("es-MX");
+  return formatBusinessDate(value);
 }
 
 function formatDateTime(value: Date | string | null | undefined) {

--- a/app/(shell)/production/requests/page.tsx
+++ b/app/(shell)/production/requests/page.tsx
@@ -50,6 +50,7 @@ import {
   type OperationalPresetFilter,
 } from "@/lib/dashboard/fulfillment-operational-presets";
 import { getOperationalUxState } from "@/lib/sales/operational-state";
+import { formatBusinessDate } from "@/lib/business-date";
 export const dynamic = "force-dynamic";
 const PAGE_SIZE = 50;
 const STALE_HOURS = 4;
@@ -101,10 +102,7 @@ function getTextLinkClassName() {
   return "text-[var(--accent)] underline-offset-4 transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)]";
 }
 function formatDate(value: Date | string | null | undefined) {
-  if (!value) return "--";
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return "--";
-  return date.toLocaleDateString("es-MX");
+  return formatBusinessDate(value);
 }
 function formatDateTime(value: Date | string | null | undefined) {
   if (!value) return "--";
@@ -1612,11 +1610,7 @@ export default async function ProductionRequestsPage({
                             : "Sin asignar"}
                         </td>
                         <td className="py-3 text-[var(--text-muted)]">
-                          {order.dueDate
-                            ? new Date(order.dueDate).toLocaleDateString(
-                                "es-MX",
-                              )
-                            : "--"}
+                          {formatBusinessDate(order.dueDate)}
                         </td>
                         <td className="py-3 text-[var(--text-muted)]">
                           {riskLabel}

--- a/components/home/SalesConsole.tsx
+++ b/components/home/SalesConsole.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { formatBusinessDate } from "@/lib/business-date";
 import prisma from "@/lib/prisma";
 import { getSalesOrderFlowStage } from "@/lib/sales/internal-orders";
 import { SalesHomeClient } from "@/app/(shell)/sales/sales-home-client";
@@ -100,7 +101,7 @@ export async function SalesConsole({ email }: { email?: string | null }) {
     assignedToUserId: true,
     preparedForDeliveryAt: true,
     deliveredToCustomerAt: true,
-    updatedAt: true,
+    dueDate: true,
     customerName: true,
     lines: { select: { id: true, lineKind: true } },
     pickLists: {
@@ -174,7 +175,7 @@ export async function SalesConsole({ email }: { email?: string | null }) {
       code: order.code,
       customerName: order.customerName ?? "Cliente desconocido",
       status,
-      dueDate: order.updatedAt ? new Date(order.updatedAt).toLocaleDateString("es-ES") : "N/A",
+      dueDate: formatBusinessDate(order.dueDate),
       nextAction: getNextAction(status),
     };
   });

--- a/lib/business-date.ts
+++ b/lib/business-date.ts
@@ -1,0 +1,35 @@
+/**
+ * Commercial due dates are calendar days, not instants. They are persisted at
+ * midnight UTC, so formatting must stay in UTC to avoid a one-day shift when
+ * the server runs in a different local timezone.
+ */
+export function formatBusinessDate(
+  value: Date | string | null | undefined,
+  locale = "es-MX",
+) {
+  if (!value) return "--";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "--";
+  return date.toLocaleDateString(locale, { timeZone: "UTC" });
+}
+
+export function parseBusinessDate(value?: string) {
+  if (!value) return null;
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match) {
+    const [, yearRaw, monthRaw, dayRaw] = match;
+    const year = Number(yearRaw);
+    const month = Number(monthRaw);
+    const day = Number(dayRaw);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    const isCalendarDate =
+      parsed.getUTCFullYear() === year &&
+      parsed.getUTCMonth() === month - 1 &&
+      parsed.getUTCDate() === day;
+    return isCalendarDate ? parsed : null;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/lib/schemas/wms.ts
+++ b/lib/schemas/wms.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { parseBusinessDate } from "@/lib/business-date";
 
 const requiredText = (label: string) =>
   z.string().trim().min(1, `${label} es obligatorio`);
@@ -123,9 +124,7 @@ export function parsePriority(value?: string, fallback = 3) {
 }
 
 export function parseDueDate(value?: string) {
-  if (!value) return null;
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
+  return parseBusinessDate(value);
 }
 
 export function firstErrorMessage(error: z.ZodError) {

--- a/tests/business-date.test.ts
+++ b/tests/business-date.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatBusinessDate } from "@/lib/business-date";
+
+describe("formatBusinessDate", () => {
+  it("preserves the calendar day regardless of the server timezone", () => {
+    expect(formatBusinessDate(new Date("2026-08-01T00:00:00.000Z"))).toBe("1/8/2026");
+  });
+
+  it("renders invalid values as an unavailable business date", () => {
+    expect(formatBusinessDate("not-a-date")).toBe("--");
+  });
+});

--- a/tests/e2e/sales-home-console.spec.ts
+++ b/tests/e2e/sales-home-console.spec.ts
@@ -6,31 +6,27 @@ import {
 
 test.describe("Sales Home Console (KAN-126)", () => {
   test.beforeEach(async ({ page }) => {
-    // Login as SALES_EXECUTIVE and navigate to /sales
-    // The /sales page is now the dedicated sales console, not a redirect
-    await loginAs(page, "SALES_EXECUTIVE", "/sales", "/sales");
-    await expect(page).toHaveURL(buildUrlExpectation("/sales"));
+    await loginAs(page, "SALES_EXECUTIVE", "/home/sales", "/home/sales");
+    await expect(page).toHaveURL(buildUrlExpectation("/home/sales"));
   });
 
-  test("SALES_EXECUTIVE can open /sales and it does not redirect to /production/requests", async ({ page }) => {
+  test("SALES_EXECUTIVE is redirected from legacy /sales to the canonical home", async ({ page }) => {
     await page.goto("/sales");
-    await expect(page).toHaveURL(buildUrlExpectation("/sales"));
-    // Should NOT redirect to production/requests
-    await expect(page).not.toHaveURL(/\/production\/requests/);
+    await expect(page).toHaveURL(buildUrlExpectation("/home/sales"));
   });
 
   test("Page shows 'Ventas' heading", async ({ page }) => {
-    await page.goto("/sales");
+    await page.goto("/home/sales");
     await expect(page.getByRole("heading", { name: "Ventas" })).toBeVisible();
   });
 
   test("Page shows primary 'Nuevo pedido' CTA", async ({ page }) => {
-    await page.goto("/sales");
+    await page.goto("/home/sales");
     await expect(page.getByRole("link", { name: /Nuevo pedido/i })).toBeVisible();
   });
 
   test("Page shows quick action links", async ({ page }) => {
-    await page.goto("/sales");
+    await page.goto("/home/sales");
 
     // Quick actions - check they exist on the page
     await expect(page.getByRole("link", { name: /Buscar producto/i })).toHaveAttribute("href", "/catalog");
@@ -40,7 +36,7 @@ test.describe("Sales Home Console (KAN-126)", () => {
   });
 
   test("Page shows 'Mi trabajo activo' section with commercial stage labels", async ({ page }) => {
-    await page.goto("/sales");
+    await page.goto("/home/sales");
 
     // Check for commercial stage labels (the cards in "Mi trabajo activo" section)
     // Just verify the stage names are visible - use first() to avoid duplicate text issues
@@ -52,7 +48,7 @@ test.describe("Sales Home Console (KAN-126)", () => {
   });
 
   test("Page does not expose warehouse-only primary actions", async ({ page }) => {
-    await page.goto("/sales");
+    await page.goto("/home/sales");
 
     // Should not have warehouse/operator-specific actions as primary
     await expect(page.getByText(/Cockpit de ejecuci[oó]n/i)).not.toBeVisible();
@@ -62,7 +58,7 @@ test.describe("Sales Home Console (KAN-126)", () => {
 
   test("Mobile layout does not horizontally overflow", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
-    await page.goto("/sales");
+    await page.goto("/home/sales");
 
     // Check body doesn't overflow
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
@@ -88,17 +84,15 @@ test.describe("Sales Home Console (KAN-126)", () => {
   });
 });
 
-// Additional test for other roles that should have access
+// `/sales` is compatibility-only: each role returns to its own canonical home.
 test.describe("Sales Home Console - Role Access", () => {
-  test("MANAGER can access /sales", async ({ page }) => {
-    await loginAs(page, "MANAGER", "/sales", "/sales");
-    await expect(page).toHaveURL(buildUrlExpectation("/sales"));
-    await expect(page.getByRole("heading", { name: "Ventas" })).toBeVisible();
+  test("MANAGER is returned to its own home", async ({ page }) => {
+    await loginAs(page, "MANAGER", "/sales", "/home/manager");
+    await expect(page).toHaveURL(buildUrlExpectation("/home/manager"));
   });
 
-  test("SYSTEM_ADMIN can access /sales", async ({ page }) => {
-    await loginAs(page, "SYSTEM_ADMIN", "/sales", "/sales");
-    await expect(page).toHaveURL(buildUrlExpectation("/sales"));
-    await expect(page.getByRole("heading", { name: "Ventas" })).toBeVisible();
+  test("SYSTEM_ADMIN is returned to its own home", async ({ page }) => {
+    await loginAs(page, "SYSTEM_ADMIN", "/sales", "/home/admin");
+    await expect(page).toHaveURL(buildUrlExpectation("/home/admin"));
   });
 });

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -220,6 +220,11 @@ describe("parseDueDate", () => {
   it("parses valid ISO date", () => {
     const date = parseDueDate("2026-06-01");
     expect(date).toBeInstanceOf(Date);
+    expect(date?.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("rejects an impossible calendar date", () => {
+    expect(parseDueDate("2026-02-30")).toBeNull();
   });
 
   it("returns null for invalid date", () => {


### PR DESCRIPTION
## Alcance\n- Conserva las fechas de compromiso como dias de calendario UTC, sin desfase segun la zona horaria del servidor.\n- La consola comercial muestra la fecha real de entrega (dueDate), no la fecha de actualizacion.\n- Homologa el listado y detalle de pedidos.\n- Alinea los E2E de inicio comercial con /home/sales como ruta canonica.\n\n## Validacion\n- 
pm run lint\n- 
pm run typecheck\n- 
px vitest run tests/business-date.test.ts tests/schemas.test.ts (46 pruebas)\n- 
px playwright test tests/e2e/sales-home-console.spec.ts --project=chromium --retries=0 (10 pruebas)\n\nSin migraciones, sin base de datos adicional y sin escrituras contra AWS.