### PR TITLE
chore: enforce test schema cleanup and retention audit

### DIFF
--- a/docs/reconciliation/test-schema-retention-audit-2026-08-17.md
+++ b/docs/reconciliation/test-schema-retention-audit-2026-08-17.md
@@ -1,0 +1,50 @@
+# Auditoría de esquemas aislados de pruebas — 2026-08-17
+
+## Alcance
+
+Auditoría read-only del PostgreSQL AWS dev para evaluar la retención de esquemas `t_run_*`. No se ejecutó `DROP SCHEMA`, no se modificó la base de datos operativa y no se eliminó evidencia.
+
+## Evidencia observada
+
+- 271 esquemas con patrón válido `t_run_<timestamp>_<runId>_w<worker>`.
+- 264 esquemas contienen tablas y 7 están vacíos.
+- 56,465 objetos y 10,901 tablas en el conjunto auditado.
+- El catálogo estima aproximadamente 383 MB en páginas de tablas e índices; la medición exacta de un esquema representativo fue 5.9 MB.
+- Antigüedad observada: 2026-06-18 a 2026-08-05.
+- Con retención de 30 días y corte generado el 2026-08-17: 260 candidatos, 29 grupos de ejecución y 11 esquemas conservados.
+- No se detectaron foreign keys cruzadas, funciones o vistas externas que referencien `t_run_*`.
+- No había sesiones externas no-idle usando esos esquemas durante la consulta final.
+
+Un esquema representativo sí contiene datos de prueba: auditorías, sincronizaciones, inventario, movimientos y órdenes. Por eso la acción sigue siendo destructiva aunque no sea productiva.
+
+## Corrección aplicada al pipeline
+
+El wrapper de PostgreSQL ya elimina los esquemas de su propia corrida, pero antes sólo registraba un error de limpieza y permitía que el proceso terminara con el resultado de las pruebas. Ahora:
+
+1. Verifica que no queden esquemas de la corrida.
+2. Reporta cuántos esquemas limpió.
+3. Devuelve código de salida fallido si la limpieza falla.
+
+La allowlist de retención se genera con:
+
+```text
+npm run db:test-schemas:list
+```
+
+o con otro corte explícito:
+
+```text
+node scripts/db/list-stale-test-schemas.cjs --retention-days 30 --json
+```
+
+## Plan de limpieza propuesto
+
+1. Renovar la sesión AWS y crear un snapshot RDS verificable.
+2. Congelar ejecuciones PostgreSQL y confirmar que no existan sesiones activas.
+3. Generar y revisar la allowlist exacta.
+4. Eliminar un solo grupo histórico aprobado.
+5. Validar `/api/health`, conexión, pruebas básicas y Jira/GitHub.
+6. Continuar en lotes de 10–20 esquemas.
+7. Comparar conteo esperado contra conteo real y conservar el manifest.
+
+La fase destructiva requiere autorización separada. Hasta entonces, los 271 esquemas permanecen intactos.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "smoke:mobile-auth": "node scripts/smoke/validate-mobile-auth.cjs",
     "env:postgres:check": "node scripts/db/assert-postgres-env.cjs",
     "env:postgres:tcp": "node scripts/db/assert-postgres-env.cjs --check-connection",
+    "db:test-schemas:list": "node scripts/db/list-stale-test-schemas.cjs",
     "sync:daily:report": "powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\ops\\daily-sync-report.ps1 -JiraProject KAN",
     "sync:jira:views": "powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\ops\\sync-jira-views.ps1 -JiraProject KAN",
     "test:rbac": "node scripts/db/run-vitest-postgres.cjs run tests/rbac",

