### PR TITLE
test: reconcile authenticated AWS E2E evidence

### DIFF
--- a/docs/reconciliation/aws-authenticated-e2e-evidence-2026-08-17.md
+++ b/docs/reconciliation/aws-authenticated-e2e-evidence-2026-08-17.md
@@ -1,0 +1,44 @@
+# Evidencia E2E autenticada AWS dev — 2026-08-17
+
+Entorno validado: `https://d2b1ltxtvypxr4.cloudfront.net` (AWS dev, no producción).
+
+Las credenciales usadas fueron las cuentas controladas del seed, configuradas en AWS dev y en GitHub Actions. No se documentan contraseñas, hashes ni URLs de base de datos.
+
+## Corridas browser
+
+| Corrida | Resultado | Evidencia |
+| --- | --- | --- |
+| RBAC por rol | 7/7 passed | SYSTEM_ADMIN, MANAGER, WAREHOUSE_OPERATOR y SALES_EXECUTIVE autenticaron y respetaron rutas/menú/permisos |
+| Continuidad directa, ensamble y mixta | 3/3 passed | Creación, confirmación, asignación, toma de tareas, escaneo, surtido, ensamble, preparación, entrega y descarga documental |
+| KAN-128 read-only | 1/1 passed | Promesa comercial y handoff preservado hacia la bandeja de almacén |
+| Sales commercial flow | 5/5 passed | Worklist, captura guiada, filtros, vista móvil y supervisión |
+
+Las capturas, videos y trazas quedan en los artefactos locales ignorados de Playwright (`test-results/`) y el reporte HTML en `playwright-report/aws-controlled/`.
+
+## Matriz V1–V8
+
+| Escenario | Estado | Evidencia actual | Pendiente para cierre total |
+| --- | --- | --- | --- |
+| V1 Promesa con reserva existente | Parcial verificado | Browser read-only KAN-128 + validación de servicio/persistencia | Browser write controlado que fuerce la revalidación de inventario y capture antes/después |
+| V2 Pedido directo | Verificado | E2E browser AWS; persistencia y documentos descargables | Aceptación operativa humana |
+| V3 Pedido sólo configurado | Verificado | E2E browser AWS; orden de producción, consumo y retorno al pedido | Aceptación operativa humana |
+| V4 Pedido mixto | Verificado | E2E browser AWS; directo y ensamble independientes hasta entrega | Aceptación operativa humana |
+| V5 Ownership físico | Parcial verificado | Pruebas PostgreSQL de asignación `MANAGER_REQUIRED` y bloqueo de toma | E2E browser con operador asignado y segundo operador bloqueado |
+| V6 Preparado para entrega | Verificado | E2E browser AWS; ubicación, notas, usuario físico y entrega | Aceptación operativa humana |
+| V7 Excepción/faltante | Parcial verificado | Pruebas PostgreSQL de faltante, rollback y bloqueo | E2E browser con intento bloqueado y resolución auditada |
+| V8 Idempotencia/concurrencia | Parcial verificado | Pruebas PostgreSQL de retry, doble entrega y sobre-entrega | E2E browser con dos sesiones y evidencia visual de resultado |
+
+## Estado de aceptación
+
+La aceptación operativa humana no se infiere de una prueba automatizada. Deben confirmar explícitamente los responsables de:
+
+- Ventas: promesa, captura, seguimiento y entrega.
+- Almacén: toma, escaneo, surtido, faltante y preparación.
+- Manager: confirmación, asignación, supervisión y excepciones.
+- Administración: usuarios, auditoría, compras y control de accesos.
+
+Jira no debe cerrarse mientras V1, V5, V7, V8 y la aceptación por rol no cuenten con evidencia completa.
+
+## Higiene de datos
+
+Los 271 esquemas históricos `t_run_*` no fueron eliminados. Su limpieza sigue requiriendo autorización destructiva separada.

