### PR TITLE
Implement KAN-133 operational exceptions

### DIFF
--- a/app/(shell)/production/requests/[id]/page.tsx
+++ b/app/(shell)/production/requests/[id]/page.tsx
@@ -26,6 +26,10 @@ import {
   markSalesRequestPreparedForDelivery,
   markSalesRequestDelivered,
   pullSalesRequestOrder,
+  receiveSalesRequestReturn,
+  requestSalesRequestCustomerReturn,
+  resolveSalesRequestOperationalException,
+  finalizeSalesRequestCancellationAfterReversal,
 } from "@/lib/sales/request-service";
 import { buildSalesRequestVisibilityWhere } from "@/lib/sales/visibility";
 import {
@@ -40,6 +44,8 @@ import { getSalesConsoleTimelineItems } from "@/lib/sales/console";
 import {
   firstErrorMessage,
   salesInternalOrderAssignmentSchema,
+  salesInternalOrderCancellationSchema,
+  salesInternalOrderDeliverySchema,
   salesInternalOrderPreparationSchema,
   salesInternalOrderProductLineCreateSchema,
   salesInternalOrderTransitionSchema,
@@ -104,8 +110,9 @@ async function cancelRequest(formData: FormData) {
   const requestId = await getRequestId();
   await requireSalesWriteAccess();
   const sessionCtx = await getSessionContext();
-  const parsed = salesInternalOrderTransitionSchema.safeParse({
+  const parsed = salesInternalOrderCancellationSchema.safeParse({
     orderId: String(formData.get("orderId") ?? "").trim(),
+    reason: String(formData.get("reason") ?? "").trim() || undefined,
   });
   if (!parsed.success) {
     redirect(`/production/requests?error=${encodeURIComponent(firstErrorMessage(parsed.error))}`);
@@ -113,9 +120,10 @@ async function cancelRequest(formData: FormData) {
 
   try {
     const servicePerf = startPerf("action.production.requests.detail.cancel.service");
-    await cancelSalesRequestOrder(prisma, {
+    const result = await cancelSalesRequestOrder(prisma, {
       orderId: parsed.data.orderId,
       cancelledByUserId: sessionCtx.user?.id ?? null,
+      reason: parsed.data.reason,
     });
     servicePerf.end({ requestId, orderId: parsed.data.orderId });
 
@@ -128,7 +136,7 @@ async function cancelRequest(formData: FormData) {
     });
     perf.end({ requestId, orderId: parsed.data.orderId, ok: true });
 
-    redirect(`/production/requests/${parsed.data.orderId}?ok=${encodeURIComponent("Pedido cancelado")}`);
+    redirect(`/production/requests/${parsed.data.orderId}?ok=${encodeURIComponent(result?.cancellationRequested ? "Solicitud de cancelación registrada; falta revisión y reversión física" : "Pedido cancelado")}`);
   } catch (error) {
     perf.end({ requestId, orderId: parsed.data.orderId, ok: false });
     if (isNextRedirectError(error)) throw error;
@@ -179,6 +187,7 @@ async function assignRequest(formData: FormData) {
   const parsed = salesInternalOrderAssignmentSchema.safeParse({
     orderId: String(formData.get("orderId") ?? "").trim(),
     assigneeUserId: String(formData.get("assigneeUserId") ?? "").trim(),
+    reason: String(formData.get("reason") ?? "").trim(),
   });
   if (!parsed.success || !sessionCtx.user?.id) {
     const message = parsed.success ? "Sesión inválida para asignar el pedido" : firstErrorMessage(parsed.error);
@@ -205,8 +214,13 @@ async function markDelivered(formData: FormData) {
   const requestId = await getRequestId();
   await requireSalesWriteAccess();
   const sessionCtx = await getSessionContext();
-  const parsed = salesInternalOrderTransitionSchema.safeParse({
+  const parsed = salesInternalOrderDeliverySchema.safeParse({
     orderId: String(formData.get("orderId") ?? "").trim(),
+    recipientName: String(formData.get("recipientName") ?? "").trim(),
+    deliveryMethod: String(formData.get("deliveryMethod") ?? "").trim(),
+    notes: String(formData.get("notes") ?? "").trim() || undefined,
+    evidenceUrl: String(formData.get("evidenceUrl") ?? "").trim() || undefined,
+    exceptionReason: String(formData.get("exceptionReason") ?? "").trim() || undefined,
   });
   if (!parsed.success) {
     redirect(`/production/requests?error=${encodeURIComponent(firstErrorMessage(parsed.error))}`);
@@ -220,6 +234,12 @@ async function markDelivered(formData: FormData) {
     const result = await markSalesRequestDelivered(prisma, {
       orderId: parsed.data.orderId,
       deliveredByUserId: sessionCtx.user.id,
+      deliveredByRoles: sessionCtx.roles,
+      recipientName: parsed.data.recipientName,
+      deliveryMethod: parsed.data.deliveryMethod,
+      notes: parsed.data.notes,
+      evidenceUrl: parsed.data.evidenceUrl,
+      exceptionReason: parsed.data.exceptionReason,
     });
     servicePerf.end({ requestId, orderId: parsed.data.orderId });
     perf.end({ requestId, orderId: parsed.data.orderId, ok: true });
@@ -245,6 +265,7 @@ async function markPreparedForDelivery(formData: FormData) {
     orderId: String(formData.get("orderId") ?? "").trim(),
     preparedLocationId: String(formData.get("preparedLocationId") ?? "").trim(),
     notes: String(formData.get("notes") ?? "").trim() || undefined,
+    evidenceUrl: String(formData.get("evidenceUrl") ?? "").trim() || undefined,
   });
   if (!parsed.success || !sessionCtx.user?.id) {
     const message = parsed.success ? "Sesión inválida para preparar el pedido" : firstErrorMessage(parsed.error);
@@ -262,6 +283,92 @@ async function markPreparedForDelivery(formData: FormData) {
     if (isNextRedirectError(error)) throw error;
     const message = error instanceof Error ? error.message : "No se pudo preparar el pedido";
     redirect(`/production/requests/${parsed.data.orderId}?error=${encodeURIComponent(message)}`);
+  }
+}
+
+async function resolveOperationalException(formData: FormData) {
+  "use server";
+  await requireSalesAssignmentAccess();
+  const sessionCtx = await getSessionContext();
+  const orderId = String(formData.get("orderId") ?? "").trim();
+  const exceptionId = String(formData.get("exceptionId") ?? "").trim();
+  const resolution = String(formData.get("resolution") ?? "").trim();
+  const notes = String(formData.get("notes") ?? "").trim();
+  const allowedResolutions = ["WAIT_REPLENISHMENT", "PARTIAL_DELIVERY", "SUBSTITUTE_PRODUCT", "REDUCE_QUANTITY", "URGENT_PURCHASE", "CANCEL_LINE", "CANCEL_ORDER", "REJECT_CANCELLATION"] as const;
+  if (!sessionCtx.user?.id || !exceptionId || !orderId || !allowedResolutions.includes(resolution as typeof allowedResolutions[number])) {
+    redirect(`/production/requests/${orderId}?error=${encodeURIComponent("Resolución operativa inválida")}`);
+  }
+  try {
+    const result = await resolveSalesRequestOperationalException(prisma, {
+      exceptionId,
+      decidedByUserId: sessionCtx.user.id,
+      resolution: resolution as typeof allowedResolutions[number],
+      notes,
+    });
+    redirect(`/production/requests/${orderId}?ok=${encodeURIComponent(result.returnId ? "Cancelación aprobada; falta reversión física" : "Excepción operativa resuelta")}`);
+  } catch (error) {
+    if (isNextRedirectError(error)) throw error;
+    redirect(`/production/requests/${orderId}?error=${encodeURIComponent(error instanceof Error ? error.message : "No se pudo resolver la excepción")}`);
+  }
+}
+
+async function receiveReturn(formData: FormData) {
+  "use server";
+  await (await import("@/lib/rbac")).requirePermission("production.execute");
+  const sessionCtx = await getSessionContext();
+  const orderId = String(formData.get("orderId") ?? "").trim();
+  const returnId = String(formData.get("returnId") ?? "").trim();
+  const itemIds = formData.getAll("returnItemId").map(String);
+  const dispositions = formData.getAll("disposition").map(String);
+  const destinations = formData.getAll("destinationLocationId").map(String);
+  if (!sessionCtx.user?.id || !returnId || itemIds.length === 0 || itemIds.length !== dispositions.length || itemIds.length !== destinations.length) {
+    redirect(`/production/requests/${orderId}?error=${encodeURIComponent("Datos de recepción de devolución incompletos")}`);
+  }
+  try {
+    await receiveSalesRequestReturn(prisma, {
+      returnId,
+      receivedByUserId: sessionCtx.user.id,
+      items: itemIds.map((itemId, index) => ({
+        itemId,
+        disposition: dispositions[index] as "RESTOCK" | "REPAIR" | "SCRAP" | "REJECT",
+        destinationLocationId: destinations[index] || undefined,
+      })),
+    });
+    redirect(`/production/requests/${orderId}?ok=${encodeURIComponent("Devolución física recibida y auditada")}`);
+  } catch (error) {
+    if (isNextRedirectError(error)) throw error;
+    redirect(`/production/requests/${orderId}?error=${encodeURIComponent(error instanceof Error ? error.message : "No se pudo recibir la devolución")}`);
+  }
+}
+
+async function finalizeCancellation(formData: FormData) {
+  "use server";
+  await requireSalesAssignmentAccess();
+  const sessionCtx = await getSessionContext();
+  const orderId = String(formData.get("orderId") ?? "").trim();
+  if (!sessionCtx.user?.id || !orderId) redirect(`/production/requests?error=${encodeURIComponent("Sesión o pedido inválido")}`);
+  try {
+    await finalizeSalesRequestCancellationAfterReversal(prisma, { orderId, cancelledByUserId: sessionCtx.user.id });
+    redirect(`/production/requests/${orderId}?ok=${encodeURIComponent("Cancelación confirmada después de la reversión física")}`);
+  } catch (error) {
+    if (isNextRedirectError(error)) throw error;
+    redirect(`/production/requests/${orderId}?error=${encodeURIComponent(error instanceof Error ? error.message : "No se pudo confirmar la cancelación")}`);
+  }
+}
+
+async function requestCustomerReturn(formData: FormData) {
+  "use server";
+  await requireSalesWriteAccess();
+  const sessionCtx = await getSessionContext();
+  const orderId = String(formData.get("orderId") ?? "").trim();
+  const reason = String(formData.get("reason") ?? "").trim();
+  if (!sessionCtx.user?.id || !orderId || !reason) redirect(`/production/requests/${orderId}?error=${encodeURIComponent("La devolución requiere un motivo")}`);
+  try {
+    await requestSalesRequestCustomerReturn(prisma, { orderId, requestedByUserId: sessionCtx.user.id, reason });
+    redirect(`/production/requests/${orderId}?ok=${encodeURIComponent("Devolución solicitada; pendiente de recepción e inspección")}`);
+  } catch (error) {
+    if (isNextRedirectError(error)) throw error;
+    redirect(`/production/requests/${orderId}?error=${encodeURIComponent(error instanceof Error ? error.message : "No se pudo solicitar la devolución")}`);
   }
 }
 
@@ -404,6 +511,11 @@ export default async function ProductionRequestDetailPage({
       preparedForDeliveryAt: true,
       preparedForDeliveryNotes: true,
       deliveredToCustomerAt: true,
+      deliveryRecipientName: true,
+      deliveryMethod: true,
+      deliveryNotes: true,
+      deliveryEvidenceUrl: true,
+      deliveryExceptionReason: true,
       createdAt: true,
       confirmedAt: true,
       cancelledAt: true,
@@ -437,6 +549,30 @@ export default async function ProductionRequestDetailPage({
           status: true,
           updatedAt: true,
           targetLocation: { select: { code: true, name: true } },
+        },
+      },
+      operationalExceptions: {
+        orderBy: { reportedAt: "desc" },
+        select: {
+          id: true,
+          type: true,
+          status: true,
+          reportedQty: true,
+          reason: true,
+          reportedAt: true,
+          resolution: true,
+          resolutionNotes: true,
+        },
+      },
+      returns: {
+        orderBy: { requestedAt: "desc" },
+        select: {
+          id: true,
+          kind: true,
+          status: true,
+          reason: true,
+          requestedAt: true,
+          items: { select: { id: true, product: { select: { sku: true, name: true } }, quantity: true, disposition: true, destinationLocationId: true } },
         },
       },
       lines: {
@@ -523,6 +659,13 @@ export default async function ProductionRequestDetailPage({
         },
         orderBy: [{ usageType: "asc" }, { code: "asc" }],
         select: { id: true, code: true, name: true, usageType: true },
+      })
+    : [];
+  const returnLocations = order.warehouse?.id
+    ? await prisma.location.findMany({
+        where: { warehouseId: order.warehouse.id, isActive: true },
+        orderBy: [{ usageType: "asc" }, { code: "asc" }],
+        select: { id: true, code: true, name: true },
       })
     : [];
 
@@ -624,6 +767,11 @@ export default async function ProductionRequestDetailPage({
     hasCompletedDirectPick,
     hasCompletedConfiguredAssembly,
   });
+  const canConfirmDelivery = deliveredEligibility.canMarkDelivered && (
+    (order.assignedToUserId === sessionCtx.user?.id && sessionCtx.roles.includes("SALES_EXECUTIVE"))
+    || sessionCtx.roles.includes("MANAGER")
+    || sessionCtx.roles.includes("SYSTEM_ADMIN")
+  );
   const canPrepareForDelivery =
     canOperateDirectPick &&
     orderStatus === "CONFIRMADA" &&
@@ -754,17 +902,39 @@ export default async function ProductionRequestDetailPage({
                     <button type="submit" className="btn-secondary">{takeEligibility.takeActionLabel ?? "Tomar pedido"}</button>
                   </form>
                 ) : null}
-                {deliveredEligibility.canMarkDelivered ? (
-                  <form action={markDelivered}>
+                {canConfirmDelivery ? (
+                  <form action={markDelivered} className="rounded-lg border border-[var(--status-success-border)] bg-[var(--status-success-bg)] p-4">
                     <input type="hidden" name="orderId" value={order.id} />
-                    <button type="submit" className="btn-primary">Entregado al cliente</button>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <label className="text-sm font-medium text-[var(--text-primary)]">
+                        Recibió *
+                        <input name="recipientName" required maxLength={200} className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm" />
+                      </label>
+                      <label className="text-sm font-medium text-[var(--text-primary)]">
+                        Método de entrega *
+                        <input name="deliveryMethod" required maxLength={100} placeholder="Entrega directa, recolección, mensajería…" className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm" />
+                      </label>
+                      <label className="text-sm font-medium text-[var(--text-primary)]">
+                        Nota
+                        <input name="notes" maxLength={500} className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm" />
+                      </label>
+                      <label className="text-sm font-medium text-[var(--text-primary)]">
+                        URL de evidencia
+                        <input name="evidenceUrl" type="url" maxLength={2000} placeholder="Opcional" className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm" />
+                      </label>
+                    </div>
+                    <label className="mt-3 block text-sm font-medium text-[var(--text-primary)]">
+                      Motivo de excepción (sólo Manager/Admin si no es el ejecutivo responsable)
+                      <input name="exceptionReason" maxLength={500} className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm" />
+                    </label>
+                    <button type="submit" className="btn-primary mt-3">Confirmar entrega al cliente</button>
                   </form>
                 ) : null}
-                {order.deliveredToCustomerAt ? (
-                  <a href={`/api/production/requests/${order.id}/delivery.pdf`} className={buttonStyles({ variant: "secondary" })}>
-                    Descargar comprobante de entrega
-                  </a>
-                ) : null}
+          {order.deliveredToCustomerAt ? (
+            <a href={`/api/production/requests/${order.id}/delivery.pdf`} className={buttonStyles({ variant: "secondary" })}>
+              Descargar comprobante de entrega
+            </a>
+          ) : null}
               </>
             ) : (
               <p className="text-sm text-[var(--text-muted)]">Este rol puede revisar el pedido, pero no ejecutar acciones de escritura.</p>
@@ -789,6 +959,10 @@ export default async function ProductionRequestDetailPage({
                   Nota (opcional)
                   <input name="notes" maxLength={500} placeholder="Ej. esperando recolección del cliente" className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]" />
                 </label>
+                <label className="min-w-56 flex-1 text-sm font-medium text-[var(--text-primary)]">
+                  URL de evidencia (opcional)
+                  <input name="evidenceUrl" type="url" maxLength={2000} placeholder="Foto o documento de preparación" className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]" />
+                </label>
                 <button type="submit" className="btn-primary" disabled={deliveryLocations.length === 0}>
                   Preparar para entrega
                 </button>
@@ -801,6 +975,14 @@ export default async function ProductionRequestDetailPage({
               ) : null}
             </form>
           ) : null}
+          {order.deliveredToCustomerAt ? (
+            <div className="rounded-lg border border-[var(--status-success-border)] bg-[var(--status-success-bg)] px-4 py-3 text-sm text-[var(--text-secondary)]" data-testid="delivery-summary">
+              <p className="font-semibold text-[var(--status-success-text)]">Entrega confirmada</p>
+              <p className="mt-1">Recibió: {order.deliveryRecipientName ?? "No registrado"} · Método: {order.deliveryMethod ?? "No registrado"}</p>
+              {order.deliveryExceptionReason ? <p className="mt-1 text-xs">Excepción autorizada: {order.deliveryExceptionReason}</p> : null}
+              {order.deliveryEvidenceUrl ? <a href={order.deliveryEvidenceUrl} target="_blank" rel="noreferrer" className="mt-1 inline-block text-xs text-[var(--accent)] underline">Ver evidencia</a> : null}
+            </div>
+          ) : null}
           {order.preparedForDeliveryAt ? (
             <div className="rounded-lg border border-[var(--status-success-border)] bg-[var(--status-success-bg)] px-4 py-3 text-sm text-[var(--text-secondary)]" data-testid="prepared-for-delivery-summary">
               <p className="font-semibold text-[var(--status-success-text)]">Preparado para entrega</p>
@@ -812,6 +994,59 @@ export default async function ProductionRequestDetailPage({
               {order.preparedForDeliveryNotes ? <p className="mt-1 text-xs">{order.preparedForDeliveryNotes}</p> : null}
             </div>
           ) : null}
+          {order.operationalExceptions.length > 0 ? (
+            <div className="space-y-3 rounded-lg border border-[var(--status-warning-border)] bg-[var(--status-warning-bg)] p-4" data-testid="operational-exceptions">
+              <h3 className="font-semibold text-[var(--status-warning-text)]">Excepciones operativas</h3>
+              {order.operationalExceptions.map((exception: any) => (
+                <div key={exception.id} className="rounded-md border border-[var(--status-warning-border)] bg-[var(--bg-surface)] p-3 text-sm">
+                  <p className="font-medium text-[var(--text-primary)]">{exception.type === "SHORTAGE" ? "Faltante" : "Solicitud de cancelación"} · {exception.status}</p>
+                  <p className="mt-1 text-[var(--text-secondary)]">{exception.reason}{exception.reportedQty ? ` · Cantidad: ${exception.reportedQty}` : ""}</p>
+                  {exception.resolution ? <p className="mt-1 text-xs text-[var(--text-muted)]">Decisión: {exception.resolution}{exception.resolutionNotes ? ` · ${exception.resolutionNotes}` : ""}</p> : null}
+                  {canManageAssignments && exception.status === "OPEN" ? (
+                    <form action={resolveOperationalException} className="mt-3 grid gap-2 sm:grid-cols-3">
+                      <input type="hidden" name="orderId" value={order.id} />
+                      <input type="hidden" name="exceptionId" value={exception.id} />
+                      <select name="resolution" required className="rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-sm">
+                        {exception.type === "CANCELLATION_REQUEST" ? <><option value="CANCEL_ORDER">Aprobar cancelación y reversión</option><option value="REJECT_CANCELLATION">Rechazar cancelación</option></> : <><option value="WAIT_REPLENISHMENT">Esperar reposición</option><option value="PARTIAL_DELIVERY">Autorizar entrega parcial</option><option value="SUBSTITUTE_PRODUCT">Sustituir producto</option><option value="REDUCE_QUANTITY">Reducir cantidad</option><option value="URGENT_PURCHASE">Compra urgente</option><option value="CANCEL_LINE">Cancelar línea</option><option value="CANCEL_ORDER">Cancelar pedido</option></>}
+                      </select>
+                      <input name="notes" required maxLength={1000} placeholder="Decisión y responsable" className="rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-sm" />
+                      <button type="submit" className="btn-secondary">Registrar decisión</button>
+                    </form>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {order.returns.length > 0 ? (
+            <div className="space-y-3 rounded-lg border border-[var(--border-default)] bg-[var(--bg-subtle)] p-4" data-testid="sales-order-returns">
+              <h3 className="font-semibold text-[var(--text-primary)]">Devoluciones y reversión física</h3>
+              {order.returns.map((record: any) => (
+                <div key={record.id} className="rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] p-3 text-sm">
+                  <p className="font-medium text-[var(--text-primary)]">{record.kind === "CANCELLATION_REVERSAL" ? "Reversión por cancelación" : "Devolución de cliente"} · {record.status}</p>
+                  <p className="mt-1 text-[var(--text-secondary)]">{record.reason}</p>
+                  {record.status === "REQUESTED" && canOperateDirectPick ? (
+                    <form action={receiveReturn} className="mt-3 space-y-2">
+                      <input type="hidden" name="orderId" value={order.id} />
+                      <input type="hidden" name="returnId" value={record.id} />
+                      {record.items.map((item: any) => (
+                        <div key={item.id} className="grid gap-2 sm:grid-cols-3">
+                          <input type="hidden" name="returnItemId" value={item.id} />
+                          <p className="self-center text-xs">{item.product.sku} · {item.quantity}</p>
+                          <select name="disposition" defaultValue={item.disposition} className="rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-sm"><option value="RESTOCK">Reintegrar</option><option value="REPAIR">Reparar</option><option value="SCRAP">Merma</option><option value="REJECT">Rechazar</option></select>
+                          <select name="destinationLocationId" defaultValue={item.destinationLocationId ?? ""} className="rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-sm"><option value="">Ubicación (reintegro)</option>{returnLocations.map((location) => <option key={location.id} value={location.id}>{location.code} — {location.name}</option>)}</select>
+                        </div>
+                      ))}
+                      <button type="submit" className="btn-primary">Confirmar recepción e inspección</button>
+                    </form>
+                  ) : null}
+                </div>
+              ))}
+              {canManageAssignments && order.returns.some((record: any) => record.kind === "CANCELLATION_REVERSAL" && record.status === "COMPLETED") && order.status !== "CANCELADA" ? <form action={finalizeCancellation}><input type="hidden" name="orderId" value={order.id} /><button type="submit" className="btn-secondary">Confirmar cancelación tras reversión</button></form> : null}
+            </div>
+          ) : null}
+          {order.deliveredToCustomerAt && canRenderWriteActions ? (
+            <form action={requestCustomerReturn} className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-subtle)] p-3"><input type="hidden" name="orderId" value={order.id} /><label className="text-sm font-medium text-[var(--text-primary)]">Motivo de devolución del cliente *<input name="reason" required maxLength={500} className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm" /></label><button type="submit" className="btn-secondary mt-2">Iniciar devolución</button></form>
+          ) : null}
           {canManageAssignments && order.status === "CONFIRMADA" && !order.pulledAt && !order.deliveredToCustomerAt ? (
             <form action={assignRequest} className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-subtle)] p-3" data-testid="manager-assign-order">
               <input type="hidden" name="orderId" value={order.id} />
@@ -822,6 +1057,10 @@ export default async function ProductionRequestDetailPage({
                     <option value="" disabled>Selecciona un ejecutivo</option>
                     {salesExecutives.map((user) => <option key={user.id} value={user.id}>{user.name ?? user.email} · {user.email}</option>)}
                   </select>
+                </label>
+                <label className="min-w-56 flex-1 text-sm font-medium text-[var(--text-primary)]">
+                  Motivo de asignación directa *
+                  <input name="reason" required maxLength={500} placeholder="Ej. pedido urgente o reasignación autorizada" className="mt-1 block w-full rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]" />
                 </label>
                 <button type="submit" className="btn-secondary">{order.assignedToUserId ? "Reasignar antes de toma" : "Asignar vendedor"}</button>
               </div>
@@ -835,7 +1074,7 @@ export default async function ProductionRequestDetailPage({
                 {order.notes ? <p><span className="font-medium text-[var(--text-primary)]">Notas:</span> {order.notes}</p> : null}
                 {latestPickList ? <p>Último surtido: <span className="font-mono text-[var(--accent)]">{latestPickList.code}</span> · {summarizePickListStatus(latestPickList.status)} · {latestPickList.targetLocation.code} - {latestPickList.targetLocation.name}</p> : null}
                 {canRenderWriteActions && order.status !== "CANCELADA" ? (
-                  <form action={cancelRequest}><input type="hidden" name="orderId" value={order.id} /><button type="submit" className="btn-secondary border-[var(--danger-soft)] bg-[var(--danger-soft)] text-[var(--danger-text)] hover:bg-[var(--danger-soft-hover)]">Cancelar pedido</button></form>
+                  <form action={cancelRequest} className="flex flex-wrap items-end gap-2"><input type="hidden" name="orderId" value={order.id} /><label className="text-xs text-[var(--text-secondary)]">Motivo (obligatorio si surtido fue liberado)<input name="reason" maxLength={500} className="mt-1 block rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-sm" /></label><button type="submit" className="btn-secondary border-[var(--danger-soft)] bg-[var(--danger-soft)] text-[var(--danger-text)] hover:bg-[var(--danger-soft-hover)]">Cancelar / solicitar reversión</button></form>
                 ) : null}
               </div>
             </details>

--- a/docs/process/kan-133-sales-to-warehouse-process-map.md
+++ b/docs/process/kan-133-sales-to-warehouse-process-map.md
@@ -2,7 +2,7 @@
 
 Fecha de corte: 2026-07-30
 
-Estado: en revisión; validación técnica realizada, validación operativa pendiente
+Estado: en revisión; reglas operativas implementadas en rama de integración, validación AWS pendiente de migración y prueba por rol
 Ámbito: pedido comercial directo, ensamble configurado y pedido mixto
 
 ## Propósito
@@ -41,7 +41,7 @@ de compromiso son días de negocio; las marcas de auditoría son instantes.
 ## Matriz de transiciones, validación y visibilidad
 
 Ninguna transición operativa es sólo de interfaz: cada una que cambia el
-pedido, una reserva, una lista de surtido o una entrega requiere validación de
+pedido, una reserva, una lista de surtido, una excepción, una devolución o una entrega requiere validación de
 backend. La interfaz sólo presenta el estado, la siguiente acción y el motivo
 de bloqueo; no puede sustituir las reglas de servicio.
 
@@ -50,9 +50,9 @@ de bloqueo; no puede sustituir las reglas de servicio.
 | Captura → Por asignar | Pedido `BORRADOR`, cliente, almacén, fecha y líneas válidos; promesa revalidada y reserva/lista de surtido creadas cuando aplica. | Confirma el pedido y luego ve `Por asignar`. | No recibe trabajo hasta que exista pedido confirmado y asignado. | Puede localizar el pedido para asignar o reasignar. |
 | Por asignar → En surtido | La toma o asignación no puede duplicar responsable ni aceptar pedido cancelado o ya tomado. | El ejecutivo elegible puede `Tomar pedido` o `Continuar pedido`; si no, ve el responsable o bloqueo. | Recibe el trabajo de surtido o ensamble sólo después de la asignación. | Puede asignar o reasignar antes de la toma, dentro de RBAC. |
 | En surtido → Separar para entrega | Surtido directo completado y todos los ensambles configurados ligados completados. | Ve seguimiento y bloqueo mientras falte trabajo físico. | Ejecuta surtido o ensamble; al completarse recibe `Preparar pedido`. | Ve el avance y atiende excepciones. |
-| Separar para entrega → Preparado para entrega | Se registra área física, usuario responsable y marca de preparado; no basta con cambiar una etiqueta UI. | Ve `En espera de almacén`. | Registra el área y preparado físico. | Puede verificar responsable, ubicación y evidencia. |
-| Preparado para entrega → Entregado | Pedido confirmado, asignado y tomado; surtido/ensamble completos; área de entrega registrada; entrega aún no confirmada. | Responsable, Manager o Admin habilitado puede confirmar entrega; de otro modo ve la condición bloqueante. | No habilita la entrega comercial antes de completar preparación. | Puede confirmar sólo si las mismas precondiciones se cumplen. |
-| Activo → Cancelado | Se impide cancelar si el surtido u orden de ensamble ya fue liberado; se cancelan reservas/listas en borrador y se registra auditoría. | Ve cancelación o motivo de bloqueo. | No recibe un trabajo cancelado; conserva evidencia de una operación liberada. | Gestiona la excepción y revisa auditoría. |
+| Separar para entrega → Preparado para entrega | Se registra área física, usuario responsable, nota/evidencia y marca de preparado; una excepción abierta bloquea la transición. | Ve `En espera de almacén`. | Registra el área y preparado físico. | Puede verificar responsable, ubicación y evidencia. |
+| Preparado para entrega → Entregado | Pedido confirmado, asignado y tomado; surtido/ensamble completos; área de entrega registrada; sin excepción abierta; se exige quién recibió y método. | Sólo el ejecutivo responsable confirma normalmente; Manager/Admin exige motivo excepcional. | No habilita la entrega comercial antes de completar preparación. | Puede confirmar sólo si las mismas precondiciones se cumplen. |
+| Activo → Solicitud de cancelación → Cancelado | Si el surtido ya fue liberado se crea una excepción, Manager/Admin decide, Almacén realiza reversión física y sólo entonces se confirma cancelación. | Ve el bloqueo y seguimiento. | Recibe reversión física antes del cierre. | Gestiona decisión y auditoría. |
 
 Los indicadores, tarjetas, etiquetas de etapa, PDFs de consulta y enlaces de
 navegación son **UI-only**: reflejan el estado calculado, pero no autorizan ni
@@ -88,9 +88,10 @@ flowchart LR
 5. Un pedido no puede prepararse para entrega hasta que el surtido directo esté
    completado y todos los ensambles configurados ligados estén completados.
 6. Un pedido no puede entregarse si falta responsable/toma, surtido directo,
-   ensamble, área de entrega o si ya fue entregado.
-7. Cancelar libera las reservas de listas aún en borrador; no puede ocultar una
-   operación ya liberada o una condición de inventario incompatible.
+   ensamble, área de entrega, evidencia mínima de entrega o existe una excepción abierta.
+7. Cancelar libera reservas de listas aún en borrador. Si existe surtido liberado,
+   crea una solicitud de cancelación y exige decisión, reversión física y auditoría.
+8. Un pedido entregado inicia una devolución; nunca se convierte en cancelación.
 
 ## Diferencia por tipo de pedido
 
@@ -114,6 +115,12 @@ Esta evidencia demuestra disponibilidad, confirmación, reserva y handoff; no
 autoriza por sí misma el cierre de las historias posteriores.
 
 ## Excepciones y decisiones
+
+La implementación persistente usa `SalesInternalOrderException` para faltantes
+y solicitudes de cancelación, y `SalesInternalOrderReturn` para reversión de
+surtido y devolución del cliente. Estos registros conservan actor, fecha,
+motivo, decisión, ubicación y disposición física; además bloquean preparación
+y entrega mientras permanezcan abiertos.
 
 | Excepción | Estado esperado | Responsable | Acción visible |
 |---|---|---|---|

--- a/lib/sales/request-service.ts
+++ b/lib/sales/request-service.ts
@@ -1025,6 +1025,7 @@ export async function assignSalesRequestOrder(
     orderId: string;
     assigneeUserId: string;
     assignedByUserId: string;
+    reason: string;
   },
 ) {
   return prisma.$transaction(async (tx) => {
@@ -1054,6 +1055,9 @@ export async function assignSalesRequestOrder(
     ]);
 
     if (!order) throw new InventoryServiceError("ORDER_NOT_FOUND", "Pedido no encontrado");
+    if (!args.reason.trim()) {
+      throw new InventoryServiceError("ASSIGNMENT_REASON_REQUIRED", "La asignación directa requiere un motivo operativo");
+    }
     if (order.status !== "CONFIRMADA" || order.deliveredToCustomerAt) {
       throw new InventoryServiceError("INVALID_ORDER_STATE", "Solo se puede asignar un pedido confirmado pendiente de entrega");
     }
@@ -1094,6 +1098,7 @@ export async function assignSalesRequestOrder(
         orderCode: order.code,
         assignedToUserId: assignee.id,
         assignedAt: now.toISOString(),
+        reason: args.reason.trim(),
       },
     }, tx);
 
@@ -1108,6 +1113,7 @@ export async function markSalesRequestPreparedForDelivery(
     preparedByUserId: string;
     preparedLocationId: string;
     notes?: string | null;
+    evidenceUrl?: string | null;
   },
 ): Promise<MarkSalesRequestPreparedForDeliveryResult> {
   const idempotentWarning = "Pedido ya preparado para entrega; operación idempotente";
@@ -1119,10 +1125,10 @@ export async function markSalesRequestPreparedForDelivery(
         id: true,
         code: true,
         status: true,
+        deliveredToCustomerAt: true,
         warehouseId: true,
         assignedToUserId: true,
         pulledAt: true,
-        deliveredToCustomerAt: true,
         preparedForDeliveryAt: true,
         lines: { select: { id: true, lineKind: true } },
         pickLists: {
@@ -1130,6 +1136,10 @@ export async function markSalesRequestPreparedForDelivery(
           orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
           take: 1,
           select: { status: true },
+        },
+        operationalExceptions: {
+          where: { status: "OPEN" },
+          select: { id: true, type: true, reason: true },
         },
       },
     });
@@ -1143,6 +1153,12 @@ export async function markSalesRequestPreparedForDelivery(
     }
     if (!order.warehouseId) {
       throw new InventoryServiceError("INVALID_ORDER_STATE", "El pedido no tiene almacén asignado");
+    }
+    if (order.operationalExceptions.length > 0) {
+      throw new InventoryServiceError(
+        "ORDER_BLOCKED_BY_EXCEPTION",
+        "El pedido tiene una excepción operativa abierta; resuélvela antes de prepararlo"
+      );
     }
 
     const hasProductLines = order.lines.some((line) => line.lineKind === "PRODUCT");
@@ -1204,6 +1220,7 @@ export async function markSalesRequestPreparedForDelivery(
         preparedForDeliveryByUserId: args.preparedByUserId,
         preparedForDeliveryLocationId: preparedLocation.id,
         preparedForDeliveryNotes: args.notes?.trim() || null,
+        preparedForDeliveryEvidenceUrl: args.evidenceUrl?.trim() || null,
       },
     });
     if (claim.count !== 1) {
@@ -1233,6 +1250,7 @@ export async function markSalesRequestPreparedForDelivery(
         preparedForDeliveryLocationId: preparedLocation.id,
         preparedForDeliveryLocationCode: preparedLocation.code,
         notes: args.notes?.trim() || null,
+        evidenceUrl: args.evidenceUrl?.trim() || null,
       },
     }, tx);
 
@@ -1245,6 +1263,12 @@ export async function markSalesRequestDelivered(
   args: {
     orderId: string;
     deliveredByUserId: string;
+    deliveredByRoles?: string[];
+    recipientName?: string;
+    deliveryMethod?: string;
+    notes?: string | null;
+    evidenceUrl?: string | null;
+    exceptionReason?: string | null;
   }
 ) {
   const deliveryDocumentType = "SALES_INTERNAL_ORDER_DELIVERY";
@@ -1276,6 +1300,10 @@ export async function markSalesRequestDelivered(
           take: 1,
           select: { id: true, status: true, code: true, targetLocationId: true },
         },
+        operationalExceptions: {
+          where: { status: "OPEN" },
+          select: { id: true, type: true },
+        },
       },
     });
 
@@ -1293,6 +1321,23 @@ export async function markSalesRequestDelivered(
     }
     if (!order.preparedForDeliveryAt) {
       throw new InventoryServiceError("INVALID_ORDER_STATE", "No se puede marcar entregado sin preparar el pedido en el área de entrega");
+    }
+    if (order.operationalExceptions.length > 0) {
+      throw new InventoryServiceError("ORDER_BLOCKED_BY_EXCEPTION", "No se puede entregar mientras exista una excepción operativa abierta");
+    }
+    const deliveredByRoles = args.deliveredByRoles ?? ["SALES_EXECUTIVE"];
+    const recipientName = args.recipientName?.trim() || "No especificado (integración histórica)";
+    const deliveryMethod = args.deliveryMethod?.trim() || "No especificado (integración histórica)";
+    if (args.deliveredByRoles && (!args.recipientName?.trim() || !args.deliveryMethod?.trim())) {
+      throw new InventoryServiceError("DELIVERY_EVIDENCE_REQUIRED", "Registra quién recibió y el método de entrega");
+    }
+    const isResponsibleExecutive = args.deliveredByUserId === order.assignedToUserId && deliveredByRoles.includes("SALES_EXECUTIVE");
+    const isOperationalException = deliveredByRoles.includes("MANAGER") || deliveredByRoles.includes("SYSTEM_ADMIN");
+    if (!isResponsibleExecutive && !isOperationalException) {
+      throw new InventoryServiceError("DELIVERY_NOT_AUTHORIZED", "Sólo el ejecutivo responsable puede confirmar la entrega");
+    }
+    if (isOperationalException && !isResponsibleExecutive && !args.exceptionReason?.trim()) {
+      throw new InventoryServiceError("DELIVERY_EXCEPTION_REASON_REQUIRED", "Manager/Admin debe registrar el motivo de la entrega excepcional");
     }
 
     const hasProductLines = order.lines.some((line) => line.lineKind === "PRODUCT");
@@ -1360,6 +1405,11 @@ export async function markSalesRequestDelivered(
       data: {
         deliveredToCustomerAt: now,
         deliveredByUserId: args.deliveredByUserId,
+        deliveryRecipientName: recipientName,
+        deliveryMethod,
+        deliveryNotes: args.notes?.trim() || null,
+        deliveryEvidenceUrl: args.evidenceUrl?.trim() || null,
+        deliveryExceptionReason: isOperationalException && !isResponsibleExecutive ? args.exceptionReason?.trim() || null : null,
       },
     });
     if (claim.count !== 1) {
@@ -1513,6 +1563,11 @@ export async function markSalesRequestDelivered(
         orderCode: order.code,
         deliveredToCustomerAt: now.toISOString(),
         deliveredByUserId: args.deliveredByUserId,
+        recipientName,
+        deliveryMethod,
+        notes: args.notes?.trim() || null,
+        evidenceUrl: args.evidenceUrl?.trim() || null,
+        exceptionReason: isOperationalException && !isResponsibleExecutive ? args.exceptionReason?.trim() || null : null,
         movementIds,
       },
     }, tx);
@@ -1576,6 +1631,7 @@ export async function cancelSalesRequestOrder(
   args: {
     orderId: string;
     cancelledByUserId?: string | null;
+    reason?: string | null;
   }
 ) {
   const perf = startPerf("sales.cancel_order");
@@ -1587,6 +1643,7 @@ export async function cancelSalesRequestOrder(
         id: true,
         code: true,
         status: true,
+        deliveredToCustomerAt: true,
       },
     });
     loadPerf.end();
@@ -1595,6 +1652,12 @@ export async function cancelSalesRequestOrder(
     }
     if (order.status === "CANCELADA") {
       throw new InventoryServiceError("INVALID_ORDER_STATE", "El pedido ya está cancelado");
+    }
+    if (order.deliveredToCustomerAt) {
+      throw new InventoryServiceError(
+        "DELIVERED_ORDER_REQUIRES_RETURN",
+        "Un pedido entregado no se cancela; inicia una devolución para registrar la recepción e inspección física"
+      );
     }
 
     const guardPerf = startPerf("sales.cancel_order.guard");
@@ -1608,10 +1671,38 @@ export async function cancelSalesRequestOrder(
       select: { id: true, code: true, status: true },
     });
     if (activeDirectPick) {
-      throw new InventoryServiceError(
-        "INVALID_ORDER_STATE",
-        `No se puede cancelar porque el surtido directo ya fue liberado (${activeDirectPick.code})`
-      );
+      const cancellationReason = args.reason?.trim();
+      if (!cancellationReason) {
+        throw new InventoryServiceError(
+          "CANCELLATION_REASON_REQUIRED",
+          "La solicitud de cancelación posterior a liberar surtido requiere un motivo"
+        );
+      }
+      const existing = await tx.salesInternalOrderException.findFirst({
+        where: { orderId: order.id, type: "CANCELLATION_REQUEST", status: "OPEN" },
+        select: { id: true },
+      });
+      if (!existing) {
+        await tx.salesInternalOrderException.create({
+          data: {
+            orderId: order.id,
+            type: "CANCELLATION_REQUEST",
+            status: "OPEN",
+            reason: cancellationReason,
+            reportedByUserId: args.cancelledByUserId ?? null,
+          },
+        });
+        await createAuditLogSafeWithDb({
+          entityType: "SALES_INTERNAL_ORDER",
+          entityId: order.id,
+          action: "REQUEST_CANCELLATION_AFTER_PICK_RELEASE",
+          actor: "system",
+          actorUserId: args.cancelledByUserId ?? null,
+          source: "sales/request-service",
+          after: { pickListCode: activeDirectPick.code, reason: cancellationReason },
+        }, tx);
+      }
+      return { cancellationRequested: true, orderCode: order.code };
     }
     guardPerf.end();
 
@@ -1686,6 +1777,336 @@ export async function cancelSalesRequestOrder(
       after: { status: "CANCELADA", code: order.code },
     }, tx);
     perf.end({ orderId: order.id });
+  });
+}
+
+export async function resolveSalesRequestOperationalException(
+  prisma: PrismaClient,
+  args: {
+    exceptionId: string;
+    decidedByUserId: string;
+    resolution: "WAIT_REPLENISHMENT" | "PARTIAL_DELIVERY" | "SUBSTITUTE_PRODUCT" | "REDUCE_QUANTITY" | "URGENT_PURCHASE" | "CANCEL_LINE" | "CANCEL_ORDER" | "REJECT_CANCELLATION";
+    notes: string;
+  },
+) {
+  return prisma.$transaction(async (tx) => {
+    const exception = await tx.salesInternalOrderException.findUnique({
+      where: { id: args.exceptionId },
+      select: {
+        id: true,
+        orderId: true,
+        type: true,
+        status: true,
+        reason: true,
+        order: { select: { code: true, deliveredToCustomerAt: true } },
+      },
+    });
+    if (!exception) throw new InventoryServiceError("EXCEPTION_NOT_FOUND", "La excepción operativa no existe");
+    if (exception.status !== "OPEN") throw new InventoryServiceError("EXCEPTION_CLOSED", "La excepción ya tiene una decisión registrada");
+    if (!args.notes.trim()) throw new InventoryServiceError("RESOLUTION_NOTES_REQUIRED", "La resolución requiere una nota operativa");
+    if (exception.type === "CANCELLATION_REQUEST" && !["CANCEL_ORDER", "REJECT_CANCELLATION"].includes(args.resolution)) {
+      throw new InventoryServiceError("INVALID_CANCELLATION_RESOLUTION", "Una solicitud de cancelación sólo puede aprobarse o rechazarse");
+    }
+
+    const status = args.resolution === "REJECT_CANCELLATION" ? "REJECTED" as const : "RESOLVED" as const;
+    const decidedAt = new Date();
+    await tx.salesInternalOrderException.update({
+      where: { id: exception.id },
+      data: {
+        status,
+        resolution: args.resolution,
+        resolutionNotes: args.notes.trim(),
+        decidedByUserId: args.decidedByUserId,
+        decidedAt,
+      },
+    });
+
+    let returnId: string | null = null;
+    if (exception.type === "CANCELLATION_REQUEST" && args.resolution === "CANCEL_ORDER") {
+      const pickedTasks = await tx.salesInternalOrderPickTask.findMany({
+        where: { pickList: { orderId: exception.orderId }, pickedQty: { gt: 0 }, orderLine: { productId: { not: null } } },
+        select: {
+          orderLineId: true,
+          pickedQty: true,
+          sourceLocationId: true,
+          targetLocationId: true,
+          orderLine: { select: { productId: true } },
+        },
+      });
+      const createdReturn = await tx.salesInternalOrderReturn.create({
+        data: {
+          orderId: exception.orderId,
+          exceptionId: exception.id,
+          kind: "CANCELLATION_REVERSAL",
+          reason: exception.reason,
+          requestedByUserId: args.decidedByUserId,
+          notes: args.notes.trim(),
+          items: {
+            create: pickedTasks.flatMap((task) => task.orderLine.productId ? [{
+              orderLineId: task.orderLineId,
+              productId: task.orderLine.productId,
+              sourceLocationId: task.targetLocationId,
+              destinationLocationId: task.sourceLocationId,
+              quantity: task.pickedQty,
+              disposition: "RESTOCK",
+              notes: "Reversión física de surtido por cancelación",
+            }] : []),
+          },
+        },
+        select: { id: true },
+      });
+      returnId = createdReturn.id;
+    }
+
+    await createAuditLogSafeWithDb({
+      entityType: "SALES_INTERNAL_ORDER",
+      entityId: exception.orderId,
+      action: "RESOLVE_OPERATIONAL_EXCEPTION",
+      actor: "system",
+      actorUserId: args.decidedByUserId,
+      source: "sales/request-service",
+      after: {
+        exceptionId: exception.id,
+        exceptionType: exception.type,
+        resolution: args.resolution,
+        notes: args.notes.trim(),
+        returnId,
+      },
+    }, tx);
+    return { exceptionId: exception.id, returnId, status };
+  });
+}
+
+export async function requestSalesRequestCustomerReturn(
+  prisma: PrismaClient,
+  args: { orderId: string; requestedByUserId: string; reason: string; notes?: string | null },
+) {
+  return prisma.$transaction(async (tx) => {
+    const order = await tx.salesInternalOrder.findUnique({
+      where: { id: args.orderId },
+      select: { id: true, code: true, deliveredToCustomerAt: true },
+    });
+    if (!order) throw new InventoryServiceError("ORDER_NOT_FOUND", "Pedido no encontrado");
+    if (!order.deliveredToCustomerAt) throw new InventoryServiceError("INVALID_ORDER_STATE", "Sólo un pedido entregado puede iniciar una devolución");
+    if (!args.reason.trim()) throw new InventoryServiceError("RETURN_REASON_REQUIRED", "La devolución requiere un motivo");
+    const existing = await tx.salesInternalOrderReturn.findFirst({
+      where: { orderId: order.id, kind: "CUSTOMER_RETURN", status: { in: ["REQUESTED", "RECEIVED"] } },
+      select: { id: true },
+    });
+    if (existing) return { returnId: existing.id, alreadyRequested: true };
+
+    const delivered = await tx.inventoryMovement.findMany({
+      where: { type: "OUT", documentType: "SALES_INTERNAL_ORDER_DELIVERY", documentId: order.id },
+      select: { productId: true, documentLineId: true, quantity: true },
+    });
+    if (delivered.length === 0) throw new InventoryServiceError("RETURN_SOURCE_NOT_FOUND", "No hay movimientos de entrega para devolver");
+    const created = await tx.salesInternalOrderReturn.create({
+      data: {
+        orderId: order.id,
+        kind: "CUSTOMER_RETURN",
+        reason: args.reason.trim(),
+        requestedByUserId: args.requestedByUserId,
+        notes: args.notes?.trim() || null,
+        items: {
+          create: delivered.map((movement) => ({
+            orderLineId: movement.documentLineId ?? null,
+            productId: movement.productId,
+            quantity: movement.quantity,
+            disposition: "REJECT",
+            notes: "Pendiente de recepción e inspección física",
+          })),
+        },
+      },
+      select: { id: true },
+    });
+    await createAuditLogSafeWithDb({
+      entityType: "SALES_INTERNAL_ORDER",
+      entityId: order.id,
+      action: "REQUEST_CUSTOMER_RETURN",
+      actor: "system",
+      actorUserId: args.requestedByUserId,
+      source: "sales/request-service",
+      after: { returnId: created.id, reason: args.reason.trim() },
+    }, tx);
+    return { returnId: created.id, alreadyRequested: false };
+  });
+}
+
+export async function receiveSalesRequestReturn(
+  prisma: PrismaClient,
+  args: {
+    returnId: string;
+    receivedByUserId: string;
+    items: Array<{
+      itemId: string;
+      disposition: "RESTOCK" | "REPAIR" | "SCRAP" | "REJECT";
+      destinationLocationId?: string | null;
+      notes?: string | null;
+    }>;
+  },
+) {
+  const inventoryService = getInventoryService(prisma);
+  return prisma.$transaction(async (tx) => {
+    const record = await tx.salesInternalOrderReturn.findUnique({
+      where: { id: args.returnId },
+      select: {
+        id: true,
+        orderId: true,
+        kind: true,
+        status: true,
+        items: { select: { id: true, productId: true, quantity: true, sourceLocationId: true, destinationLocationId: true } },
+      },
+    });
+    if (!record) throw new InventoryServiceError("RETURN_NOT_FOUND", "La devolución no existe");
+    if (record.status !== "REQUESTED") throw new InventoryServiceError("RETURN_ALREADY_RECEIVED", "La devolución ya fue recibida o cerrada");
+    if (args.items.length !== record.items.length) throw new InventoryServiceError("RETURN_ITEMS_INCOMPLETE", "Registra el resultado de todos los renglones de devolución");
+
+    const inputById = new Map(args.items.map((item) => [item.itemId, item]));
+    if (inputById.size !== record.items.length || record.items.some((item) => !inputById.has(item.id))) {
+      throw new InventoryServiceError("RETURN_ITEMS_INVALID", "Los renglones de devolución no corresponden al registro");
+    }
+
+    for (const item of record.items) {
+      const input = inputById.get(item.id)!;
+      const destinationLocationId = input.destinationLocationId?.trim() || item.destinationLocationId || null;
+      if (input.disposition === "RESTOCK" && !destinationLocationId) {
+        throw new InventoryServiceError("RETURN_DESTINATION_REQUIRED", "El reintegro requiere una ubicación de destino");
+      }
+      if (record.kind === "CANCELLATION_REVERSAL") {
+        if (!item.sourceLocationId) throw new InventoryServiceError("RETURN_SOURCE_REQUIRED", "La reversión no tiene ubicación física de origen");
+        if (input.disposition === "RESTOCK") {
+          await inventoryService.transferStock(item.productId, item.sourceLocationId, destinationLocationId!, item.quantity, record.id, {
+            tx,
+            actor: "system",
+            actorUserId: args.receivedByUserId,
+            operatorUserId: args.receivedByUserId,
+            notes: "Reversión física de surtido por cancelación",
+            documentType: "SALES_INTERNAL_ORDER_RETURN",
+            documentId: record.id,
+            documentLineId: item.id,
+          });
+        } else {
+          await inventoryService.adjustStock(item.productId, item.sourceLocationId, -item.quantity, `Disposición ${input.disposition} en reversión ${record.id}`, {
+            tx,
+            actor: "system",
+            actorUserId: args.receivedByUserId,
+            documentType: "SALES_INTERNAL_ORDER_RETURN",
+            documentId: record.id,
+            documentLineId: item.id,
+          });
+        }
+      } else if (input.disposition === "RESTOCK") {
+        await inventoryService.adjustStock(item.productId, destinationLocationId!, item.quantity, `Reintegro aceptado de devolución ${record.id}`, {
+          tx,
+          actor: "system",
+          actorUserId: args.receivedByUserId,
+          documentType: "SALES_INTERNAL_ORDER_RETURN",
+          documentId: record.id,
+          documentLineId: item.id,
+        });
+      } else {
+        await tx.inventoryMovement.create({
+          data: {
+            productId: item.productId,
+            locationId: destinationLocationId,
+            type: "ADJUSTMENT",
+            quantity: 0,
+            operatorName: "system",
+            operatorUserId: args.receivedByUserId,
+            reference: record.id,
+            notes: `Devolución recibida sin reintegro: ${input.disposition}`,
+            documentType: "SALES_INTERNAL_ORDER_RETURN",
+            documentId: record.id,
+            documentLineId: item.id,
+          },
+        });
+      }
+      await tx.salesInternalOrderReturnItem.update({
+        where: { id: item.id },
+        data: {
+          destinationLocationId,
+          disposition: input.disposition,
+          notes: input.notes?.trim() || null,
+        },
+      });
+    }
+
+    const now = new Date();
+    await tx.salesInternalOrderReturn.update({
+      where: { id: record.id },
+      data: { status: "COMPLETED", receivedByUserId: args.receivedByUserId, receivedAt: now, completedByUserId: args.receivedByUserId, completedAt: now },
+    });
+    await createAuditLogSafeWithDb({
+      entityType: "SALES_INTERNAL_ORDER",
+      entityId: record.orderId,
+      action: "COMPLETE_SALES_ORDER_RETURN",
+      actor: "system",
+      actorUserId: args.receivedByUserId,
+      source: "sales/request-service",
+      after: { returnId: record.id, kind: record.kind },
+    }, tx);
+    return { returnId: record.id, completed: true };
+  });
+}
+
+export async function finalizeSalesRequestCancellationAfterReversal(
+  prisma: PrismaClient,
+  args: { orderId: string; cancelledByUserId: string },
+) {
+  const inventoryService = getInventoryService(prisma);
+  return prisma.$transaction(async (tx) => {
+    const order = await tx.salesInternalOrder.findUnique({
+      where: { id: args.orderId },
+      select: {
+        id: true,
+        code: true,
+        status: true,
+        operationalExceptions: { where: { type: "CANCELLATION_REQUEST", status: "RESOLVED", resolution: "CANCEL_ORDER" }, select: { id: true } },
+        returns: { where: { kind: "CANCELLATION_REVERSAL" }, select: { status: true } },
+      },
+    });
+    if (!order) throw new InventoryServiceError("ORDER_NOT_FOUND", "Pedido no encontrado");
+    if (order.status === "CANCELADA") return { alreadyCancelled: true };
+    if (order.operationalExceptions.length === 0 || order.returns.some((record) => record.status !== "COMPLETED")) {
+      throw new InventoryServiceError("CANCELLATION_REVERSAL_PENDING", "La cancelación requiere una reversión física completada");
+    }
+    const activeAssemblies = await tx.productionOrder.count({
+      where: { sourceDocumentType: "SalesInternalOrder", sourceDocumentId: order.id, status: { not: "CANCELADA" } },
+    });
+    if (activeAssemblies > 0) {
+      throw new InventoryServiceError("ASSEMBLY_CANCELLATION_REVIEW_REQUIRED", "Existe ensamble ligado; Manager/Admin debe decidir su disposición antes de cancelar");
+    }
+    const tasks = await tx.salesInternalOrderPickTask.findMany({
+      where: { pickList: { orderId: order.id, status: { in: ["RELEASED", "IN_PROGRESS", "PARTIAL", "COMPLETED"] } }, orderLine: { productId: { not: null } } },
+      select: { id: true, reservedQty: true, pickedQty: true, shortQty: true, sourceLocationId: true, orderLine: { select: { productId: true } } },
+    });
+    for (const task of tasks) {
+      const pendingReservedQty = Math.max(0, task.reservedQty - task.pickedQty - task.shortQty);
+      if (pendingReservedQty > 0 && task.orderLine.productId) {
+        await inventoryService.releaseReservedStock(task.orderLine.productId, task.sourceLocationId, pendingReservedQty, {
+          tx,
+          actor: "system",
+          actorUserId: args.cancelledByUserId,
+          reference: order.code,
+          notes: "Liberación por cancelación posterior a surtido",
+          documentType: "SALES_INTERNAL_ORDER",
+          documentId: order.id,
+        });
+      }
+    }
+    await tx.salesInternalOrderPickTask.updateMany({ where: { pickList: { orderId: order.id } }, data: { status: "CANCELLED" } });
+    await tx.salesInternalOrderPickList.updateMany({ where: { orderId: order.id, status: { not: "CANCELLED" } }, data: { status: "CANCELLED", canceledAt: new Date() } });
+    await tx.salesInternalOrder.update({ where: { id: order.id }, data: { status: "CANCELADA", cancelledAt: new Date(), cancelledByUserId: args.cancelledByUserId } });
+    await createAuditLogSafeWithDb({
+      entityType: "SALES_INTERNAL_ORDER",
+      entityId: order.id,
+      action: "CONFIRM_CANCELLATION_AFTER_PHYSICAL_REVERSAL",
+      actor: "system",
+      actorUserId: args.cancelledByUserId,
+      source: "sales/request-service",
+      after: { status: "CANCELADA", code: order.code },
+    }, tx);
+    return { alreadyCancelled: false };
   });
 }
 
@@ -1908,6 +2329,32 @@ export async function confirmSalesRequestPickTasksBatch(
           shortReason: update.shortReason,
         },
       });
+    }
+    for (const update of updates.filter((item) => item.shortQty > 0)) {
+      const task = taskById.get(update.id);
+      if (!task) continue;
+      const existingOpenException = await tx.salesInternalOrderException.findFirst({
+        where: {
+          pickTaskId: update.id,
+          type: "SHORTAGE",
+          status: "OPEN",
+        },
+        select: { id: true },
+      });
+      if (!existingOpenException) {
+        await tx.salesInternalOrderException.create({
+          data: {
+            orderId: args.orderId,
+            orderLineId: task.orderLineId,
+            pickTaskId: update.id,
+            type: "SHORTAGE",
+            status: "OPEN",
+            reportedQty: update.shortQty,
+            reason: update.shortReason ?? "FALTANTE_EN_SURTIDO",
+            reportedByUserId: args.operatorUserId ?? null,
+          },
+        });
+      }
     }
     taskUpdatePerf.end({ updatedTasks: updates.length });
 

--- a/lib/schemas/wms.ts
+++ b/lib/schemas/wms.ts
@@ -381,11 +381,27 @@ export const salesInternalOrderPreparationSchema = z.object({
   orderId: requiredText("Pedido"),
   preparedLocationId: requiredText("Área de entrega"),
   notes: z.string().trim().max(500).optional(),
+  evidenceUrl: z.string().trim().url("La evidencia debe ser una URL válida").max(2000).optional(),
 });
 
 export const salesInternalOrderAssignmentSchema = z.object({
   orderId: requiredText("Pedido"),
   assigneeUserId: requiredText("Vendedor"),
+  reason: requiredText("Motivo de asignación directa").max(500),
+});
+
+export const salesInternalOrderDeliverySchema = z.object({
+  orderId: requiredText("Pedido"),
+  recipientName: requiredText("Persona que recibió").max(200),
+  deliveryMethod: requiredText("Método de entrega").max(100),
+  notes: z.string().trim().max(500).optional(),
+  evidenceUrl: z.string().trim().url("La evidencia debe ser una URL válida").max(2000).optional(),
+  exceptionReason: z.string().trim().max(500).optional(),
+});
+
+export const salesInternalOrderCancellationSchema = z.object({
+  orderId: requiredText("Pedido"),
+  reason: z.string().trim().max(500).optional(),
 });
 
 export const salesGenerateProductionOrderSchema = z.object({

--- a/prisma/postgresql/migrations/20260731090000_sales_order_operational_exceptions/migration.sql
+++ b/prisma/postgresql/migrations/20260731090000_sales_order_operational_exceptions/migration.sql
@@ -1,0 +1,99 @@
+-- KAN-133 operational exceptions, delivery evidence, cancellation reversal and returns.
+-- Additive migration: it does not mutate existing orders or inventory balances.
+
+CREATE TYPE "SalesInternalOrderExceptionType" AS ENUM ('SHORTAGE', 'CANCELLATION_REQUEST');
+CREATE TYPE "SalesInternalOrderExceptionStatus" AS ENUM ('OPEN', 'RESOLVED', 'REJECTED');
+CREATE TYPE "SalesInternalOrderExceptionResolution" AS ENUM ('WAIT_REPLENISHMENT', 'PARTIAL_DELIVERY', 'SUBSTITUTE_PRODUCT', 'REDUCE_QUANTITY', 'URGENT_PURCHASE', 'CANCEL_LINE', 'CANCEL_ORDER', 'REJECT_CANCELLATION');
+CREATE TYPE "SalesInternalOrderReturnKind" AS ENUM ('CANCELLATION_REVERSAL', 'CUSTOMER_RETURN');
+CREATE TYPE "SalesInternalOrderReturnStatus" AS ENUM ('REQUESTED', 'RECEIVED', 'COMPLETED', 'REJECTED');
+CREATE TYPE "SalesInternalOrderReturnDisposition" AS ENUM ('RESTOCK', 'REPAIR', 'SCRAP', 'REJECT');
+
+ALTER TABLE "SalesInternalOrder"
+  ADD COLUMN "preparedForDeliveryEvidenceUrl" TEXT,
+  ADD COLUMN "deliveryRecipientName" TEXT,
+  ADD COLUMN "deliveryMethod" TEXT,
+  ADD COLUMN "deliveryNotes" TEXT,
+  ADD COLUMN "deliveryEvidenceUrl" TEXT,
+  ADD COLUMN "deliveryExceptionReason" TEXT;
+
+CREATE TABLE "SalesInternalOrderException" (
+  "id" TEXT NOT NULL,
+  "orderId" TEXT NOT NULL,
+  "orderLineId" TEXT,
+  "pickTaskId" TEXT,
+  "type" "SalesInternalOrderExceptionType" NOT NULL,
+  "status" "SalesInternalOrderExceptionStatus" NOT NULL DEFAULT 'OPEN',
+  "reportedQty" DOUBLE PRECISION,
+  "reason" TEXT NOT NULL,
+  "reportedByUserId" TEXT,
+  "reportedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "resolution" "SalesInternalOrderExceptionResolution",
+  "resolutionNotes" TEXT,
+  "decidedByUserId" TEXT,
+  "decidedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "SalesInternalOrderException_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "SalesInternalOrderReturn" (
+  "id" TEXT NOT NULL,
+  "orderId" TEXT NOT NULL,
+  "exceptionId" TEXT,
+  "kind" "SalesInternalOrderReturnKind" NOT NULL,
+  "status" "SalesInternalOrderReturnStatus" NOT NULL DEFAULT 'REQUESTED',
+  "reason" TEXT NOT NULL,
+  "requestedByUserId" TEXT,
+  "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "receivedByUserId" TEXT,
+  "receivedAt" TIMESTAMP(3),
+  "completedByUserId" TEXT,
+  "completedAt" TIMESTAMP(3),
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "SalesInternalOrderReturn_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "SalesInternalOrderReturnItem" (
+  "id" TEXT NOT NULL,
+  "returnId" TEXT NOT NULL,
+  "orderLineId" TEXT,
+  "productId" TEXT NOT NULL,
+  "sourceLocationId" TEXT,
+  "destinationLocationId" TEXT,
+  "quantity" DOUBLE PRECISION NOT NULL,
+  "disposition" "SalesInternalOrderReturnDisposition" NOT NULL,
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "SalesInternalOrderReturnItem_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "SalesInternalOrderException"
+  ADD CONSTRAINT "SalesInternalOrderException_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "SalesInternalOrder"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderException_orderLineId_fkey" FOREIGN KEY ("orderLineId") REFERENCES "SalesInternalOrderLine"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderException_pickTaskId_fkey" FOREIGN KEY ("pickTaskId") REFERENCES "SalesInternalOrderPickTask"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderException_reportedByUserId_fkey" FOREIGN KEY ("reportedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderException_decidedByUserId_fkey" FOREIGN KEY ("decidedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "SalesInternalOrderReturn"
+  ADD CONSTRAINT "SalesInternalOrderReturn_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "SalesInternalOrder"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderReturn_exceptionId_fkey" FOREIGN KEY ("exceptionId") REFERENCES "SalesInternalOrderException"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderReturn_requestedByUserId_fkey" FOREIGN KEY ("requestedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderReturn_receivedByUserId_fkey" FOREIGN KEY ("receivedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderReturn_completedByUserId_fkey" FOREIGN KEY ("completedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "SalesInternalOrderReturnItem"
+  ADD CONSTRAINT "SalesInternalOrderReturnItem_returnId_fkey" FOREIGN KEY ("returnId") REFERENCES "SalesInternalOrderReturn"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderReturnItem_orderLineId_fkey" FOREIGN KEY ("orderLineId") REFERENCES "SalesInternalOrderLine"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderReturnItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderReturnItem_sourceLocationId_fkey" FOREIGN KEY ("sourceLocationId") REFERENCES "Location"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "SalesInternalOrderReturnItem_destinationLocationId_fkey" FOREIGN KEY ("destinationLocationId") REFERENCES "Location"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "SalesInternalOrderException_orderId_status_type_idx" ON "SalesInternalOrderException"("orderId", "status", "type");
+CREATE INDEX "SalesInternalOrderException_orderLineId_idx" ON "SalesInternalOrderException"("orderLineId");
+CREATE INDEX "SalesInternalOrderException_pickTaskId_idx" ON "SalesInternalOrderException"("pickTaskId");
+CREATE INDEX "SalesInternalOrderReturn_orderId_status_kind_idx" ON "SalesInternalOrderReturn"("orderId", "status", "kind");
+CREATE INDEX "SalesInternalOrderReturn_exceptionId_idx" ON "SalesInternalOrderReturn"("exceptionId");
+CREATE INDEX "SalesInternalOrderReturnItem_returnId_idx" ON "SalesInternalOrderReturnItem"("returnId");
+CREATE INDEX "SalesInternalOrderReturnItem_productId_idx" ON "SalesInternalOrderReturnItem"("productId");

--- a/prisma/postgresql/schema.prisma
+++ b/prisma/postgresql/schema.prisma
@@ -25,6 +25,11 @@ model User {
   assignedSalesOrders  SalesInternalOrder[] @relation("SalesInternalOrderAssignedTo")
   preparedSalesOrders SalesInternalOrder[] @relation("SalesInternalOrderPreparedForDeliveryBy")
   deliveredSalesOrders SalesInternalOrder[] @relation("SalesInternalOrderDeliveredBy")
+  reportedSalesOrderExceptions SalesInternalOrderException[] @relation("SalesInternalOrderExceptionReportedBy")
+  decidedSalesOrderExceptions SalesInternalOrderException[] @relation("SalesInternalOrderExceptionDecidedBy")
+  requestedSalesOrderReturns SalesInternalOrderReturn[] @relation("SalesInternalOrderReturnRequestedBy")
+  receivedSalesOrderReturns SalesInternalOrderReturn[] @relation("SalesInternalOrderReturnReceivedBy")
+  completedSalesOrderReturns SalesInternalOrderReturn[] @relation("SalesInternalOrderReturnCompletedBy")
 
   inventoryMovements InventoryMovement[] @relation("MovementOperatorUser")
   traceRecords       TraceRecord[]       @relation("TraceOperatorUser")
@@ -124,6 +129,7 @@ model Product {
   technicalAttributes ProductTechnicalAttribute[]
   productionOrderItems ProductionOrderItem[]
   salesInternalOrderLines SalesInternalOrderLine[]
+  salesInternalOrderReturnItems SalesInternalOrderReturnItem[]
   salesAssemblyConfigurationsEntry SalesInternalOrderAssemblyConfig[] @relation("SalesAssemblyEntryFittingProduct")
   salesAssemblyConfigurationsHose  SalesInternalOrderAssemblyConfig[] @relation("SalesAssemblyHoseProduct")
   salesAssemblyConfigurationsExit  SalesInternalOrderAssemblyConfig[] @relation("SalesAssemblyExitFittingProduct")
@@ -261,6 +267,8 @@ model Location {
   salesOrderPickTasksSource SalesInternalOrderPickTask[] @relation("SalesOrderPickTaskSourceLocation")
   salesOrderPickTasksTarget SalesInternalOrderPickTask[] @relation("SalesOrderPickTaskTargetLocation")
   preparedSalesOrders SalesInternalOrder[] @relation("SalesInternalOrderPreparedForDeliveryLocation")
+  salesOrderReturnItemsFrom SalesInternalOrderReturnItem[] @relation("SalesInternalOrderReturnItemSourceLocation")
+  salesOrderReturnItemsTo SalesInternalOrderReturnItem[] @relation("SalesInternalOrderReturnItemDestinationLocation")
   assemblyWipWorkOrders  AssemblyWorkOrder[] @relation("AssemblyWipLocation")
   traceRecords TraceRecord[]
 
@@ -321,6 +329,50 @@ enum SalesInternalOrderStatus {
 enum SalesInternalOrderLineKind {
   PRODUCT
   CONFIGURED_ASSEMBLY
+}
+
+// Operational exceptions are explicit records instead of side effects hidden in
+// picking tasks. They block preparation and delivery until an authorized
+// decision is recorded.
+enum SalesInternalOrderExceptionType {
+  SHORTAGE
+  CANCELLATION_REQUEST
+}
+
+enum SalesInternalOrderExceptionStatus {
+  OPEN
+  RESOLVED
+  REJECTED
+}
+
+enum SalesInternalOrderExceptionResolution {
+  WAIT_REPLENISHMENT
+  PARTIAL_DELIVERY
+  SUBSTITUTE_PRODUCT
+  REDUCE_QUANTITY
+  URGENT_PURCHASE
+  CANCEL_LINE
+  CANCEL_ORDER
+  REJECT_CANCELLATION
+}
+
+enum SalesInternalOrderReturnKind {
+  CANCELLATION_REVERSAL
+  CUSTOMER_RETURN
+}
+
+enum SalesInternalOrderReturnStatus {
+  REQUESTED
+  RECEIVED
+  COMPLETED
+  REJECTED
+}
+
+enum SalesInternalOrderReturnDisposition {
+  RESTOCK
+  REPAIR
+  SCRAP
+  REJECT
 }
 
 enum ProductionOrderKind {
@@ -556,7 +608,13 @@ model SalesInternalOrder {
   pulledAt DateTime?
   preparedForDeliveryAt DateTime?
   preparedForDeliveryNotes String?
+  preparedForDeliveryEvidenceUrl String?
   deliveredToCustomerAt DateTime?
+  deliveryRecipientName String?
+  deliveryMethod String?
+  deliveryNotes String?
+  deliveryEvidenceUrl String?
+  deliveryExceptionReason String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -571,6 +629,8 @@ model SalesInternalOrder {
   deliveredByUser User? @relation("SalesInternalOrderDeliveredBy", fields: [deliveredByUserId], references: [id], onDelete: SetNull)
   lines SalesInternalOrderLine[]
   pickLists SalesInternalOrderPickList[]
+  operationalExceptions SalesInternalOrderException[]
+  returns SalesInternalOrderReturn[]
 
   @@index([status, createdAt])
   @@index([requestedByUserId])
@@ -581,6 +641,86 @@ model SalesInternalOrder {
   @@index([customerId])
   @@index([warehouseId])
   @@index([sourceMaterialRequestCode])
+}
+
+model SalesInternalOrderException {
+  id String @id @default(uuid())
+  orderId String
+  orderLineId String?
+  pickTaskId String?
+  type SalesInternalOrderExceptionType
+  status SalesInternalOrderExceptionStatus @default(OPEN)
+  reportedQty Float?
+  reason String
+  reportedByUserId String?
+  reportedAt DateTime @default(now())
+  resolution SalesInternalOrderExceptionResolution?
+  resolutionNotes String?
+  decidedByUserId String?
+  decidedAt DateTime?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  order SalesInternalOrder @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  orderLine SalesInternalOrderLine? @relation(fields: [orderLineId], references: [id], onDelete: SetNull)
+  pickTask SalesInternalOrderPickTask? @relation(fields: [pickTaskId], references: [id], onDelete: SetNull)
+  reportedByUser User? @relation("SalesInternalOrderExceptionReportedBy", fields: [reportedByUserId], references: [id], onDelete: SetNull)
+  decidedByUser User? @relation("SalesInternalOrderExceptionDecidedBy", fields: [decidedByUserId], references: [id], onDelete: SetNull)
+  returns SalesInternalOrderReturn[]
+
+  @@index([orderId, status, type])
+  @@index([orderLineId])
+  @@index([pickTaskId])
+}
+
+model SalesInternalOrderReturn {
+  id String @id @default(uuid())
+  orderId String
+  exceptionId String?
+  kind SalesInternalOrderReturnKind
+  status SalesInternalOrderReturnStatus @default(REQUESTED)
+  reason String
+  requestedByUserId String?
+  requestedAt DateTime @default(now())
+  receivedByUserId String?
+  receivedAt DateTime?
+  completedByUserId String?
+  completedAt DateTime?
+  notes String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  order SalesInternalOrder @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  exception SalesInternalOrderException? @relation(fields: [exceptionId], references: [id], onDelete: SetNull)
+  requestedByUser User? @relation("SalesInternalOrderReturnRequestedBy", fields: [requestedByUserId], references: [id], onDelete: SetNull)
+  receivedByUser User? @relation("SalesInternalOrderReturnReceivedBy", fields: [receivedByUserId], references: [id], onDelete: SetNull)
+  completedByUser User? @relation("SalesInternalOrderReturnCompletedBy", fields: [completedByUserId], references: [id], onDelete: SetNull)
+  items SalesInternalOrderReturnItem[]
+
+  @@index([orderId, status, kind])
+  @@index([exceptionId])
+}
+
+model SalesInternalOrderReturnItem {
+  id String @id @default(uuid())
+  returnId String
+  orderLineId String?
+  productId String
+  sourceLocationId String?
+  destinationLocationId String?
+  quantity Float
+  disposition SalesInternalOrderReturnDisposition
+  notes String?
+  createdAt DateTime @default(now())
+
+  return SalesInternalOrderReturn @relation(fields: [returnId], references: [id], onDelete: Cascade)
+  orderLine SalesInternalOrderLine? @relation(fields: [orderLineId], references: [id], onDelete: SetNull)
+  product Product @relation(fields: [productId], references: [id], onDelete: Restrict)
+  sourceLocation Location? @relation("SalesInternalOrderReturnItemSourceLocation", fields: [sourceLocationId], references: [id], onDelete: SetNull)
+  destinationLocation Location? @relation("SalesInternalOrderReturnItemDestinationLocation", fields: [destinationLocationId], references: [id], onDelete: SetNull)
+
+  @@index([returnId])
+  @@index([productId])
 }
 
 model SalesInternalOrderLine {
@@ -597,6 +737,8 @@ model SalesInternalOrderLine {
   product Product? @relation(fields: [productId], references: [id], onDelete: Restrict)
   assemblyConfiguration SalesInternalOrderAssemblyConfig?
   pickTasks SalesInternalOrderPickTask[]
+  operationalExceptions SalesInternalOrderException[]
+  returnItems SalesInternalOrderReturnItem[]
 
   @@index([orderId])
   @@index([productId])
@@ -671,6 +813,7 @@ model SalesInternalOrderPickTask {
   orderLine SalesInternalOrderLine @relation(fields: [orderLineId], references: [id], onDelete: Cascade)
   sourceLocation Location @relation("SalesOrderPickTaskSourceLocation", fields: [sourceLocationId], references: [id], onDelete: Restrict)
   targetLocation Location @relation("SalesOrderPickTaskTargetLocation", fields: [targetLocationId], references: [id], onDelete: Restrict)
+  operationalExceptions SalesInternalOrderException[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/tests/sales/operational-exception-contract.unit.test.ts
+++ b/tests/sales/operational-exception-contract.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  salesInternalOrderAssignmentSchema,
+  salesInternalOrderDeliverySchema,
+  salesInternalOrderPreparationSchema,
+} from "@/lib/schemas/wms";
+
+describe("KAN-133 operational evidence contracts", () => {
+  it("requires a reason for a direct Manager/Admin assignment", () => {
+    expect(salesInternalOrderAssignmentSchema.safeParse({ orderId: "order-1", assigneeUserId: "sales-1" }).success).toBe(false);
+    expect(salesInternalOrderAssignmentSchema.safeParse({ orderId: "order-1", assigneeUserId: "sales-1", reason: "Pedido urgente" }).success).toBe(true);
+  });
+
+  it("requires recipient and delivery method while allowing optional evidence", () => {
+    expect(salesInternalOrderDeliverySchema.safeParse({ orderId: "order-1", recipientName: "", deliveryMethod: "Entrega directa" }).success).toBe(false);
+    expect(salesInternalOrderDeliverySchema.safeParse({
+      orderId: "order-1",
+      recipientName: "Ana Cliente",
+      deliveryMethod: "Entrega directa",
+      evidenceUrl: "https://evidence.example/delivery/1",
+    }).success).toBe(true);
+  });
+
+  it("keeps the preparation location mandatory and validates optional evidence URLs", () => {
+    expect(salesInternalOrderPreparationSchema.safeParse({ orderId: "order-1", preparedLocationId: "" }).success).toBe(false);
+    expect(salesInternalOrderPreparationSchema.safeParse({ orderId: "order-1", preparedLocationId: "stage-1", evidenceUrl: "not-a-url" }).success).toBe(false);
+    expect(salesInternalOrderPreparationSchema.safeParse({ orderId: "order-1", preparedLocationId: "stage-1", evidenceUrl: "https://evidence.example/prepared/1" }).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Qué cambia\n\nImplementa el contrato operativo aprobado para excepciones, entrega, cancelación posterior al surtido y devolución.\n\n- Faltantes y solicitudes de cancelación quedan como excepciones persistentes y bloqueantes.\n- La entrega exige ejecutivo responsable o excepción Manager/Admin con motivo, receptor y método.\n- La cancelación posterior al surtido exige reversión física antes del cierre.\n- Un pedido entregado inicia devolución, no cancelación.\n- Incluye migración PostgreSQL aditiva y UI/auditoría para cada decisión.\n\n## Validación\n\n- npm run lint\n- npm run typecheck\n- npm run build\n- 31 pruebas unitarias puras aprobadas\n\nNo se ejecutaron pruebas que reinician la base porque este entorno usa AWS como única base autorizada.