### PR TITLE
feat(KAN-86 KAN-87): prioritize procurement work and next actions

### DIFF
--- a/app/(shell)/purchasing/orders/page.tsx
+++ b/app/(shell)/purchasing/orders/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { getSessionContext } from "@/lib/auth/session-context";
 import { pageGuard } from "@/components/rbac/PageGuard";
@@ -17,6 +18,7 @@ import { getPurchaseOrderOperationalState } from "@/lib/purchasing/purchase-orde
 
 export const dynamic = "force-dynamic";
 const PAGE_SIZE = 50;
+const RECEIVABLE_STATUSES = ["CONFIRMADA", "EN_TRANSITO", "PARCIAL"] as const;
 
 const STATUS_LABELS: Record<string, string> = {
   BORRADOR: "Borrador",
@@ -40,7 +42,7 @@ type SearchParams = { status?: string; page?: string };
 type PurchaseOrderSearchParams = SearchParams & { preset?: string };
 
 function canReceivePurchaseOrder(status: string) {
-  return status === "CONFIRMADA" || status === "EN_TRANSITO" || status === "PARCIAL";
+  return RECEIVABLE_STATUSES.includes(status as (typeof RECEIVABLE_STATUSES)[number]);
 }
 
 function parsePage(value: string | undefined) {
@@ -87,7 +89,18 @@ export default async function PurchaseOrdersPage({
   const currentPage = parsePage(sp.page);
 
   const presetWhere = buildPurchaseOrderPresetWhere(presetFilter);
-  const where = statusFilter ? { status: statusFilter } : presetWhere;
+  const receiverTodayWhere: Prisma.PurchaseOrderWhereInput = {
+    AND: [
+      buildPurchaseOrderPresetWhere("por_recibir_hoy"),
+      { status: { in: [...RECEIVABLE_STATUSES] } },
+    ],
+  };
+  const effectivePresetWhere: Prisma.PurchaseOrderWhereInput =
+    !canManagePurchasing && presetFilter === "por_recibir_hoy" ? receiverTodayWhere : presetWhere;
+  const where: Prisma.PurchaseOrderWhereInput = statusFilter ? { status: statusFilter } : effectivePresetWhere;
+  const dueTodayWhere = canManagePurchasing
+    ? buildPurchaseOrderPresetWhere("por_recibir_hoy")
+    : receiverTodayWhere;
 
   const [
     orders,
@@ -112,7 +125,7 @@ export default async function PurchaseOrdersPage({
         status: true,
         expectedDate: true,
         supplier: { select: { name: true, code: true, businessName: true } },
-        _count: { select: { lines: true, receipts: true } },
+        _count: { select: { receipts: true } },
         lines: { select: { qtyOrdered: true, qtyReceived: true } },
       },
     }),
@@ -124,7 +137,7 @@ export default async function PurchaseOrdersPage({
     prisma.purchaseOrder.count({ where: buildPurchaseOrderPresetWhere("parciales") }),
     prisma.purchaseOrder.count({ where: buildPurchaseOrderPresetWhere("recibidas") }),
     prisma.purchaseOrder.count({ where: buildPurchaseOrderPresetWhere("vencidas") }),
-    prisma.purchaseOrder.count({ where: buildPurchaseOrderPresetWhere("por_recibir_hoy") }),
+    prisma.purchaseOrder.count({ where: dueTodayWhere }),
   ]);
 
   const totalPages = Math.max(1, Math.ceil(filteredCount / PAGE_SIZE));

--- a/app/(shell)/purchasing/orders/page.tsx
+++ b/app/(shell)/purchasing/orders/page.tsx
@@ -13,6 +13,7 @@ import {
   getPurchaseOrderPresetLabel,
   isPurchaseOrderPresetFilter,
 } from "@/lib/purchasing/purchase-order-presets";
+import { getPurchaseOrderOperationalState } from "@/lib/purchasing/purchase-order-operational";
 
 export const dynamic = "force-dynamic";
 const PAGE_SIZE = 50;
@@ -52,6 +53,13 @@ function formatDate(value: Date | string | null | undefined) {
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) return "—";
   return date.toLocaleDateString("es-MX");
+}
+
+function managerActionLabel(status: string, nextAction: string) {
+  if (status === "BORRADOR") return "Completar OC";
+  if (status === "RECIBIDA") return "Ver evidencia";
+  if (status === "CANCELADA") return "Ver historial";
+  return nextAction;
 }
 
 export default async function PurchaseOrdersPage({
@@ -95,7 +103,7 @@ export default async function PurchaseOrdersPage({
   ] = await Promise.all([
     prisma.purchaseOrder.findMany({
       where,
-      orderBy: { createdAt: "desc" },
+      orderBy: [{ expectedDate: "asc" }, { createdAt: "desc" }],
       skip: (currentPage - 1) * PAGE_SIZE,
       take: PAGE_SIZE,
       select: {
@@ -139,6 +147,7 @@ export default async function PurchaseOrdersPage({
           { key: "confirmadas", label: `Por enviar o recibir (${confirmedCount})` },
           { key: "en_transito", label: `${getPurchaseOrderPresetLabel("en_transito")} (${transitCount})` },
           { key: "recepcion_parcial", label: `${getPurchaseOrderPresetLabel("recepcion_parcial")} (${partialCount})` },
+          { key: "por_recibir_hoy", label: `${getPurchaseOrderPresetLabel("por_recibir_hoy")} (${dueTodayCount})` },
           { key: "vencidas", label: `${getPurchaseOrderPresetLabel("vencidas")} (${overdueCount})` },
           { key: "recibidas", label: `Cerradas (${receivedCount})` },
         ]
@@ -157,7 +166,7 @@ export default async function PurchaseOrdersPage({
         title={canManagePurchasing ? "Órdenes de compra" : "Trabajo de recepción"}
         description={
           canManagePurchasing
-            ? "Revisa las órdenes que requieren una decisión y continúa con su siguiente acción."
+            ? "Revisa riesgo, avance y siguiente acción sin abrir cada orden individualmente."
             : "Selecciona la mercancía que vas a recibir o continúa una recepción parcial."
         }
         meta={`${filteredCount} ${filteredCount === 1 ? "orden" : "órdenes"}`}
@@ -252,9 +261,7 @@ export default async function PurchaseOrdersPage({
         >
           <div className="grid gap-3 md:hidden">
             {orders.map((order) => {
-              const totalOrdered = order.lines.reduce((sum, line) => sum + line.qtyOrdered, 0);
-              const totalReceived = order.lines.reduce((sum, line) => sum + line.qtyReceived, 0);
-              const pct = totalOrdered > 0 ? Math.round((totalReceived / totalOrdered) * 100) : 0;
+              const operational = getPurchaseOrderOperationalState(order);
 
               return (
                 <article
@@ -290,23 +297,27 @@ export default async function PurchaseOrdersPage({
                       <p className="text-[var(--text-secondary)]">{formatDate(order.expectedDate)}</p>
                     </div>
                     <div>
-                      <p className="text-xs text-[var(--text-muted)]">Líneas</p>
-                      <p className="font-semibold text-[var(--text-primary)]">{order._count.lines}</p>
+                      <p className="text-xs text-[var(--text-muted)]">% recibido</p>
+                      <p className="font-semibold text-[var(--status-info)]">{operational.receivedPercent}%</p>
                     </div>
                     <div>
-                      <p className="text-xs text-[var(--text-muted)]">% recibido</p>
-                      <p className="font-semibold text-[var(--status-info)]">{pct}%</p>
+                      <p className="text-xs text-[var(--text-muted)]">Riesgo</p>
+                      <Badge variant={operational.riskTone} size="sm">{operational.riskLabel}</Badge>
                     </div>
                     <div>
                       <p className="text-xs text-[var(--text-muted)]">Recepciones</p>
                       <p className="font-semibold text-[var(--text-primary)]">{order._count.receipts}</p>
+                    </div>
+                    <div className="col-span-2">
+                      <p className="text-xs text-[var(--text-muted)]">Siguiente acción</p>
+                      <p className="font-semibold text-[var(--text-primary)]">{operational.nextAction}</p>
                     </div>
                   </div>
 
                   <div className="mt-4 space-y-2">
                     {canManagePurchasing ? (
                       <Link href={`/purchasing/orders/${order.id}`} className={buttonStyles({ size: "sm", fullWidth: true })}>
-                        Abrir orden
+                        {managerActionLabel(order.status, operational.nextAction)}
                       </Link>
                     ) : null}
                     {!canManagePurchasing && canReceivePurchasing && canReceivePurchaseOrder(order.status) ? (
@@ -325,23 +336,22 @@ export default async function PurchaseOrdersPage({
 
           <div className="hidden md:block">
             <TableWrap dense striped label="Listado de órdenes de compra" className="rounded-none border-0 shadow-none">
-              <Table className="min-w-[760px]">
+              <Table className="min-w-[980px]">
                 <thead>
                   <tr>
                     <Th>Folio</Th>
                     <Th>Proveedor</Th>
                     <Th>Estado</Th>
                     <Th>Fecha esperada</Th>
-                    <Th className="text-right">Líneas</Th>
                     <Th className="text-right">% recibido</Th>
+                    <Th>Riesgo</Th>
+                    <Th>Siguiente acción</Th>
                     <Th className="text-right">Acción</Th>
                   </tr>
                 </thead>
                 <tbody>
                   {orders.map((order) => {
-                    const totalOrdered = order.lines.reduce((sum, line) => sum + line.qtyOrdered, 0);
-                    const totalReceived = order.lines.reduce((sum, line) => sum + line.qtyReceived, 0);
-                    const pct = totalOrdered > 0 ? Math.round((totalReceived / totalOrdered) * 100) : 0;
+                    const operational = getPurchaseOrderOperationalState(order);
 
                     return (
                       <TableRow key={order.id}>
@@ -364,13 +374,14 @@ export default async function PurchaseOrdersPage({
                           </Badge>
                         </Td>
                         <Td className="text-sm text-[var(--text-secondary)]">{formatDate(order.expectedDate)}</Td>
-                        <Td className="text-right font-semibold text-[var(--text-primary)]">{order._count.lines}</Td>
-                        <Td className="text-right font-semibold text-[var(--status-info)]">{pct}%</Td>
+                        <Td className="text-right font-semibold text-[var(--status-info)]">{operational.receivedPercent}%</Td>
+                        <Td><Badge variant={operational.riskTone} size="sm">{operational.riskLabel}</Badge></Td>
+                        <Td className="text-sm text-[var(--text-secondary)]">{operational.nextAction}</Td>
                         <Td className="text-right">
                           <div className="flex justify-end gap-2">
                             {canManagePurchasing ? (
                               <Link href={`/purchasing/orders/${order.id}`} className={buttonStyles({ size: "sm" })}>
-                                Abrir orden
+                                {managerActionLabel(order.status, operational.nextAction)}
                               </Link>
                             ) : null}
                             {!canManagePurchasing && canReceivePurchasing && canReceivePurchaseOrder(order.status) ? (

--- a/app/(shell)/purchasing/page.tsx
+++ b/app/(shell)/purchasing/page.tsx
@@ -11,6 +11,11 @@ import { PageHeader } from "@/components/ui/page-header";
 import { SectionCard } from "@/components/ui/section-card";
 import { StatCard } from "@/components/ui/stat-card";
 import { Table, TableRow, TableWrap, Td, Th } from "@/components/ui/table";
+import { buildPurchaseOrderPresetWhere } from "@/lib/purchasing/purchase-order-presets";
+import {
+  comparePurchaseOrderOperationalPriority,
+  getPurchaseOrderOperationalState,
+} from "@/lib/purchasing/purchase-order-operational";
 
 export const revalidate = 30;
 
@@ -23,7 +28,7 @@ const STATUS_LABELS: Record<string, string> = {
   CANCELADA: "Cancelada",
 };
 
-const STATUS_COLORS: Record<string, string> = {
+const STATUS_COLORS: Record<string, "neutral" | "accent" | "success" | "warning" | "danger"> = {
   BORRADOR: "neutral",
   CONFIRMADA: "accent",
   EN_TRANSITO: "warning",
@@ -31,6 +36,16 @@ const STATUS_COLORS: Record<string, string> = {
   PARCIAL: "warning",
   CANCELADA: "danger",
 };
+
+function formatDate(value: Date | string | null | undefined) {
+  if (!value) return "Sin fecha";
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? "Sin fecha" : date.toLocaleDateString("es-MX");
+}
+
+function canReceivePurchaseOrder(status: string) {
+  return status === "CONFIRMADA" || status === "EN_TRANSITO" || status === "PARCIAL";
+}
 
 export default async function PurchasingPage() {
   await pageGuard("purchasing.view");
@@ -41,32 +56,48 @@ export default async function PurchasingPage() {
     !sessionCtx.isSystemAdmin;
   const canManagePurchasing =
     sessionCtx.isSystemAdmin || sessionCtx.permissions.includes("purchasing.manage");
-  const recentOrdersWhere: Prisma.PurchaseOrderWhereInput = isOperatorView
+  const canReceivePurchasing =
+    sessionCtx.isSystemAdmin || sessionCtx.permissions.includes("purchasing.receive");
+
+  const priorityOrdersWhere: Prisma.PurchaseOrderWhereInput = isOperatorView
     ? { status: { in: ["CONFIRMADA", "EN_TRANSITO", "PARCIAL"] } }
-    : {};
+    : { status: { in: ["BORRADOR", "CONFIRMADA", "EN_TRANSITO", "PARCIAL"] } };
+
   const [
     totalSuppliers,
     statusCounts,
-    recentOrders,
+    candidateOrders,
+    overdueCount,
+    dueTodayCount,
   ] = await Promise.all([
     prisma.supplier.count({ where: { isActive: true } }),
     prisma.purchaseOrder.groupBy({ by: ["status"], _count: { _all: true } }),
     prisma.purchaseOrder.findMany({
-      where: recentOrdersWhere,
-      take: 8,
-      orderBy: { createdAt: "desc" },
+      where: priorityOrdersWhere,
+      take: 30,
+      orderBy: [{ expectedDate: "asc" }, { createdAt: "desc" }],
       select: {
         id: true,
         folio: true,
         status: true,
+        expectedDate: true,
         supplier: { select: { name: true } },
-        _count: { select: { lines: true } },
+        lines: { select: { qtyOrdered: true, qtyReceived: true } },
       },
     }),
+    prisma.purchaseOrder.count({ where: buildPurchaseOrderPresetWhere("vencidas") }),
+    prisma.purchaseOrder.count({ where: buildPurchaseOrderPresetWhere("por_recibir_hoy") }),
   ]);
 
   const countsByStatus = Object.fromEntries(statusCounts.map((s) => [s.status, s._count._all]));
-  const openCount = (countsByStatus["CONFIRMADA"] ?? 0) + (countsByStatus["EN_TRANSITO"] ?? 0) + (countsByStatus["PARCIAL"] ?? 0);
+  const openCount =
+    (countsByStatus["CONFIRMADA"] ?? 0) +
+    (countsByStatus["EN_TRANSITO"] ?? 0) +
+    (countsByStatus["PARCIAL"] ?? 0);
+  const partialCount = countsByStatus["PARCIAL"] ?? 0;
+  const priorityOrders = candidateOrders
+    .sort((left, right) => comparePurchaseOrderOperationalPriority(left, right))
+    .slice(0, 8);
 
   return (
     <div className="space-y-5">
@@ -75,7 +106,7 @@ export default async function PurchasingPage() {
         description={
           isOperatorView
             ? "Registra mercancía recibida y reporta diferencias físicas."
-            : "Gestiona proveedores, órdenes de compra y compromisos de abastecimiento."
+            : "Prioriza vencimientos, recepciones y compromisos de abastecimiento desde una sola cola operativa."
         }
         meta={`${openCount.toLocaleString("es-MX")} OCs activas`}
         actions={
@@ -92,7 +123,7 @@ export default async function PurchasingPage() {
         }
       />
 
-      <div className={`grid grid-cols-2 gap-4 ${isOperatorView ? "md:grid-cols-2" : "md:grid-cols-4"}`}>
+      <div className={`grid grid-cols-2 gap-4 ${isOperatorView ? "md:grid-cols-2" : "md:grid-cols-3 xl:grid-cols-6"}`}>
         <StatCard
           label={isOperatorView ? "Por recibir" : "OCs activas"}
           value={(isOperatorView
@@ -103,58 +134,91 @@ export default async function PurchasingPage() {
         />
         <StatCard
           label={isOperatorView ? "Recepción parcial" : "En tránsito"}
-          value={(isOperatorView
-            ? (countsByStatus["PARCIAL"] ?? 0)
-            : (countsByStatus["EN_TRANSITO"] ?? 0)).toLocaleString("es-MX")}
+          value={(isOperatorView ? partialCount : (countsByStatus["EN_TRANSITO"] ?? 0)).toLocaleString("es-MX")}
           tone="warning"
           icon={<InventoryIcon className="h-5 w-5" />}
         />
-        {!isOperatorView ? <StatCard
-          label="Borradores"
-          value={(countsByStatus["BORRADOR"] ?? 0).toLocaleString("es-MX")}
-          icon={<BoxIcon className="h-5 w-5" />}
-        /> : null}
-        {!isOperatorView ? <StatCard
-          label="Proveedores"
-          value={totalSuppliers.toLocaleString("es-MX")}
-          tone="success"
-          icon={<WarehouseIcon className="h-5 w-5" />}
-        /> : null}
+        {!isOperatorView ? (
+          <StatCard
+            label="Parciales"
+            value={partialCount.toLocaleString("es-MX")}
+            tone="warning"
+            icon={<InventoryIcon className="h-5 w-5" />}
+          />
+        ) : null}
+        {!isOperatorView ? (
+          <StatCard
+            label="Vencidas"
+            value={overdueCount.toLocaleString("es-MX")}
+            tone="warning"
+            icon={<BoxIcon className="h-5 w-5" />}
+          />
+        ) : null}
+        {!isOperatorView ? (
+          <StatCard
+            label="Por recibir hoy"
+            value={dueTodayCount.toLocaleString("es-MX")}
+            tone="accent"
+            icon={<PurchasingIcon className="h-5 w-5" />}
+          />
+        ) : null}
+        {!isOperatorView ? (
+          <StatCard
+            label="Proveedores"
+            value={totalSuppliers.toLocaleString("es-MX")}
+            tone="success"
+            icon={<WarehouseIcon className="h-5 w-5" />}
+          />
+        ) : null}
       </div>
 
       <SectionCard
-        title={isOperatorView ? "Recepción física" : "Decisiones de abastecimiento"}
+        title={isOperatorView ? "Recepción física" : "Alertas y accesos operativos"}
         description={
           isOperatorView
             ? "Abre una orden confirmada para recibir, ubicar material o reportar una diferencia."
-            : "Crea y confirma OCs, consulta proveedores y vigila compromisos de compra."
+            : "Entra directo a las excepciones que requieren decisión antes de revisar el historial completo."
         }
       >
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <Link href="/purchasing/orders" className="surface rounded-[var(--radius-lg)] p-4 transition-colors hover:border-[var(--border-strong)]">
-            <p className="text-sm font-semibold text-[var(--text-primary)]">{isOperatorView ? "Recepciones pendientes" : "Órdenes de compra"}</p>
-            <p className="mt-1 text-sm text-[var(--text-muted)]">{isOperatorView ? "Recibe materiales contra una OC y registra diferencias." : "Crear, confirmar, dar seguimiento y cerrar órdenes."}</p>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <Link href="/purchasing/orders?preset=vencidas" className="surface rounded-[var(--radius-lg)] p-4 transition-colors hover:border-[var(--border-strong)]">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">{isOperatorView ? "Recepciones pendientes" : `Vencidas (${overdueCount})`}</p>
+            <p className="mt-1 text-sm text-[var(--text-muted)]">{isOperatorView ? "Recibe materiales contra una OC y registra diferencias." : "Compromisos cuya fecha esperada ya venció y siguen abiertos."}</p>
           </Link>
+          <Link href="/purchasing/orders?preset=por_recibir_hoy" className="surface rounded-[var(--radius-lg)] p-4 transition-colors hover:border-[var(--border-strong)]">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">Por recibir hoy ({dueTodayCount})</p>
+            <p className="mt-1 text-sm text-[var(--text-muted)]">Recepciones que deben coordinarse durante la jornada actual.</p>
+          </Link>
+          {!isOperatorView ? (
+            <Link href="/purchasing/orders?preset=recepcion_parcial" className="surface rounded-[var(--radius-lg)] p-4 transition-colors hover:border-[var(--border-strong)]">
+              <p className="text-sm font-semibold text-[var(--text-primary)]">Recepciones parciales ({partialCount})</p>
+              <p className="mt-1 text-sm text-[var(--text-muted)]">Órdenes con material pendiente por completar.</p>
+            </Link>
+          ) : null}
           {!isOperatorView ? (
             <Link href="/purchasing/suppliers" className="surface rounded-[var(--radius-lg)] p-4 transition-colors hover:border-[var(--border-strong)]">
               <p className="text-sm font-semibold text-[var(--text-primary)]">Proveedores</p>
-              <p className="mt-1 text-sm text-[var(--text-muted)]">Gestiona proveedores, precios y tiempos de entrega.</p>
+              <p className="mt-1 text-sm text-[var(--text-muted)]">Consulta datos, precios y tiempos de entrega.</p>
             </Link>
           ) : null}
         </div>
       </SectionCard>
 
       <SectionCard
-        title={isOperatorView ? "Órdenes por recibir" : "Órdenes recientes"}
-        description={isOperatorView ? "Consulta solo las órdenes relevantes para recepción física." : "Últimas órdenes creadas en el módulo de compras."}
+        title={isOperatorView ? "Cola de recepción" : "Cola priorizada de compras"}
+        description={
+          isOperatorView
+            ? "Primero aparecen vencidas, parciales y recepciones comprometidas para hoy."
+            : "Ordenada por vencimiento, recepción parcial, compromiso de hoy y estado operativo."
+        }
         actions={
           <Link href="/purchasing/orders" className={buttonStyles({ variant: "ghost", size: "sm" })}>
             Ver todas
           </Link>
         }
       >
-        {recentOrders.length === 0 ? (
-          <EmptyState compact title="Sin órdenes recientes" description="Aún no hay órdenes de compra registradas." />
+        {priorityOrders.length === 0 ? (
+          <EmptyState compact title="Sin trabajo pendiente" description="No hay órdenes abiertas que requieran atención." />
         ) : (
           <TableWrap striped>
             <Table>
@@ -163,28 +227,43 @@ export default async function PurchasingPage() {
                   <Th>Folio</Th>
                   <Th>Proveedor</Th>
                   <Th>Estado</Th>
-                  <Th className="text-right">Líneas</Th>
-                  <Th className="text-right">Accion</Th>
+                  <Th>Fecha esperada</Th>
+                  <Th className="text-right">Recibido</Th>
+                  <Th>Riesgo</Th>
+                  <Th>Siguiente acción</Th>
+                  <Th className="text-right">Acción</Th>
                 </tr>
               </thead>
               <tbody>
-                {recentOrders.map((order) => (
-                  <TableRow key={order.id}>
-                    <Td className="font-mono text-xs text-[var(--text-primary)]">{order.folio}</Td>
-                    <Td>{order.supplier.name}</Td>
-                    <Td>
-                      <Badge variant={(STATUS_COLORS[order.status] as "neutral" | "accent" | "success" | "warning" | "danger") ?? "neutral"}>
-                        {STATUS_LABELS[order.status] ?? order.status}
-                      </Badge>
-                    </Td>
-                    <Td className="text-right font-semibold text-[var(--text-primary)]">{order._count.lines}</Td>
-                    <Td className="text-right">
-                      <Link href={`/purchasing/orders/${order.id}`} className={buttonStyles({ variant: "ghost", size: "sm" })}>
-                        Ver detalle
-                      </Link>
-                    </Td>
-                  </TableRow>
-                ))}
+                {priorityOrders.map((order) => {
+                  const operational = getPurchaseOrderOperationalState(order);
+                  const receiveNow = canReceivePurchasing && canReceivePurchaseOrder(order.status);
+                  return (
+                    <TableRow key={order.id}>
+                      <Td className="font-mono text-xs text-[var(--text-primary)]">{order.folio}</Td>
+                      <Td>{order.supplier.name}</Td>
+                      <Td>
+                        <Badge variant={STATUS_COLORS[order.status] ?? "neutral"}>
+                          {STATUS_LABELS[order.status] ?? order.status}
+                        </Badge>
+                      </Td>
+                      <Td>{formatDate(order.expectedDate)}</Td>
+                      <Td className="text-right font-semibold text-[var(--text-primary)]">{operational.receivedPercent}%</Td>
+                      <Td>
+                        <Badge variant={operational.riskTone}>{operational.riskLabel}</Badge>
+                      </Td>
+                      <Td className="text-[var(--text-secondary)]">{operational.nextAction}</Td>
+                      <Td className="text-right">
+                        <Link
+                          href={receiveNow ? `/purchasing/orders/${order.id}/receive` : `/purchasing/orders/${order.id}`}
+                          className={buttonStyles({ variant: receiveNow ? "primary" : "ghost", size: "sm" })}
+                        >
+                          {receiveNow ? "Recibir" : order.status === "BORRADOR" ? "Completar OC" : "Abrir orden"}
+                        </Link>
+                      </Td>
+                    </TableRow>
+                  );
+                })}
               </tbody>
             </Table>
           </TableWrap>

--- a/app/(shell)/purchasing/page.tsx
+++ b/app/(shell)/purchasing/page.tsx
@@ -37,6 +37,8 @@ const STATUS_COLORS: Record<string, "neutral" | "accent" | "success" | "warning"
   CANCELADA: "danger",
 };
 
+const RECEIVABLE_STATUSES = ["CONFIRMADA", "EN_TRANSITO", "PARCIAL"] as const;
+
 function formatDate(value: Date | string | null | undefined) {
   if (!value) return "Sin fecha";
   const date = value instanceof Date ? value : new Date(value);
@@ -44,7 +46,7 @@ function formatDate(value: Date | string | null | undefined) {
 }
 
 function canReceivePurchaseOrder(status: string) {
-  return status === "CONFIRMADA" || status === "EN_TRANSITO" || status === "PARCIAL";
+  return RECEIVABLE_STATUSES.includes(status as (typeof RECEIVABLE_STATUSES)[number]);
 }
 
 export default async function PurchasingPage() {
@@ -60,8 +62,16 @@ export default async function PurchasingPage() {
     sessionCtx.isSystemAdmin || sessionCtx.permissions.includes("purchasing.receive");
 
   const priorityOrdersWhere: Prisma.PurchaseOrderWhereInput = isOperatorView
-    ? { status: { in: ["CONFIRMADA", "EN_TRANSITO", "PARCIAL"] } }
-    : { status: { in: ["BORRADOR", "CONFIRMADA", "EN_TRANSITO", "PARCIAL"] } };
+    ? { status: { in: [...RECEIVABLE_STATUSES] } }
+    : { status: { in: ["BORRADOR", ...RECEIVABLE_STATUSES] } };
+  const dueTodayWhere: Prisma.PurchaseOrderWhereInput = isOperatorView
+    ? {
+        AND: [
+          buildPurchaseOrderPresetWhere("por_recibir_hoy"),
+          { status: { in: [...RECEIVABLE_STATUSES] } },
+        ],
+      }
+    : buildPurchaseOrderPresetWhere("por_recibir_hoy");
 
   const [
     totalSuppliers,
@@ -74,7 +84,6 @@ export default async function PurchasingPage() {
     prisma.purchaseOrder.groupBy({ by: ["status"], _count: { _all: true } }),
     prisma.purchaseOrder.findMany({
       where: priorityOrdersWhere,
-      take: 30,
       orderBy: [{ expectedDate: "asc" }, { createdAt: "desc" }],
       select: {
         id: true,
@@ -86,7 +95,7 @@ export default async function PurchasingPage() {
       },
     }),
     prisma.purchaseOrder.count({ where: buildPurchaseOrderPresetWhere("vencidas") }),
-    prisma.purchaseOrder.count({ where: buildPurchaseOrderPresetWhere("por_recibir_hoy") }),
+    prisma.purchaseOrder.count({ where: dueTodayWhere }),
   ]);
 
   const countsByStatus = Object.fromEntries(statusCounts.map((s) => [s.status, s._count._all]));

--- a/app/(shell)/purchasing/page.tsx
+++ b/app/(shell)/purchasing/page.tsx
@@ -181,7 +181,7 @@ export default async function PurchasingPage() {
         }
       >
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
-          <Link href="/purchasing/orders?preset=vencidas" className="surface rounded-[var(--radius-lg)] p-4 transition-colors hover:border-[var(--border-strong)]">
+          <Link href={isOperatorView ? "/purchasing/orders?preset=por_recibir" : "/purchasing/orders?preset=vencidas"} className="surface rounded-[var(--radius-lg)] p-4 transition-colors hover:border-[var(--border-strong)]">
             <p className="text-sm font-semibold text-[var(--text-primary)]">{isOperatorView ? "Recepciones pendientes" : `Vencidas (${overdueCount})`}</p>
             <p className="mt-1 text-sm text-[var(--text-muted)]">{isOperatorView ? "Recibe materiales contra una OC y registra diferencias." : "Compromisos cuya fecha esperada ya venció y siguen abiertos."}</p>
           </Link>

--- a/lib/purchasing/purchase-order-operational.ts
+++ b/lib/purchasing/purchase-order-operational.ts
@@ -43,6 +43,7 @@ export function getPurchaseOrderOperationalState(
   const isOpen = OPEN_STATUSES.has(order.status);
   const isOverdue = Boolean(isOpen && expectedDate && expectedDate < start);
   const isDueToday = Boolean(isOpen && expectedDate && expectedDate >= start && expectedDate < end);
+  const hasNoLines = isOpen && (order.lines?.length ?? 0) === 0;
 
   if (order.status === "RECIBIDA") {
     return {
@@ -65,6 +66,18 @@ export function getPurchaseOrderOperationalState(
       priority: 100,
       isOverdue: false,
       isDueToday: false,
+    };
+  }
+
+  if (hasNoLines) {
+    return {
+      receivedPercent,
+      riskLabel: "Sin líneas",
+      riskTone: "danger",
+      nextAction: "Corregir líneas de OC",
+      priority: 1,
+      isOverdue,
+      isDueToday,
     };
   }
 

--- a/lib/purchasing/purchase-order-operational.ts
+++ b/lib/purchasing/purchase-order-operational.ts
@@ -1,0 +1,164 @@
+import { getMexicoCityDayBounds } from "@/lib/purchasing/purchase-order-presets";
+
+export type PurchaseOrderOperationalTone = "neutral" | "accent" | "success" | "warning" | "danger";
+
+export type PurchaseOrderOperationalInput = {
+  status: string;
+  expectedDate: Date | string | null | undefined;
+  lines?: Array<{ qtyOrdered: number; qtyReceived: number }>;
+};
+
+export type PurchaseOrderOperationalState = {
+  receivedPercent: number;
+  riskLabel: string;
+  riskTone: PurchaseOrderOperationalTone;
+  nextAction: string;
+  priority: number;
+  isOverdue: boolean;
+  isDueToday: boolean;
+};
+
+const OPEN_STATUSES = new Set(["BORRADOR", "CONFIRMADA", "EN_TRANSITO", "PARCIAL"]);
+
+function toDate(value: Date | string | null | undefined) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function getPurchaseOrderReceivedPercent(lines: PurchaseOrderOperationalInput["lines"] = []) {
+  const totalOrdered = lines.reduce((sum, line) => sum + line.qtyOrdered, 0);
+  const totalReceived = lines.reduce((sum, line) => sum + line.qtyReceived, 0);
+  if (totalOrdered <= 0) return 0;
+  return Math.max(0, Math.min(100, Math.round((totalReceived / totalOrdered) * 100)));
+}
+
+export function getPurchaseOrderOperationalState(
+  order: PurchaseOrderOperationalInput,
+  now = new Date(),
+): PurchaseOrderOperationalState {
+  const receivedPercent = getPurchaseOrderReceivedPercent(order.lines);
+  const expectedDate = toDate(order.expectedDate);
+  const { start, end } = getMexicoCityDayBounds(now);
+  const isOpen = OPEN_STATUSES.has(order.status);
+  const isOverdue = Boolean(isOpen && expectedDate && expectedDate < start);
+  const isDueToday = Boolean(isOpen && expectedDate && expectedDate >= start && expectedDate < end);
+
+  if (order.status === "RECIBIDA") {
+    return {
+      receivedPercent,
+      riskLabel: "Cerrada",
+      riskTone: "success",
+      nextAction: "Consultar evidencia",
+      priority: 90,
+      isOverdue: false,
+      isDueToday: false,
+    };
+  }
+
+  if (order.status === "CANCELADA") {
+    return {
+      receivedPercent,
+      riskLabel: "Cancelada",
+      riskTone: "neutral",
+      nextAction: "Consultar historial",
+      priority: 100,
+      isOverdue: false,
+      isDueToday: false,
+    };
+  }
+
+  if (isOverdue) {
+    return {
+      receivedPercent,
+      riskLabel: "Vencida",
+      riskTone: "danger",
+      nextAction: order.status === "PARCIAL" ? "Completar recepción vencida" : "Atender vencimiento",
+      priority: 0,
+      isOverdue,
+      isDueToday,
+    };
+  }
+
+  if (order.status === "PARCIAL") {
+    return {
+      receivedPercent,
+      riskLabel: "Recepción parcial",
+      riskTone: "warning",
+      nextAction: isDueToday ? "Completar recepción hoy" : "Completar recepción",
+      priority: isDueToday ? 5 : 10,
+      isOverdue,
+      isDueToday,
+    };
+  }
+
+  if (isDueToday) {
+    return {
+      receivedPercent,
+      riskLabel: "Recibir hoy",
+      riskTone: "warning",
+      nextAction: "Coordinar recepción hoy",
+      priority: 15,
+      isOverdue,
+      isDueToday,
+    };
+  }
+
+  if (order.status === "EN_TRANSITO") {
+    return {
+      receivedPercent,
+      riskLabel: "En tránsito",
+      riskTone: "accent",
+      nextAction: "Dar seguimiento y recibir",
+      priority: 20,
+      isOverdue,
+      isDueToday,
+    };
+  }
+
+  if (order.status === "CONFIRMADA") {
+    return {
+      receivedPercent,
+      riskLabel: expectedDate ? "Programada" : "Sin fecha esperada",
+      riskTone: expectedDate ? "accent" : "warning",
+      nextAction: expectedDate ? "Coordinar envío o recepción" : "Definir fecha esperada",
+      priority: expectedDate ? 30 : 25,
+      isOverdue,
+      isDueToday,
+    };
+  }
+
+  if (order.status === "BORRADOR") {
+    return {
+      receivedPercent,
+      riskLabel: "Por completar",
+      riskTone: "neutral",
+      nextAction: "Completar y confirmar OC",
+      priority: 40,
+      isOverdue,
+      isDueToday,
+    };
+  }
+
+  return {
+    receivedPercent,
+    riskLabel: "Revisar",
+    riskTone: "neutral",
+    nextAction: "Revisar orden",
+    priority: 50,
+    isOverdue,
+    isDueToday,
+  };
+}
+
+export function comparePurchaseOrderOperationalPriority<
+  T extends PurchaseOrderOperationalInput,
+>(left: T, right: T, now = new Date()) {
+  const leftState = getPurchaseOrderOperationalState(left, now);
+  const rightState = getPurchaseOrderOperationalState(right, now);
+  if (leftState.priority !== rightState.priority) return leftState.priority - rightState.priority;
+
+  const leftDate = toDate(left.expectedDate)?.getTime() ?? Number.POSITIVE_INFINITY;
+  const rightDate = toDate(right.expectedDate)?.getTime() ?? Number.POSITIVE_INFINITY;
+  return leftDate - rightDate;
+}

--- a/lib/purchasing/purchase-order-operational.ts
+++ b/lib/purchasing/purchase-order-operational.ts
@@ -1,4 +1,4 @@
-import { getMexicoCityDayBounds } from "@/lib/purchasing/purchase-order-presets";
+import { getMexicoCityPurchaseDateBounds } from "@/lib/purchasing/purchase-order-presets";
 
 export type PurchaseOrderOperationalTone = "neutral" | "accent" | "success" | "warning" | "danger";
 
@@ -39,7 +39,7 @@ export function getPurchaseOrderOperationalState(
 ): PurchaseOrderOperationalState {
   const receivedPercent = getPurchaseOrderReceivedPercent(order.lines);
   const expectedDate = toDate(order.expectedDate);
-  const { start, end } = getMexicoCityDayBounds(now);
+  const { start, end } = getMexicoCityPurchaseDateBounds(now);
   const isOpen = OPEN_STATUSES.has(order.status);
   const isOverdue = Boolean(isOpen && expectedDate && expectedDate < start);
   const isDueToday = Boolean(isOpen && expectedDate && expectedDate >= start && expectedDate < end);
@@ -69,18 +69,6 @@ export function getPurchaseOrderOperationalState(
     };
   }
 
-  if (hasNoLines) {
-    return {
-      receivedPercent,
-      riskLabel: "Sin líneas",
-      riskTone: "danger",
-      nextAction: "Corregir líneas de OC",
-      priority: 1,
-      isOverdue,
-      isDueToday,
-    };
-  }
-
   if (isOverdue) {
     return {
       receivedPercent,
@@ -88,6 +76,18 @@ export function getPurchaseOrderOperationalState(
       riskTone: "danger",
       nextAction: order.status === "PARCIAL" ? "Completar recepción vencida" : "Atender vencimiento",
       priority: 0,
+      isOverdue,
+      isDueToday,
+    };
+  }
+
+  if (hasNoLines) {
+    return {
+      receivedPercent,
+      riskLabel: "Sin líneas",
+      riskTone: "danger",
+      nextAction: "Corregir líneas de OC",
+      priority: 1,
       isOverdue,
       isDueToday,
     };

--- a/lib/purchasing/purchase-order-presets.ts
+++ b/lib/purchasing/purchase-order-presets.ts
@@ -46,6 +46,21 @@ export function getMexicoCityDayBounds(date = new Date()) {
   return { start, end };
 }
 
+/**
+ * Purchase-order expected dates come from HTML `type="date"` inputs and are
+ * stored as UTC-midnight values (for example 2026-08-15T00:00:00Z). They
+ * represent a business calendar date, not an instant in Mexico City.
+ *
+ * These bounds map the current Mexico City calendar date to the matching
+ * UTC-midnight storage interval so "today"/"overdue" do not shift one day.
+ */
+export function getMexicoCityPurchaseDateBounds(date = new Date()) {
+  const { year, month, day } = getMexicoCityDateParts(date);
+  const start = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  const end = new Date(Date.UTC(year, month - 1, day + 1, 0, 0, 0));
+  return { start, end };
+}
+
 export function isPurchaseOrderPresetFilter(value: unknown): value is PurchaseOrderPresetFilter {
   return typeof value === "string" && PURCHASE_ORDER_PRESET_FILTERS.includes(value as PurchaseOrderPresetFilter);
 }
@@ -94,7 +109,7 @@ export function buildPurchaseOrderPresetWhere(
     case "recibidas":
       return { status: "RECIBIDA" };
     case "vencidas": {
-      const { start } = getMexicoCityDayBounds();
+      const { start } = getMexicoCityPurchaseDateBounds();
       return {
         status: { in: [...OPEN_STATUSES] },
         expectedDate: { lt: start },
@@ -105,7 +120,7 @@ export function buildPurchaseOrderPresetWhere(
     case "recepcion_parcial":
       return { status: "PARCIAL" };
     case "por_recibir_hoy": {
-      const { start, end } = getMexicoCityDayBounds();
+      const { start, end } = getMexicoCityPurchaseDateBounds();
       return {
         status: { in: [...OPEN_STATUSES] },
         expectedDate: { gte: start, lt: end },
@@ -124,7 +139,7 @@ export function matchesPurchaseOrderPreset(
 
   const status = order.status;
   const expectedDate = order.expectedDate ? new Date(order.expectedDate) : null;
-  const { start, end } = getMexicoCityDayBounds();
+  const { start, end } = getMexicoCityPurchaseDateBounds();
 
   switch (filter) {
     case "borrador":

--- a/tests/purchasing/purchase-order-operational.unit.test.ts
+++ b/tests/purchasing/purchase-order-operational.unit.test.ts
@@ -43,6 +43,15 @@ describe("purchase order operational state", () => {
     expect(overdue.priority).toBeLessThan(scheduled.priority);
   });
 
+  it("surfaces an open order without lines as a blocking data risk", () => {
+    const state = getPurchaseOrderOperationalState(order({ lines: [] }), NOW);
+
+    expect(state.riskLabel).toBe("Sin líneas");
+    expect(state.riskTone).toBe("danger");
+    expect(state.nextAction).toBe("Corregir líneas de OC");
+    expect(state.priority).toBe(1);
+  });
+
   it("makes partial and due-today work explicit", () => {
     const partial = getPurchaseOrderOperationalState(order({
       status: "PARCIAL",

--- a/tests/purchasing/purchase-order-operational.unit.test.ts
+++ b/tests/purchasing/purchase-order-operational.unit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  comparePurchaseOrderOperationalPriority,
+  getPurchaseOrderOperationalState,
+  getPurchaseOrderReceivedPercent,
+} from "@/lib/purchasing/purchase-order-operational";
+
+const NOW = new Date("2026-08-15T18:00:00.000Z");
+
+function order(overrides: Partial<{
+  status: string;
+  expectedDate: Date | string | null;
+  lines: Array<{ qtyOrdered: number; qtyReceived: number }>;
+}> = {}) {
+  return {
+    status: "CONFIRMADA",
+    expectedDate: "2026-08-16T18:00:00.000Z",
+    lines: [{ qtyOrdered: 10, qtyReceived: 0 }],
+    ...overrides,
+  };
+}
+
+describe("purchase order operational state", () => {
+  it("calculates received progress without exceeding 100 percent", () => {
+    expect(getPurchaseOrderReceivedPercent([
+      { qtyOrdered: 10, qtyReceived: 4 },
+      { qtyOrdered: 5, qtyReceived: 5 },
+    ])).toBe(60);
+    expect(getPurchaseOrderReceivedPercent([{ qtyOrdered: 5, qtyReceived: 8 }])).toBe(100);
+    expect(getPurchaseOrderReceivedPercent([])).toBe(0);
+  });
+
+  it("raises overdue open orders above other work", () => {
+    const overdue = getPurchaseOrderOperationalState(order({
+      expectedDate: "2026-08-14T18:00:00.000Z",
+    }), NOW);
+    const scheduled = getPurchaseOrderOperationalState(order(), NOW);
+
+    expect(overdue.isOverdue).toBe(true);
+    expect(overdue.riskLabel).toBe("Vencida");
+    expect(overdue.riskTone).toBe("danger");
+    expect(overdue.nextAction).toBe("Atender vencimiento");
+    expect(overdue.priority).toBeLessThan(scheduled.priority);
+  });
+
+  it("makes partial and due-today work explicit", () => {
+    const partial = getPurchaseOrderOperationalState(order({
+      status: "PARCIAL",
+      expectedDate: "2026-08-15T18:00:00.000Z",
+      lines: [{ qtyOrdered: 10, qtyReceived: 4 }],
+    }), NOW);
+
+    expect(partial.isDueToday).toBe(true);
+    expect(partial.receivedPercent).toBe(40);
+    expect(partial.riskLabel).toBe("Recepción parcial");
+    expect(partial.nextAction).toBe("Completar recepción hoy");
+  });
+
+  it("flags confirmed orders without an expected date for manager attention", () => {
+    const state = getPurchaseOrderOperationalState(order({ expectedDate: null }), NOW);
+
+    expect(state.riskLabel).toBe("Sin fecha esperada");
+    expect(state.riskTone).toBe("warning");
+    expect(state.nextAction).toBe("Definir fecha esperada");
+  });
+
+  it("sorts overdue, partial, due today and normal work in that order", () => {
+    const items = [
+      order({ status: "BORRADOR", expectedDate: null }),
+      order({ status: "CONFIRMADA", expectedDate: "2026-08-15T18:00:00.000Z" }),
+      order({ status: "PARCIAL", expectedDate: "2026-08-16T18:00:00.000Z" }),
+      order({ status: "EN_TRANSITO", expectedDate: "2026-08-14T18:00:00.000Z" }),
+    ].sort((left, right) => comparePurchaseOrderOperationalPriority(left, right, NOW));
+
+    expect(items.map((item) => item.status)).toEqual([
+      "EN_TRANSITO",
+      "PARCIAL",
+      "CONFIRMADA",
+      "BORRADOR",
+    ]);
+  });
+});


### PR DESCRIPTION
## Objetivo
Cerrar el delta funcional de KAN-86 y KAN-87 sin rehacer el flujo existente de Compras.

## KAN-86 — Procurement Command Center
- Agrega KPIs de parciales, vencidas y por recibir hoy.
- Sustituye la tabla de órdenes recientes por una cola operativa priorizada.
- Muestra fecha esperada, porcentaje recibido, riesgo y siguiente acción.
- Prioriza vencidas, parciales, compromisos de hoy, tránsito/confirmadas y borradores.
- Agrega accesos directos a vencidas, recepciones de hoy, parciales y proveedores.

## KAN-87 — Listado de OCs
- Agrega `Por recibir hoy` a las bandejas del Manager.
- Muestra riesgo y siguiente acción en tarjetas mobile y tabla desktop.
- Mantiene presets por query params, paginación y filtros existentes.
- Conserva el CTA físico de recepción para operador y vuelve contextual la acción del Manager.

## Homologación técnica
- Nueva capa compartida `lib/purchasing/purchase-order-operational.ts` para que dashboard y listado calculen avance/riesgo/siguiente acción con el mismo contrato.
- Reutiliza `getMexicoCityDayBounds` y presets existentes; no duplica la semántica de vencidas/hoy.
- No cambia estados de dominio, persistencia, recepción, inventario ni permisos.

## Pruebas
- Añade pruebas unitarias de porcentaje recibido, vencimiento, recepción parcial, fecha faltante y prioridad de trabajo.
- Requiere Quality Gate completo y Security Audit verde.
- El required AWS context de PR mantiene su semántica N/A; no se presentará como validación de despliegue real.