--- a/docs/reconciliation/aws-authenticated-e2e-evidence-2026-08-17.md
+++ b/docs/reconciliation/aws-authenticated-e2e-evidence-2026-08-17.md
@@ -12,6 +12,7 @@ Las credenciales usadas fueron las cuentas controladas del seed, configuradas en
 | Continuidad directa, ensamble y mixta | 3/3 passed | Creación, confirmación, asignación, toma de tareas, escaneo, surtido, ensamble, preparación, entrega y descarga documental |
 | KAN-128 read-only | 1/1 passed | Promesa comercial y handoff preservado hacia la bandeja de almacén |
 | Sales commercial flow | 5/5 passed | Worklist, captura guiada, filtros, vista móvil y supervisión |
+| Gates browser V1/V5/V7/V8 | 4/4 passed | Escritura/revalidación, ownership entre operadores, faltante con decisión de manager y claims concurrentes; screenshots, video y trace por escenario |
 
 Las capturas, videos y trazas quedan en los artefactos locales ignorados de Playwright (`test-results/`) y el reporte HTML en `playwright-report/aws-controlled/`.
 
@@ -19,14 +20,14 @@ Las capturas, videos y trazas quedan en los artefactos locales ignorados de Play
 
 | Escenario | Estado | Evidencia actual | Pendiente para cierre total |
 | --- | --- | --- | --- |
-| V1 Promesa con reserva existente | Parcial verificado | Browser read-only KAN-128 + validación de servicio/persistencia | Browser write controlado que fuerce la revalidación de inventario y capture antes/después |
+| V1 Promesa con reserva existente | Verificado en browser AWS dev | Browser write: reserva persistida (6), disponibilidad revalidada (4), propuesta stale bloqueada y auditoría `REVALIDATE_COMMERCIAL_PROMISE` |
 | V2 Pedido directo | Verificado | E2E browser AWS; persistencia y documentos descargables | Aceptación operativa humana |
 | V3 Pedido sólo configurado | Verificado | E2E browser AWS; orden de producción, consumo y retorno al pedido | Aceptación operativa humana |
 | V4 Pedido mixto | Verificado | E2E browser AWS; directo y ensamble independientes hasta entrega | Aceptación operativa humana |
-| V5 Ownership físico | Parcial verificado | Pruebas PostgreSQL de asignación `MANAGER_REQUIRED` y bloqueo de toma | E2E browser con operador asignado y segundo operador bloqueado |
+| V5 Ownership físico | Verificado en browser AWS dev | Manager activó `MANAGER_REQUIRED`; operador no asignado quedó bloqueado; operador asignado tomó la tarea y ownership persistió |
 | V6 Preparado para entrega | Verificado | E2E browser AWS; ubicación, notas, usuario físico y entrega | Aceptación operativa humana |
-| V7 Excepción/faltante | Parcial verificado | Pruebas PostgreSQL de faltante, rollback y bloqueo | E2E browser con intento bloqueado y resolución auditada |
-| V8 Idempotencia/concurrencia | Parcial verificado | Pruebas PostgreSQL de retry, doble entrega y sobre-entrega | E2E browser con dos sesiones y evidencia visual de resultado |
+| V7 Excepción/faltante | Verificado en browser AWS dev | Faltante escrito con razón controlada, preparación bloqueada, excepción visible y decisión `WAIT_REPLENISHMENT` persistida como `RESOLVED` |
+| V8 Idempotencia/concurrencia | Verificado en browser AWS dev | Dos sesiones reclamaron en paralelo; quedó un solo `claimedByUserId` y un único evento `CLAIM_WAREHOUSE_PICK_TASKS` |
 
 ## Estado de aceptación
 

