### PR TITLE
fix: close WMS reconciliation safety gaps

### DIFF
--- a/lib/catalog/technical-specs.ts
+++ b/lib/catalog/technical-specs.ts
@@ -300,10 +300,25 @@ export function validateTechnicalSpecRows(rows: TechnicalSpecRow[]): TechnicalVa
     "angle",
     "hose_length",
   ]);
+  const positivePhysicalKeys = new Set([
+    "inner_diameter",
+    "outer_diameter",
+    "working_pressure",
+    "burst_pressure",
+    "bend_radius",
+    "port_size",
+    "hose_length",
+  ]);
 
   for (const row of rows) {
-    if (numericKeys.has(row.key) && !Number.isFinite(numericValue(row))) {
+    if (!numericKeys.has(row.key)) continue;
+    const value = numericValue(row);
+    if (!Number.isFinite(value)) {
       errors.push(`${row.key}: debe contener un valor numérico válido`);
+      continue;
+    }
+    if (positivePhysicalKeys.has(row.key) && value <= 0) {
+      errors.push(`${row.key}: debe ser mayor que cero`);
     }
   }
 

--- a/tests/catalog/technical-specs.unit.test.ts
+++ b/tests/catalog/technical-specs.unit.test.ts
@@ -71,6 +71,30 @@ describe("technical product specification contract", () => {
     ]));
   });
 
+  it("rejects nonpositive physical measurements while allowing valid temperatures and zero-degree angles", () => {
+    const invalidRows = buildTechnicalSpecRows("HOSE", JSON.stringify({
+      inner_diameter: 0,
+      working_pressure: -50,
+      temperature_min: -40,
+      temperature_max: 0,
+    }));
+
+    const invalidResult = validateTechnicalSpecRows(invalidRows);
+    expect(invalidResult.valid).toBe(false);
+    expect(invalidResult.errors).toEqual(expect.arrayContaining([
+      "inner_diameter: debe ser mayor que cero",
+      "working_pressure: debe ser mayor que cero",
+    ]));
+
+    const allowedRows = buildTechnicalSpecRows("FITTING", JSON.stringify({
+      port_size: 12,
+      working_pressure: 100,
+      temperature_max: -20,
+      angle: 0,
+    }));
+    expect(validateTechnicalSpecRows(allowedRows).valid).toBe(true);
+  });
+
   it("persists technical fields idempotently without deleting the product history", async () => {
     const upserts: unknown[] = [];
     const deletes: unknown[] = [];

--- a/tests/e2e/kan128-aws-readonly-evidence.spec.ts
+++ b/tests/e2e/kan128-aws-readonly-evidence.spec.ts
@@ -40,7 +40,7 @@ test.describe("KAN-128: AWS read-only operational evidence", () => {
           const singleCreateOrderLink = salesPage.getByRole("link", { name: "Crear pedido", exact: true }).first();
           const href = await singleCreateOrderLink.getAttribute("href");
           if (!href) throw new Error("The single warehouse order link has no href");
-          const promisedWarehouseCode = new URL(href, salesPage.url()).searchParams.get("warehouseCode");
+          const promisedWarehouseCode = new URL(href, salesPage.url()).searchParams.get("promiseWarehouseCode");
           expect(promisedWarehouseCode).toBe(warehouseCode);
           await singleCreateOrderLink.click();
         }


### PR DESCRIPTION
## Objetivo
Cerrar dos defectos reales encontrados durante la reconciliación Jira↔GitHub antes de declarar completados KAN-128 y el bloque de reglas técnicas.

## Cambios
- KAN-128: el E2E AWS de almacén único ahora valida el parámetro canónico `promiseWarehouseCode` generado por el flujo comercial.
- Catálogo técnico: dimensiones, presiones, radio de curvatura, tamaño de puerto y longitud de manguera deben ser estrictamente mayores que cero.
- Se preservan valores físicamente válidos como temperaturas negativas y ángulo de 0°.
- Se agrega cobertura unitaria explícita para ambos límites de validación técnica.

## Alcance
- Sin cambios de esquema ni migraciones.
- Sin ampliación RBAC.
- Sin cambios de estados de pedido.
- Sin cambios en inventario AWS.

## Validación esperada
- Quality Gate requerido de GitHub Actions.
- AWS Read-only E2E requerido.
- `tests/catalog/technical-specs.unit.test.ts` cubre el nuevo contrato; el gate actual no ejecuta `test:unit`, por lo que esa brecha de CI se reconciliará por separado bajo Calidad/Despliegue y no se ocultará como evidencia ejecutada.

## Trazabilidad
- Corrige los dos hilos de review que quedaron abiertos en PR #94.
- KAN-128 no debe cerrarse hasta que esta PR quede integrada y el gate AWS esté verde.
- KAN-4/KAN-19/KAN-20 no deben cerrarse sólo por esta PR; requieren reconciliación completa de compatibilidad/bloqueos además de esta validación de datos.