--- a/scripts/db/list-stale-test-schemas.cjs
+++ b/scripts/db/list-stale-test-schemas.cjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+require("dotenv/config");
+const { PrismaClient } = require("@prisma/client");
+const { assertPostgresEnv } = require("./assert-postgres-env.cjs");
+
+const retentionArgIndex = process.argv.findIndex((arg) => arg === "--retention-days");
+const retentionDays = retentionArgIndex >= 0 ? Number(process.argv[retentionArgIndex + 1]) : 30;
+if (!Number.isInteger(retentionDays) || retentionDays < 1 || retentionDays > 3650) {
+  throw new Error("--retention-days debe ser un entero entre 1 y 3650");
+}
+
+const { databaseUrl } = assertPostgresEnv();
+const parsedDatabaseUrl = new URL(databaseUrl);
+parsedDatabaseUrl.searchParams.set("schema", "public");
+const prisma = new PrismaClient({ datasources: { db: { url: parsedDatabaseUrl.toString() } } });
+
+async function main() {
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+  const rows = await prisma.$queryRawUnsafe(
+    `SELECT
+       n.nspname AS schema_name,
+       pg_get_userbyid(n.nspowner) AS owner,
+       to_timestamp((substring(n.nspname from '^t_run_([0-9]+)')::numeric) / 1000) AS created_at,
+       regexp_replace(n.nspname, '_w[0-9]+$', '') AS run_prefix,
+       count(c.oid)::int AS object_count,
+       count(c.oid) FILTER (WHERE c.relkind IN ('r', 'p'))::int AS table_count,
+       (COALESCE(sum(c.relpages), 0)::numeric * 8192)::text AS approx_bytes
+     FROM pg_namespace n
+     LEFT JOIN pg_class c ON c.relnamespace = n.oid
+     WHERE n.nspname ~ '^t_run_[0-9]+_[a-z0-9]+_w[0-9]+$'
+     GROUP BY n.nspname, n.nspowner
+     ORDER BY created_at, n.nspname`
+  );
+
+  const candidates = rows.filter((row) => new Date(row.created_at) < cutoff);
+  const groups = new Map();
+  for (const row of candidates) {
+    const current = groups.get(row.run_prefix) ?? { schemaCount: 0, objectCount: 0, tableCount: 0 };
+    current.schemaCount += 1;
+    current.objectCount += Number(row.object_count ?? 0);
+    current.tableCount += Number(row.table_count ?? 0);
+    groups.set(row.run_prefix, current);
+  }
+
+  const result = {
+    generatedAt: new Date().toISOString(),
+    retentionDays,
+    cutoff: cutoff.toISOString(),
+    totalMatchingSchemas: rows.length,
+    candidateSchemaCount: candidates.length,
+    candidateGroupCount: groups.size,
+    candidateObjectCount: candidates.reduce((sum, row) => sum + Number(row.object_count ?? 0), 0),
+    candidateTableCount: candidates.reduce((sum, row) => sum + Number(row.table_count ?? 0), 0),
+    candidates,
+    groups: Array.from(groups, ([runPrefix, values]) => ({ runPrefix, ...values })),
+  };
+
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`cutoff=${result.cutoff}`);
+    console.log(`matching=${result.totalMatchingSchemas}`);
+    console.log(`candidates=${result.candidateSchemaCount}`);
+    console.log(`groups=${result.candidateGroupCount}`);
+    for (const row of candidates) {
+      console.log(`${row.schema_name}\t${row.created_at.toISOString()}\t${row.object_count} objects\t${row.table_count} tables`);
+    }
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/db/run-vitest-postgres.cjs
+++ b/scripts/db/run-vitest-postgres.cjs
@@ -11,6 +11,7 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 const vitestCli = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
 const args = process.argv.slice(2);
 const runId = process.env.WMS_TEST_RUN_ID || `run_${Date.now()}_${randomUUID().slice(0, 8)}`;
+const normalizedRunId = runId.replace(/[^a-zA-Z0-9_]/g, "_");
 const forceSerial = process.env.WMS_POSTGRES_FORCE_SERIAL === "1";
 const hasWorkerOverride = args.some((arg) => arg === "--maxWorkers" || arg.startsWith("--maxWorkers="));
 const finalArgs = forceSerial && !hasWorkerOverride ? ["--maxWorkers=1", ...args] : args;
@@ -28,15 +29,24 @@ async function cleanupIsolatedSchemas() {
     datasources: { db: { url: adminUrl } },
   });
 
+  const schemaPattern = `^t_${normalizedRunId}_w[0-9]+$`;
   try {
     const rows = await prisma.$queryRawUnsafe(
-      "SELECT nspname FROM pg_namespace WHERE nspname LIKE $1 ESCAPE '\\'",
-      `t_${runId}_w%`
+      "SELECT nspname FROM pg_namespace WHERE nspname ~ $1",
+      schemaPattern
     );
-    for (const row of rows) {
-      if (!row?.nspname) continue;
-      await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${row.nspname}" CASCADE`);
+    const schemaNames = rows.map((row) => row?.nspname).filter(Boolean);
+    for (const schemaName of schemaNames) {
+      await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
     }
+    const remaining = await prisma.$queryRawUnsafe(
+      "SELECT nspname FROM pg_namespace WHERE nspname ~ $1",
+      schemaPattern
+    );
+    if (remaining.length > 0) {
+      throw new Error(`Persisten ${remaining.length} esquemas aislados despues de la limpieza`);
+    }
+    return schemaNames.length;
   } finally {
     await prisma.$disconnect();
   }
@@ -54,11 +64,14 @@ async function main() {
     stdio: "inherit",
   });
 
+  let cleanupError = null;
   try {
-    await cleanupIsolatedSchemas();
+    const cleanedCount = await cleanupIsolatedSchemas();
+    console.log(`[test] cleaned ${cleanedCount} isolated schemas for ${runId}`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`[test] failed to cleanup isolated schemas for ${runId}: ${message}`);
+    cleanupError = error;
   }
 
   if (result.error) {
@@ -66,7 +79,8 @@ async function main() {
     process.exit(1);
   }
 
-  process.exit(result.status ?? 0);
+  if (cleanupError) process.exit(1);
+  process.exit(result.status ?? 1);
 }
 
 void main();


### PR DESCRIPTION
## Qué cambia
- El wrapper PostgreSQL verifica que su corrida no deje esquemas aislados y falla si la limpieza falla.
- La limpieza usa un patrón exacto por corrida/worker para evitar coincidencias amplias.
- Se agrega `db:test-schemas:list` para generar una allowlist exacta con retención configurable.
- Se documenta la auditoría AWS dev y el plan de limpieza por lotes.

## Evidencia
- Prueba acotada PostgreSQL: 2 tests passed; el wrapper reportó `cleaned 1 isolated schema`.
- Allowlist read-only a 30 días: 271 encontrados, 260 candidatos, 29 grupos, 11 conservados.
- No se ejecutó `DROP SCHEMA` sobre los 260 candidatos.

## Pendiente
- Snapshot RDS verificable: AWS CLI requiere reautenticación.
- La limpieza destructiva requiere autorización separada y no forma parte de este PR.