### PR TITLE
fix: show operational timestamps locally

### DIFF
--- a/app/(shell)/page.tsx
+++ b/app/(shell)/page.tsx
@@ -5,6 +5,7 @@ import { startPerf } from "@/lib/perf";
 import { getRequestId } from "@/lib/request-meta";
 import { buttonStyles } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
+import { LocalDateTime } from "@/components/ui/local-date-time";
 import { FulfillmentKpiGrid } from "@/components/dashboard/fulfillment-kpi-grid";
 import { FulfillmentPriorityQueue } from "@/components/dashboard/fulfillment-priority-queue";
 import { FulfillmentAlertList } from "@/components/dashboard/fulfillment-alert-list";
@@ -39,13 +40,6 @@ export default async function Home() {
     overdue: snapshot.kpis.overdue,
   });
 
-  const generatedAt = new Date(snapshot.generatedAt).toLocaleString("es-MX", {
-    hour: "2-digit",
-    minute: "2-digit",
-    day: "2-digit",
-    month: "short",
-  });
-
   return (
     <div className="space-y-6">
       <PageHeader
@@ -55,7 +49,7 @@ export default async function Home() {
             ? "Visión global de backlog, riesgo y bloqueos operativos para destrabar surtido y entrega."
             : "Backlog operativo priorizado para ejecutar surtidos y resolver bloqueos en tiempo."
         }
-        meta={`Actualizado ${generatedAt} · Umbral sin movimiento ${snapshot.staleHours}h`}
+        meta={<>Actualizado <LocalDateTime value={snapshot.generatedAt} /> · Umbral sin movimiento {snapshot.staleHours}h</>}
         actions={
           <>
             <Link href="/production/requests" prefetch={false} className={buttonStyles({ variant: "secondary" })}>

--- a/app/(shell)/production/requests/[id]/page.tsx
+++ b/app/(shell)/production/requests/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getSessionContext } from "@/lib/auth/session-context";
 import { formatBusinessDate } from "@/lib/business-date";
 import { Badge } from "@/components/ui/badge";
 import { buttonStyles } from "@/components/ui/button";
+import { LocalDateTime } from "@/components/ui/local-date-time";
 import RequestProductLineForm from "@/components/RequestProductLineForm";
 import { isSystemAdmin } from "@/lib/rbac/permissions";
 import {
@@ -332,13 +333,6 @@ async function deleteLine(formData: FormData) {
 
 function formatDate(value: Date | string | null | undefined) {
   return formatBusinessDate(value);
-}
-
-function formatDateTime(value: Date | string | null | undefined) {
-  if (!value) return "--";
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return "--";
-  return date.toLocaleString("es-MX");
 }
 
 function getExecutionBadgeVariant(status: string | null | undefined): "neutral" | "accent" | "success" | "warning" | "danger" {
@@ -813,7 +807,7 @@ export default async function ProductionRequestDetailPage({
               <p className="mt-1">
                 Área: {order.preparedForDeliveryLocation ? `${order.preparedForDeliveryLocation.code} — ${order.preparedForDeliveryLocation.name}` : "Sin área registrada"}
                 {" · "}Preparó: {order.preparedForDeliveryByUser?.name ?? order.preparedForDeliveryByUser?.email ?? "Usuario operativo"}
-                {" · "}{formatDateTime(order.preparedForDeliveryAt)}
+                {" · "}<LocalDateTime value={order.preparedForDeliveryAt} />
               </p>
               {order.preparedForDeliveryNotes ? <p className="mt-1 text-xs">{order.preparedForDeliveryNotes}</p> : null}
             </div>
@@ -925,7 +919,7 @@ export default async function ProductionRequestDetailPage({
                     <p className="text-xs text-[var(--text-muted)]">{item.detail}</p>
                   </div>
                   <Badge variant={item.variant} size="sm">
-                    {item.at ? formatDateTime(item.at) : "Pendiente"}
+                    {item.at ? <LocalDateTime value={item.at} /> : "Pendiente"}
                   </Badge>
                 </div>
               </li>
@@ -946,7 +940,7 @@ export default async function ProductionRequestDetailPage({
                   <li key={`${entry.action}-${entry.createdAt.toISOString()}-${idx}`} className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-subtle)] px-3 py-2">
                     <p className="text-[var(--text-primary)]">{entry.action}</p>
                     <p className="text-xs text-[var(--text-muted)]">
-                      {entry.actorUser?.name ?? entry.actorUser?.email ?? entry.actor ?? "system"} · {formatDateTime(entry.createdAt)}
+                      {entry.actorUser?.name ?? entry.actorUser?.email ?? entry.actor ?? "system"} · <LocalDateTime value={entry.createdAt} />
                     </p>
                   </li>
                 ))}

--- a/components/OrderSummary.tsx
+++ b/components/OrderSummary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
+import { LocalDateTime } from "@/components/ui/local-date-time";
 import { SectionCard } from "@/components/ui/section-card";
 import { cn } from "@/lib/cn";
 
@@ -297,12 +298,7 @@ function OrderSummaryContent({
             )}
             {commercialPromise.checkedAt && (
               <p className="text-xs text-slate-400">
-                Verificado: {new Date(commercialPromise.checkedAt).toLocaleString("es-MX", {
-                  day: "2-digit",
-                  month: "2-digit",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
+                Verificado: <LocalDateTime value={commercialPromise.checkedAt} />
               </p>
             )}
             {commercialPromise.isSubstitute && commercialPromise.originalProductName && (

--- a/components/ui/local-date-time.tsx
+++ b/components/ui/local-date-time.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import {
+  formatDateTimeForTimeZone,
+  type LocalDateTimeValue,
+} from "@/lib/local-date-time";
+
+type Props = {
+  value: LocalDateTimeValue;
+  className?: string;
+};
+
+/** Renders an instant in the browser's timezone without leaking Lambda time. */
+export function LocalDateTime({ value, className }: Props) {
+  const date = value instanceof Date ? value : value ? new Date(value) : null;
+  const isoValue = date && !Number.isNaN(date.getTime()) ? date.toISOString() : undefined;
+  const timeZone = typeof window === "undefined"
+    ? null
+    : Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const formatted = timeZone ? formatDateTimeForTimeZone(value, timeZone) : "--";
+
+  return (
+    <time
+      className={className}
+      dateTime={isoValue}
+      title="Hora local del equipo"
+      suppressHydrationWarning
+    >
+      {formatted}
+    </time>
+  );
+}

--- a/lib/local-date-time.ts
+++ b/lib/local-date-time.ts
@@ -1,0 +1,26 @@
+export type LocalDateTimeValue = Date | string | null | undefined;
+
+/**
+ * Timestamps represent instants and should be rendered in the timezone of the
+ * device that is operating the WMS. Calendar business dates use business-date
+ * instead and must not use this formatter.
+ */
+export function formatDateTimeForTimeZone(
+  value: LocalDateTimeValue,
+  timeZone: string,
+  locale = "es-MX",
+) {
+  if (!value) return "--";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "--";
+
+  return new Intl.DateTimeFormat(locale, {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}

--- a/tests/local-date-time.test.ts
+++ b/tests/local-date-time.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { formatDateTimeForTimeZone } from "@/lib/local-date-time";
+
+describe("formatDateTimeForTimeZone", () => {
+  const instant = "2026-07-30T18:59:00.000Z";
+
+  it("renders the same instant in the requested device timezone", () => {
+    expect(formatDateTimeForTimeZone(instant, "UTC")).toContain("18:59");
+    expect(formatDateTimeForTimeZone(instant, "America/Mexico_City")).toContain("12:59");
+  });
+
+  it("keeps invalid timestamps unavailable", () => {
+    expect(formatDateTimeForTimeZone("not-a-date", "UTC")).toBe("--");
+  });
+});


### PR DESCRIPTION
## Alcance\n\n- Renderiza las marcas de tiempo del flujo operativo según la zona horaria del navegador.\n- Aplica la regla a promesa comercial, detalle/auditoría de pedido y actualización del dashboard.\n- Mantiene las fechas de compromiso como días de negocio estables, sin convertirlas a una hora local.\n\n## Validación\n\n- 
px vitest run tests/local-date-time.test.ts tests/business-date.test.ts\n- 
pm run typecheck\n- 
pm run lint\n- Navegador local contra AWS: eventos de PI-2026-0010 se muestran a las 10:32 en la zona del equipo para el instante 16:32 UTC.\n\nSin migraciones, sin cambios en PostgreSQL y sin segunda base de datos.