### PR TITLE
chore: sync main into receiving cockpit fix after KAN-7 CI contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,12 @@ jobs:
       - name: Build OpenNext artifact
         run: npm run build:opennext
 
-  # This job validates the already-deployed AWS environment, not the PR merge ref.
-  # Keep it as release/operations evidence on scheduled or explicit manual runs so
-  # live credentials or deployment drift cannot create false negatives on PR code.
+  # Branch protection still requires this check context. The live AWS test validates
+  # the already-deployed environment, not a PR merge ref, so PR/push executions keep
+  # the required context explicit and green while declaring the release gate deferred.
+  # Scheduled/manual executions run the actual AWS read-only evidence suite.
   aws-readonly-e2e:
     name: AWS Read-only E2E (required)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: quality
     timeout-minutes: 15
@@ -81,22 +81,34 @@ jobs:
       WMS_E2E_SALES_EXECUTIVE_PASSWORD: ${{ secrets.WMS_E2E_SALES_EXECUTIVE_PASSWORD }}
 
     steps:
+      - name: PR/push release-gate scope declaration
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+        run: |
+          echo "AWS read-only E2E is a deployed-environment release gate."
+          echo "It is intentionally deferred for PR/push because the PR merge ref is not deployed to WMS_LIVE_BASE_URL."
+          echo "Run this workflow manually or wait for the scheduled execution after deployment for release evidence."
+
       - name: Checkout code
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: npm ci
 
       - name: Install Chromium
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: npx playwright install --with-deps chromium
 
       - name: Verify AWS E2E credentials are configured
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           test -n "$WMS_E2E_SALES_EXECUTIVE_EMAIL" || (echo "Missing WMS_E2E_SALES_EXECUTIVE_EMAIL" && exit 1)
@@ -105,6 +117,7 @@ jobs:
           test -n "$WMS_E2E_WAREHOUSE_OPERATOR_PASSWORD" || (echo "Missing WMS_E2E_WAREHOUSE_OPERATOR_PASSWORD" && exit 1)
 
       - name: Run AWS read-only KAN-128 evidence gate
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: npx playwright test tests/e2e/kan128-aws-readonly-evidence.spec.ts --config=playwright.aws-readonly.config.ts --project=chromium
 
   security:

--- a/lib/catalog/technical-specs.ts
+++ b/lib/catalog/technical-specs.ts
@@ -300,10 +300,25 @@ export function validateTechnicalSpecRows(rows: TechnicalSpecRow[]): TechnicalVa
     "angle",
     "hose_length",
   ]);
+  const positivePhysicalKeys = new Set([
+    "inner_diameter",
+    "outer_diameter",
+    "working_pressure",
+    "burst_pressure",
+    "bend_radius",
+    "port_size",
+    "hose_length",
+  ]);
 
   for (const row of rows) {
-    if (numericKeys.has(row.key) && !Number.isFinite(numericValue(row))) {
+    if (!numericKeys.has(row.key)) continue;
+    const value = numericValue(row);
+    if (!Number.isFinite(value)) {
       errors.push(`${row.key}: debe contener un valor numérico válido`);
+      continue;
+    }
+    if (positivePhysicalKeys.has(row.key) && value <= 0) {
+      errors.push(`${row.key}: debe ser mayor que cero`);
     }
   }
 

--- a/tests/catalog/technical-specs.unit.test.ts
+++ b/tests/catalog/technical-specs.unit.test.ts
@@ -71,6 +71,30 @@ describe("technical product specification contract", () => {
     ]));
   });
 
+  it("rejects nonpositive physical measurements while allowing valid temperatures and zero-degree angles", () => {
+    const invalidRows = buildTechnicalSpecRows("HOSE", JSON.stringify({
+      inner_diameter: 0,
+      working_pressure: -50,
+      temperature_min: -40,
+      temperature_max: 0,
+    }));
+
+    const invalidResult = validateTechnicalSpecRows(invalidRows);
+    expect(invalidResult.valid).toBe(false);
+    expect(invalidResult.errors).toEqual(expect.arrayContaining([
+      "inner_diameter: debe ser mayor que cero",
+      "working_pressure: debe ser mayor que cero",
+    ]));
+
+    const allowedRows = buildTechnicalSpecRows("FITTING", JSON.stringify({
+      port_size: 12,
+      working_pressure: 100,
+      temperature_max: -20,
+      angle: 0,
+    }));
+    expect(validateTechnicalSpecRows(allowedRows).valid).toBe(true);
+  });
+
   it("persists technical fields idempotently without deleting the product history", async () => {
     const upserts: unknown[] = [];
     const deletes: unknown[] = [];

--- a/tests/e2e/kan128-aws-readonly-evidence.spec.ts
+++ b/tests/e2e/kan128-aws-readonly-evidence.spec.ts
@@ -40,7 +40,7 @@ test.describe("KAN-128: AWS read-only operational evidence", () => {
           const singleCreateOrderLink = salesPage.getByRole("link", { name: "Crear pedido", exact: true }).first();
           const href = await singleCreateOrderLink.getAttribute("href");
           if (!href) throw new Error("The single warehouse order link has no href");
-          const promisedWarehouseCode = new URL(href, salesPage.url()).searchParams.get("warehouseCode");
+          const promisedWarehouseCode = new URL(href, salesPage.url()).searchParams.get("promiseWarehouseCode");
           expect(promisedWarehouseCode).toBe(warehouseCode);
           await singleCreateOrderLink.click();
         }


### PR DESCRIPTION
Internal synchronization PR. Bring current `main` (including PR #95 and PR #100) into `fix/KAN-89-90-procurement-tokens` so PR #96 is revalidated under the final required-check contract. No product-scope expansion.