--- a/tests/e2e/aws-v1-v5-v7-v8-browser.spec.ts
+++ b/tests/e2e/aws-v1-v5-v7-v8-browser.spec.ts
@@ -1,0 +1,279 @@
+import bcrypt from "bcryptjs";
+import { PrismaClient } from "@prisma/client";
+import { expect, test, type Page } from "@playwright/test";
+import { InventoryService } from "@/lib/inventory-service";
+import {
+  addSalesRequestProductLine,
+  confirmSalesRequestOrder,
+  createSalesRequestDraftHeader,
+  releaseSalesRequestPickList,
+} from "@/lib/sales/request-service";
+import { loginAs } from "./lib/auth.helpers";
+
+const prisma = new PrismaClient();
+const enabled = process.env.WMS_AWS_WRITE_E2E === "1";
+const secondaryPassword = process.env.WMS_E2E_SECONDARY_OPERATOR_PASSWORD ?? "Operator123*";
+const tag = `QA-GATES-${Date.now().toString().slice(-8)}`;
+
+const fixture = {
+  warehouseId: "",
+  storageLocationId: "",
+  stagingLocationId: "",
+  shippingLocationId: "",
+  productId: "",
+  customerId: "",
+  orderIds: [] as string[],
+  productSku: `${tag}-SKU`,
+  warehouseCode: `${tag}-WH`,
+  customerName: `Cliente gates ${tag}`,
+  secondaryOperatorId: "",
+};
+
+type GateOrder = { id: string; code: string; taskId: string; sourceLocationId: string; targetLocationId: string };
+
+async function loginWithCredentials(page: Page, email: string, password: string, callbackUrl: string) {
+  await page.context().clearCookies();
+  await page.goto(`/logout?e2eNonce=${Date.now()}`);
+  await page.context().clearCookies();
+  await page.goto(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}&e2eNonce=${Date.now()}`);
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Contrasena").fill(password);
+  await page.getByRole("button", { name: "Iniciar sesion" }).click();
+  await expect(page).toHaveURL(new RegExp(callbackUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+}
+
+async function createConfirmedDirectOrder(quantity = 2): Promise<GateOrder> {
+  const order = await createSalesRequestDraftHeader(prisma, {
+    customerName: fixture.customerName,
+    warehouseId: fixture.warehouseId,
+    dueDate: new Date("2026-12-31T00:00:00.000Z"),
+    notes: `AWS browser gate ${tag}`,
+  });
+  fixture.orderIds.push(order.id);
+  const line = await addSalesRequestProductLine(prisma, {
+    orderId: order.id,
+    productId: fixture.productId,
+    requestedQty: quantity,
+  });
+  await confirmSalesRequestOrder(prisma, { orderId: order.id });
+  await releaseSalesRequestPickList(prisma, order.id);
+  const task = await prisma.salesInternalOrderPickTask.findFirstOrThrow({
+    where: { orderLineId: line.id },
+    select: { id: true, sourceLocationId: true, targetLocationId: true },
+  });
+  return { id: order.id, code: order.code, taskId: task.id, sourceLocationId: task.sourceLocationId, targetLocationId: task.targetLocationId };
+}
+
+async function cleanupFixture() {
+  if (fixture.orderIds.length) {
+    await prisma.inventoryMovement.deleteMany({ where: { documentId: { in: fixture.orderIds } } });
+    await prisma.auditLog.deleteMany({ where: { entityId: { in: fixture.orderIds } } });
+    await prisma.salesInternalOrder.deleteMany({ where: { id: { in: fixture.orderIds } } });
+  }
+  if (fixture.productId) {
+    await prisma.inventory.deleteMany({ where: { productId: fixture.productId } });
+    await prisma.product.delete({ where: { id: fixture.productId } });
+  }
+  if (fixture.customerId) await prisma.customer.delete({ where: { id: fixture.customerId } });
+  if (fixture.warehouseId) {
+    await prisma.location.deleteMany({ where: { warehouseId: fixture.warehouseId } });
+    await prisma.warehouse.delete({ where: { id: fixture.warehouseId } });
+  }
+  if (fixture.secondaryOperatorId) await prisma.user.delete({ where: { id: fixture.secondaryOperatorId } });
+}
+
+test.describe.serial("AWS dev browser gates V1/V5/V7/V8", () => {
+  test.skip(
+    !enabled,
+    "Set WMS_AWS_WRITE_E2E=1 only for the explicitly authorized AWS dev write lane.",
+  );
+
+  test.beforeAll(async () => {
+    const warehouse = await prisma.warehouse.create({
+      data: { code: fixture.warehouseCode, name: `Almacén ${tag}`, isActive: true },
+    });
+    fixture.warehouseId = warehouse.id;
+    const [storage, staging, shipping] = await Promise.all([
+      prisma.location.create({ data: { code: `${tag}-STO`, name: "Storage gate", zone: "QA", usageType: "STORAGE", isActive: true, warehouseId: warehouse.id } }),
+      prisma.location.create({ data: { code: `${tag}-STG`, name: "Staging gate", zone: "QA", usageType: "STAGING", isActive: true, warehouseId: warehouse.id } }),
+      prisma.location.create({ data: { code: `${tag}-SHIP`, name: "Shipping gate", zone: "QA", usageType: "SHIPPING", isActive: true, warehouseId: warehouse.id } }),
+    ]);
+    fixture.storageLocationId = storage.id;
+    fixture.stagingLocationId = staging.id;
+    fixture.shippingLocationId = shipping.id;
+    const product = await prisma.product.create({
+      data: { sku: fixture.productSku, name: `Producto gate ${tag}`, type: "ACCESSORY" },
+    });
+    fixture.productId = product.id;
+    const customer = await prisma.customer.create({
+      data: { code: `${tag}-C`, name: fixture.customerName, isActive: true },
+    });
+    fixture.customerId = customer.id;
+    const inventoryService = new InventoryService(prisma);
+    await inventoryService.receiveStock(product.id, storage.id, 10, `RCV-${tag}`);
+
+    const role = await prisma.role.findUniqueOrThrow({ where: { code: "WAREHOUSE_OPERATOR" }, select: { id: true } });
+    const secondary = await prisma.user.create({
+      data: {
+        email: `${tag.toLowerCase()}-operator@scmayher.com`,
+        name: `Operador secundario ${tag}`,
+        passwordHash: await bcrypt.hash(secondaryPassword, 10),
+        isActive: true,
+        userRoles: { create: [{ roleId: role.id }] },
+      },
+      select: { id: true },
+    });
+    fixture.secondaryOperatorId = secondary.id;
+  });
+
+  test.afterAll(async () => {
+    await cleanupFixture();
+    await prisma.$disconnect();
+  });
+
+  test("V1 browser escribe una reserva y revalida disponibilidad actual", async ({ page }) => {
+    await loginAs(page, "SALES_EXECUTIVE", "/production/requests/new", "/production/requests/new");
+    const promise = new URLSearchParams({
+      productId: fixture.productId,
+      sku: fixture.productSku,
+      source: "availability",
+      promiseProductId: fixture.productId,
+      promiseSku: fixture.productSku,
+      promiseWarehouseId: fixture.warehouseId,
+      promiseWarehouseCode: fixture.warehouseCode,
+      promiseWarehouseName: `Almacén ${tag}`,
+      promiseRequestedQty: "6",
+      promiseAvailableQty: "10",
+      promiseCheckedAt: new Date().toISOString(),
+      promiseSource: "availability",
+      promiseIsSubstitute: "false",
+      quantity: "6",
+    });
+    await page.goto(`/production/requests/new?${promise.toString()}`);
+    await page.getByLabel("Selecciona o crea el cliente").fill(fixture.customerName);
+    await page.getByRole("button", { name: new RegExp(fixture.customerName) }).click();
+    await page.getByRole("button", { name: "Continuar a producto →" }).click();
+    await page.getByRole("button", { name: "Producto directo" }).click();
+    await page.getByTestId("new-order-direct-product-input").fill(fixture.productSku);
+    await page.getByRole("button", { name: new RegExp(fixture.productSku) }).click();
+    await page.getByLabel("Cantidad").fill("6");
+    await page.getByRole("button", { name: "Agregar producto al pedido" }).click();
+    await page.getByRole("button", { name: "Continuar a entrega →" }).click();
+    await page.getByLabel("Fecha compromiso").fill("2026-12-31");
+    await Promise.all([
+      page.waitForURL(/\/production\/requests\/[^/?]+\?ok=/),
+      page.getByTestId("create-order-button").click(),
+    ]);
+
+    const created = await prisma.salesInternalOrder.findFirstOrThrow({ where: { warehouseId: fixture.warehouseId, customerId: fixture.customerId }, orderBy: { createdAt: "desc" } });
+    fixture.orderIds.push(created.id);
+    const inventory = await prisma.inventory.findFirstOrThrow({ where: { productId: fixture.productId, locationId: fixture.storageLocationId } });
+    expect(inventory.reserved).toBe(6);
+    expect(inventory.available).toBe(4);
+
+    const stalePromise = new URLSearchParams({
+      productId: fixture.productId,
+      sku: fixture.productSku,
+      source: "availability",
+      promiseProductId: fixture.productId,
+      promiseSku: fixture.productSku,
+      promiseWarehouseId: fixture.warehouseId,
+      promiseWarehouseCode: fixture.warehouseCode,
+      promiseWarehouseName: `Almacén ${tag}`,
+      promiseRequestedQty: "5",
+      promiseAvailableQty: "10",
+      promiseCheckedAt: new Date().toISOString(),
+      promiseSource: "availability",
+      promiseIsSubstitute: "false",
+      quantity: "5",
+    });
+    await page.goto(`/production/requests/new?${stalePromise.toString()}`);
+    await expect(page.getByTestId("commercial-promise-status")).toHaveText("Disponibilidad insuficiente");
+    await expect(page.getByTestId("commercial-promise-available-qty")).toHaveText("4");
+    await expect(page.getByTestId("commercial-promise-reserved-qty")).toHaveText("6");
+    await expect(page.getByRole("button", { name: "Continuar a producto →" })).toBeDisabled();
+    await expect(prisma.auditLog.findFirst({ where: { entityId: created.id, action: "REVALIDATE_COMMERCIAL_PROMISE" } })).resolves.toBeTruthy();
+  });
+
+  test("V5 browser enforces ownership MANAGER_REQUIRED entre dos operadores", async ({ browser, page }) => {
+    const order = await createConfirmedDirectOrder();
+    await loginAs(page, "MANAGER", `/production/fulfillment/${order.id}`, `/production/fulfillment/${order.id}`);
+    await page.locator('input[name="reason"]').fill("Cliente prioritario gate");
+    await page.getByRole("button", { name: "Exigir asignación" }).click();
+    const assignmentForm = page.locator("form").filter({ hasText: "Asignación requerida" });
+    await expect(assignmentForm).toBeVisible();
+    await assignmentForm.locator('select[name="assigneeUserId"]').selectOption((await prisma.user.findUniqueOrThrow({ where: { email: "operator@scmayher.com" }, select: { id: true } })).id);
+    await assignmentForm.getByRole("button", { name: "Asignar tareas" }).click();
+
+    const secondaryContext = await browser.newContext();
+    const secondaryPage = await secondaryContext.newPage();
+    try {
+      await loginWithCredentials(secondaryPage, `${tag.toLowerCase()}-operator@scmayher.com`, secondaryPassword, `/production/fulfillment/${order.id}`);
+      await expect(secondaryPage.getByText("Asignada a operador")).toBeVisible();
+      await expect(secondaryPage.getByRole("button", { name: "Tomar tareas" })).toHaveCount(0);
+    } finally {
+      await secondaryContext.close();
+    }
+
+    await loginWithCredentials(page, "operator@scmayher.com", "Operator123*", `/production/fulfillment/${order.id}`);
+    await page.getByRole("button", { name: "Tomar tareas" }).click();
+    await expect(page.getByText("Tomada por ti")).toBeVisible();
+    const task = await prisma.salesInternalOrderPickTask.findFirstOrThrow({ where: { orderLine: { orderId: order.id } } });
+    expect(task.assignedToUserId).toBe((await prisma.user.findUniqueOrThrow({ where: { email: "operator@scmayher.com" }, select: { id: true } })).id);
+    expect(task.claimedByUserId).toBe(task.assignedToUserId);
+  });
+
+  test("V7 browser registra faltante, bloquea preparación y permite decisión auditada", async ({ page }) => {
+    const order = await createConfirmedDirectOrder();
+    await loginWithCredentials(page, "operator@scmayher.com", "Operator123*", `/production/fulfillment/${order.id}`);
+    await page.getByRole("button", { name: "Tomar tareas" }).click();
+    await expect(page.getByText("Tomada por ti")).toBeVisible();
+    await page.locator('input[name^="scanRef__"]').first().fill(fixture.productSku);
+    await page.locator('input[name^="pickedQty__"]').first().fill("0");
+    await page.locator('input[name^="shortReason__"]').first().fill("FALTANTE_BROWSER_GATE");
+    await Promise.all([
+      page.waitForURL((url) => url.pathname.endsWith(`/production/fulfillment/${order.id}`) && url.searchParams.get("ok")?.includes("Surtido confirmado") === true),
+      page.getByRole("button", { name: "Confirmar surtido" }).click(),
+    ]);
+    await expect(page.getByTestId("fulfillment-next-action")).toContainText("Confirma las cantidades");
+    await expect(prisma.salesInternalOrderPickTask.findFirst({ where: { id: order.taskId, status: "PARTIAL", shortQty: { gt: 0 } } })).resolves.toBeTruthy();
+    await page.goto(`/production/requests/${order.id}`);
+    await expect(page.getByTestId("operational-exceptions")).toContainText("FALTANTE_BROWSER_GATE");
+    await expect(page.getByTestId("prepare-for-delivery-form")).toHaveCount(0);
+
+    await loginWithCredentials(page, "manager@scmayher.com", "Manager123*", `/production/requests/${order.id}`);
+    const exceptions = page.getByTestId("operational-exceptions");
+    await expect(exceptions).toContainText("OPEN");
+    await exceptions.locator('select[name="resolution"]').selectOption("WAIT_REPLENISHMENT");
+    await exceptions.locator('input[name="notes"]').fill("Reposición autorizada por manager gate");
+    await exceptions.getByRole("button", { name: "Registrar decisión" }).click();
+    await expect(page.getByTestId("operational-exceptions")).toContainText("WAIT_REPLENISHMENT");
+    await expect(prisma.salesInternalOrderException.findFirst({ where: { orderId: order.id, status: "RESOLVED" } })).resolves.toBeTruthy();
+  });
+
+  test("V8 browser ejecuta dos claims concurrentes y conserva un solo ownership", async ({ browser }) => {
+    const order = await createConfirmedDirectOrder();
+    const primaryContext = await browser.newContext();
+    const secondaryContext = await browser.newContext();
+    const primaryPage = await primaryContext.newPage();
+    const secondaryPage = await secondaryContext.newPage();
+    try {
+      await Promise.all([
+        loginWithCredentials(primaryPage, "operator@scmayher.com", "Operator123*", `/production/fulfillment/${order.id}`),
+        loginWithCredentials(secondaryPage, `${tag.toLowerCase()}-operator@scmayher.com`, secondaryPassword, `/production/fulfillment/${order.id}`),
+      ]);
+      await Promise.all([
+        Promise.all([primaryPage.waitForURL(/\/production\/fulfillment\/[^?]+\?(?:ok|error)=/), primaryPage.getByRole("button", { name: "Tomar tareas" }).click()]),
+        Promise.all([secondaryPage.waitForURL(/\/production\/fulfillment\/[^?]+\?(?:ok|error)=/), secondaryPage.getByRole("button", { name: "Tomar tareas" }).click()]),
+      ]);
+      const task = await prisma.salesInternalOrderPickTask.findFirstOrThrow({ where: { orderLine: { orderId: order.id } } });
+      expect(task.claimedByUserId).toBeTruthy();
+      expect(await prisma.auditLog.count({ where: { entityId: order.id, action: "CLAIM_WAREHOUSE_PICK_TASKS" } })).toBe(1);
+      await expect(primaryPage.locator("body")).toContainText(/Tareas tomadas|fueron tomadas mientras confirmabas/);
+      await expect(secondaryPage.locator("body")).toContainText(/Tareas tomadas|fueron tomadas mientras confirmabas/);
+    } finally {
+      await primaryContext.close();
+      await secondaryContext.close();
+    }
+  });
+});

--- a/tests/e2e/lib/auth.helpers.ts
+++ b/tests/e2e/lib/auth.helpers.ts
@@ -80,7 +80,10 @@ export async function loginAs(
   // This avoids flaky first-request failures while webpack compiles auth routes.
   await page.request.get("/api/auth/session");
   await page.request.get("/api/auth/csrf");
-  await page.goto(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+  const cacheBuster = process.env.WMS_E2E_NO_CACHE === "1"
+    ? `&e2eNonce=${Date.now()}`
+    : "";
+  await page.goto(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}${cacheBuster}`);
   if (await page.getByLabel("Email").isVisible()) {
     await page.getByLabel("Email").fill(user.email);
     await page.getByLabel("Contrasena").fill(user.password);

--- a/tests/e2e/mixed-order-continuity.spec.ts
+++ b/tests/e2e/mixed-order-continuity.spec.ts
@@ -23,8 +23,13 @@ const fixture = {
 };
 
 async function loginFresh(page: Page, role: "MANAGER" | "SALES_EXECUTIVE" | "WAREHOUSE_OPERATOR", callbackUrl: string) {
-  await page.getByRole("link", { name: "Cerrar sesión" }).click();
-  await expect(page).toHaveURL(/\/login/);
+  // CloudFront may serve the logout redirect from cache while the auth
+  // session cookie remains in the browser context. Isolate each role switch
+  // explicitly so the browser evidence cannot be attributed to the previous
+  // actor.
+  await page.context().clearCookies();
+  await page.goto(`/logout?e2eNonce=${Date.now()}`);
+  await page.context().clearCookies();
   await loginAs(page, role, callbackUrl, callbackUrl);
 }
 
@@ -169,6 +174,8 @@ test.describe.serial("mixed sales order continuity", () => {
     await page.getByRole("link", { name: "Descargar lista de surtido" }).click();
     expect((await pickDownload).suggestedFilename()).toMatch(/^surtido-.*\.pdf$/);
     await page.getByRole("button", { name: "Liberar surtido directo" }).click();
+    await page.getByRole("button", { name: "Tomar tareas" }).click();
+    await page.locator('input[name^="scanRef__"]').first().fill(fixture.directSku);
     await page.getByRole("button", { name: "Confirmar surtido" }).click();
     await expect(page.getByTestId("fulfillment-next-action")).toContainText("Surtido directo terminado");
     await page.goto(`/production/requests/${directOrder.id}`);
@@ -182,7 +189,9 @@ test.describe.serial("mixed sales order continuity", () => {
     await expect(page.getByTestId("prepared-for-delivery-summary")).toContainText("Preparado para entrega");
 
     await loginFresh(page, "SALES_EXECUTIVE", `/production/requests/${directOrder.id}`);
-    await page.getByRole("button", { name: "Entregado al cliente" }).click();
+    await page.getByLabel("Recibió *").fill("Cliente QA directo");
+    await page.getByLabel("Método de entrega *").fill("Entrega directa");
+    await page.getByRole("button", { name: "Confirmar entrega al cliente" }).click();
     const deliveryDownload = page.waitForEvent("download");
     await page.getByRole("link", { name: "Descargar comprobante de entrega" }).click();
     expect((await deliveryDownload).suggestedFilename()).toMatch(/^entrega-.*\.pdf$/);
@@ -261,7 +270,9 @@ test.describe.serial("mixed sales order continuity", () => {
     await expect(page.getByTestId("prepared-for-delivery-summary")).toContainText("Preparado para entrega");
 
     await loginFresh(page, "SALES_EXECUTIVE", `/production/requests/${assemblyOrder.id}`);
-    await page.getByRole("button", { name: "Entregado al cliente" }).click();
+    await page.getByLabel("Recibió *").fill("Cliente QA ensamble");
+    await page.getByLabel("Método de entrega *").fill("Entrega directa");
+    await page.getByRole("button", { name: "Confirmar entrega al cliente" }).click();
     await expect(page.getByRole("link", { name: "Descargar comprobante de entrega" })).toBeVisible();
     const finalOrder = await prisma.salesInternalOrder.findUniqueOrThrow({
       where: { id: assemblyOrder.id },
@@ -319,6 +330,8 @@ test.describe.serial("mixed sales order continuity", () => {
 
     await loginFresh(page, "WAREHOUSE_OPERATOR", `/production/fulfillment/${order.id}`);
     await page.getByRole("button", { name: "Liberar surtido directo" }).click();
+    await page.getByRole("button", { name: "Tomar tareas" }).click();
+    await page.locator('input[name^="scanRef__"]').first().fill(fixture.directSku);
     await page.getByRole("button", { name: "Confirmar surtido" }).click();
     const continueAssembly = page.getByRole("link", { name: /Continuar ensamble/ });
     await expect(page.getByTestId("fulfillment-next-action")).toContainText("Continuar ensamble");
@@ -354,9 +367,11 @@ test.describe.serial("mixed sales order continuity", () => {
 
     await loginFresh(page, "SALES_EXECUTIVE", `/production/requests/${order.id}`);
     await expect(page.getByText("Preparado para entrega", { exact: true }).first()).toBeVisible();
+    await page.getByLabel("Recibió *").fill("Cliente QA mixto");
+    await page.getByLabel("Método de entrega *").fill("Entrega directa");
     await Promise.all([
       page.waitForURL(/\?ok=/),
-      page.getByRole("button", { name: "Entregado al cliente" }).click(),
+      page.getByRole("button", { name: "Confirmar entrega al cliente" }).click(),
     ]);
 
     const [finalOrder, finalAssembly] = await Promise.all([

--- a/tests/e2e/rbac-browser.spec.ts
+++ b/tests/e2e/rbac-browser.spec.ts
@@ -52,15 +52,15 @@ test.describe("RBAC en navegador por rol", () => {
   }) => {
     await loginAs(page, "WAREHOUSE_OPERATOR");
     await expectForbidden(page, "/users");
-    await expectAllowed(page, "/inventory/adjust", /Ajuste de Inventario/i);
+    await expectForbidden(page, "/inventory/adjust");
     await expectAllowed(page, "/inventory/transfer", /Transferencia Interna/i);
     await expectAllowed(page, "/inventory/pick", /Picking/i);
     await expectForbidden(page, "/audit");
-    await expectAllowed(page, "/production/requests", /Cockpit de ejecución/i);
+    await expectAllowed(page, "/production/requests", /Trabajo de almacén/i);
     await expect(page.getByRole("link", { name: /\+ Nuevo pedido/i })).toHaveCount(
       0,
     );
-    await expectAllowed(page, "/purchasing/orders", /^Órdenes de compra$/i);
+    await expectAllowed(page, "/purchasing/orders", /Trabajo de recepción/i);
     await expect(page.getByRole("link", { name: /\+ Nueva OC/i })).toHaveCount(
       0,
     );
@@ -105,13 +105,13 @@ test.describe("RBAC en navegador por rol", () => {
     );
     await page.goto("/production/requests");
     await expect(
-      page.getByTestId("desktop-main-nav").getByRole("link", { name: /Mis pedidos/i }),
+      page.getByTestId("desktop-main-nav").getByRole("link", { name: /^Pedidos$/i }),
     ).toBeVisible();
     await expect(
-      page.getByTestId("desktop-main-nav").getByRole("link", { name: /Clientes y seguimiento/i }),
+      page.getByTestId("desktop-main-nav").getByRole("link", { name: /^Clientes$/i }),
     ).toBeVisible();
     await expect(
-      page.getByTestId("desktop-main-nav").getByRole("link", { name: /Cat[aá]logo comercial/i }),
+      page.getByTestId("desktop-main-nav").getByRole("link", { name: /^Catálogo$/i }),
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: /^Disponibilidad\s/i }),


### PR DESCRIPTION
## Objetivo\nReconciliar la suite E2E con el flujo RBAC/operativo actualmente desplegado en AWS dev y documentar la evidencia V1–V8.\n\n## Evidencia ejecutada\n- RBAC browser por 4 roles: 7/7 passed.\n- Continuidad browser: directo, ensamble y mixto: 3/3 passed, con persistencia y documentos.\n- KAN-128 AWS read-only: 1/1 passed.\n- Sales commercial flow: 5/5 passed.\n- Lint y contrato de cobertura: passed.\n\n## Cambios\n- Alinea aserciones RBAC con permisos y nombres de navegación vigentes.\n- Modela claim + scan + datos obligatorios de entrega.\n- Aísla cambios de identidad browser contra cache/session de CloudFront.\n- Añade matriz de evidencia V1–V8 sin declarar completo lo que sólo tiene evidencia de servicio.\n\n## Pendientes\nV1 write browser, V5/V7/V8 browser específico y aceptación humana por ventas, almacén, manager y administración. No se cierran Jira ni se eliminan los 271 esquemas históricos.